### PR TITLE
fix: device/settings no longer uses extension based format rendering

### DIFF
--- a/Conch/cpanfile
+++ b/Conch/cpanfile
@@ -10,7 +10,6 @@ requires 'Mail::Sendmail';
 requires 'aliased';
 requires 'Try::Tiny';
 requires 'Class::StrongSingleton';
-requires 'YAML::Tiny';
 
 # mojolicious
 requires 'Mojolicious';

--- a/Conch/cpanfile
+++ b/Conch/cpanfile
@@ -10,6 +10,7 @@ requires 'Mail::Sendmail';
 requires 'aliased';
 requires 'Try::Tiny';
 requires 'Class::StrongSingleton';
+requires 'YAML::Tiny';
 
 # mojolicious
 requires 'Mojolicious';

--- a/Conch/cpanfile.snapshot
+++ b/Conch/cpanfile.snapshot
@@ -3881,20 +3881,6 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       perl 5.008001
-  YAML-Tiny-1.70
-    pathname: E/ET/ETHER/YAML-Tiny-1.70.tar.gz
-    provides:
-      YAML::Tiny 1.70
-    requirements:
-      B 0
-      Carp 0
-      Exporter 0
-      ExtUtils::MakeMaker 0
-      Fcntl 0
-      Scalar::Util 0
-      perl 5.008001
-      strict 0
-      warnings 0
   aliased-0.34
     pathname: E/ET/ETHER/aliased-0.34.tar.gz
     provides:

--- a/Conch/cpanfile.snapshot
+++ b/Conch/cpanfile.snapshot
@@ -273,7 +273,6 @@ DISTRIBUTIONS
       Config::Any::XML undef
       Config::Any::YAML undef
     requirements:
-      Config::General 2.47
       Module::Pluggable::Object 3.6
   Config-General-2.63
     pathname: T/TL/TLINDEN/Config-General-2.63.tar.gz

--- a/Conch/lib/Conch/Route/Device.pm
+++ b/Conch/lib/Conch/Route/Device.pm
@@ -46,10 +46,10 @@ sub device_routes {
 	$with_device->get('/settings')->to('device_settings#get_all');
 	$with_device->post('/settings')->to('device_settings#set_all');
 
-	$with_device->get('/settings/:key')->to('device_settings#get_single');
-	$with_device->post('/settings/:key')->to('device_settings#set_single');
+	$with_device->get('/settings/#key')->to('device_settings#get_single');
+	$with_device->post('/settings/#key')->to('device_settings#set_single');
 
-	$with_device->delete('/settings/:key')->to('device_settings#delete_single');
+	$with_device->delete('/settings/#key')->to('device_settings#delete_single');
 
 }
 

--- a/Conch/lib/Conch/Route/User.pm
+++ b/Conch/lib/Conch/Route/User.pm
@@ -30,9 +30,9 @@ sub user_routes {
 	$r->get('/settings')->to('user#get_settings');
 	$r->post('/settings')->to('user#set_settings');
 
-	$r->get('/settings/:key')->to('user#get_setting');
-	$r->post('/settings/:key')->to('user#set_setting');
-	$r->delete('/settings/:key')->to('user#delete_setting');
+	$r->get('/settings/#key')->to('user#get_setting');
+	$r->post('/settings/#key')->to('user#set_setting');
+	$r->delete('/settings/#key')->to('user#delete_setting');
 }
 
 1;

--- a/Conch/t/integration/00_only_1_user_loaded.t
+++ b/Conch/t/integration/00_only_1_user_loaded.t
@@ -122,6 +122,21 @@ subtest 'User' => sub {
 			error => "No such setting 'TEST'",
 		}
 	);
+
+	$t->post_ok(
+		"/user/me/settings/dot.setting" => json => {
+			"dot.setting" => "set",
+		}
+	)->status_is(200)->content_is('');
+
+	$t->get_ok("/user/me/settings/dot.setting")->status_is(200)->json_is(
+		'',
+		{
+			"dot.setting" => "set",
+		}
+	);
+	$t->delete_ok("/user/me/settings/dot.setting")->status_is(204)->content_is('');
+
 };
 
 my $id;

--- a/Conch/t/integration/04_test_datacenter_loaded.t
+++ b/Conch/t/integration/04_test_datacenter_loaded.t
@@ -217,6 +217,15 @@ subtest 'Single device' => sub {
 			->json_like( '/error', qr/fizzle/ );
 		$t->delete_ok('/device/TEST/settings/fizzle')->status_is(404)
 			->json_like( '/error', qr/fizzle/ );
+
+		$t->post_ok( '/device/TEST/settings/foo.bar', json => { 'foo.bar' => 'bar' } )
+			->status_is(200);
+		$t->get_ok('/device/TEST/settings/foo.bar')->status_is(200)
+			->json_is( '/foo.bar', 'bar', 'Setting was stored' );
+		$t->delete_ok('/device/TEST/settings/foo.bar')->status_is(204)
+			->content_is('');
+		$t->get_ok('/device/TEST/settings/foo.bar')->status_is(404)
+			->json_like( '/error', qr/foo\.bar/ );
 	};
 
 };

--- a/Conch/t/integration/05_v1_schema.t
+++ b/Conch/t/integration/05_v1_schema.t
@@ -6,7 +6,6 @@ use Data::UUID;
 use Data::Validate::UUID 'is_uuid';
 use IO::All;
 use JSON::Validator;
-use YAML::Tiny;
 
 use Data::Printer;
 

--- a/Conch/t/integration/06_secured_endpoints.t
+++ b/Conch/t/integration/06_secured_endpoints.t
@@ -54,6 +54,10 @@ $t->get_ok("/user/me/settings/test")->status_is(401)
 	->json_is( '/error' => 'unauthorized' );
 $t->post_ok("/user/me/settings/test", json => { a => 'b' })->status_is(401)
 	->json_is( '/error' => 'unauthorized' );
+$t->get_ok("/user/me/settings/test.dot")->status_is(401)
+	->json_is( '/error' => 'unauthorized' );
+$t->post_ok("/user/me/settings/test.dot", json => { 'test.dot' => 'b' })
+	->status_is(401)->json_is( '/error' => 'unauthorized' );
 
 $t->get_ok("/hardware_product")->status_is(401)
 	->json_is( '/error' => 'unauthorized' );


### PR DESCRIPTION
This is an alternate implementation of the fix presented in #156.

The s/:/#/ tells Mojo to no longer use extension based content type detection. 'foo.bar' comes through as whole parameter rather than mojo thinking that 'bar' is some format type.