### PR TITLE
Make set_single_setting do what it says

### DIFF
--- a/Conch/lib/Conch/Controller/DeviceSettings.pm
+++ b/Conch/lib/Conch/Controller/DeviceSettings.pm
@@ -37,7 +37,11 @@ overwritten
 
 sub set_single ($c) {
 	my $body          = $c->req->json;
-	my $setting_key   = $c->param('key');
+  my @k = keys %{$body};
+
+  # $c->param('key') seems to mangle input values if you use periods in
+  # the key. Which we do. So bdha did something gross.
+  my $setting_key   = $k[0];
 	my $setting_value = $body->{$setting_key};
 	return $c->status(
 		400,


### PR DESCRIPTION
This function seems to have been broken during the migration from dancer2. The `$c->param('key')` function seems to strip off anything after a `.` in the key name. We use `build.foo` keys (and other `kwatz.foo` values) in several places.

This fix is probably too ugly to live, but it's been tested and seems happy.