### PR TITLE
Mojo log adjustments

### DIFF
--- a/Conch/lib/Conch.pm
+++ b/Conch/lib/Conch.pm
@@ -45,10 +45,10 @@ sub startup {
 
 	$self->helper(
 		status => sub {
-			my ($self, $code, $payload) = @_;
+			my ( $self, $code, $payload ) = @_;
 
 			$self->res->code($code);
-			if ( ($code == 403) && !$payload) {
+			if ( ( $code == 403 ) && !$payload ) {
 				$payload = { error => "Forbidden" };
 			}
 
@@ -58,30 +58,26 @@ sub startup {
 
 	$self->helper(
 		global_auth => sub {
-			my ($c, $role_name) = @_;
+			my ( $c, $role_name ) = @_;
 			return 0 unless $c->stash('user_id');
 
 			my $ws = $c->workspace->lookup_by_name('GLOBAL');
 			return 0 unless $ws;
 
-			my $user_ws = $c->workspace->get_user_workspace(
-				$c->stash('user_id'),
-				$ws->id,
-			);
+			my $user_ws =
+				$c->workspace->get_user_workspace( $c->stash('user_id'), $ws->id, );
 
 			return 0 unless $user_ws;
 			return 0 unless $user_ws->role eq $role_name;
 			return 1;
 		},
 	);
-	
+
 	$self->helper(
 		is_global_admin => sub {
-			shift->global_auth('Administrator')
+			shift->global_auth('Administrator');
 		}
 	);
-
-
 
 	# Render exceptions and Not Found as JSON
 	$self->hook(

--- a/Conch/lib/Conch.pm
+++ b/Conch/lib/Conch.pm
@@ -36,6 +36,9 @@ sub startup {
 	$self->sessions->cookie_name('conch');
 	$self->sessions->default_expiration(2592000);    # 30 days
 
+	# Log all messages regardless of operating mode
+	$self->log->level('debug');
+
 	my $pg_uri = $self->config('pg');
 	$self->helper(
 		pg => sub {

--- a/Conch/lib/Conch.pm
+++ b/Conch/lib/Conch.pm
@@ -82,6 +82,24 @@ sub startup {
 		}
 	);
 
+	my $unparsable_report_logger = Mojo::Log->new(
+		path   => "log/unparsable_report.log",
+		format => sub {
+			my ( $time, undef, @lines ) = @_;
+			$time = localtime($time);
+			return map { "[$time] " . $_ . "\n" } @lines;
+		}
+	);
+	$self->helper(
+		log_unparsable_report => sub {
+			my ( undef, $report, $errs ) = @_;
+			$unparsable_report_logger->error(
+				'Failed parsing device report: ' . $errs );
+			$unparsable_report_logger->error(
+				"Device Report: " . Mojo::JSON::encode_json($report) );
+		}
+	);
+
 	# Render exceptions and Not Found as JSON
 	$self->hook(
 		before_render => sub {
@@ -122,7 +140,7 @@ __DATA__
 
 Copyright Joyent, Inc.
 
-This Source Code Form is subject to the terms of the Mozilla Public License, 
+This Source Code Form is subject to the terms of the Mozilla Public License,
 v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
 one at http://mozilla.org/MPL/2.0/.
 

--- a/Conch/lib/Conch/Controller/DeviceReport.pm
+++ b/Conch/lib/Conch/Controller/DeviceReport.pm
@@ -22,22 +22,16 @@ use Conch::Legacy::Control::Device::Validation 'validate_device';
 use Conch::Legacy::Data::Report::Switch;
 use Conch::Legacy::Data::Report::Server;
 
-
 =head2 process
 
 Processes the device report using the Legacy report code base
 
 =cut
 
-# TODO: None of the available Mojolicious Log4Perl libraries allow selecting
-# the category (appender) for Log4Perl. We use this mechanism to log unparsable
-# device reports and device reports that result in processing exceptions
 sub process ($c) {
 	my $raw_report = $c->req->json;
 
-	#Log::Any->get_logger( category => 'report.raw' )
-	#->trace( encode_json $raw_report);
-	my ($device_report, $errs);
+	my ( $device_report, $errs );
 	try {
 		if ( $raw_report->{device_type} && $raw_report->{device_type} eq "switch" )
 		{
@@ -49,7 +43,7 @@ sub process ($c) {
 	}
 	catch {
 		$errs = join( "; ", map { $_->message } $_->errors );
-		$c->app->log->error( 'Failed parsing device report: ' . $errs );
+		$c->app->log_unparsable_report( $raw_report, $errs );
 	};
 	return $c->status( 400, { error => $errs } ) if $errs;
 
@@ -87,7 +81,6 @@ sub process ($c) {
 
 1;
 
-
 __DATA__
 
 =pod
@@ -101,4 +94,3 @@ v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
 one at http://mozilla.org/MPL/2.0/.
 
 =cut
-


### PR DESCRIPTION
Adds log changes discussed during Lifecycle WG meeting.

* The main Mojo log is hardcoded to the debug level for all 'operating modes' (development and production). This will log all messages.
* Logs unparsable device reports into a separate log file, `log/unparsable_report.log`. Includes the parse errors. Example log lines for a unparsable device report:

```
[Tue Feb 13 17:00:39 2018] Failed parsing device report: Attribute (product_name) is required; Attribute (serial_number) is required; Attribute (system_uuid) is required; Attribute (state) is required; Attribute (bios_version) is required; Attribute (processor) is required; Attribute (memory) is required
[Tue Feb 13 17:00:39 2018] Device Report: {"deadbeef":"coffee"}
```
