### PR TITLE
Fix: Registering Relays

### DIFF
--- a/Conch/lib/Conch/Controller/Relay.pm
+++ b/Conch/lib/Conch/Controller/Relay.pm
@@ -15,7 +15,6 @@ use Data::Validate::UUID 'is_uuid';
 
 use Data::Printer;
 
-
 =head2 register
 
 Registers a relay and connects it with the current user. The relay is created
@@ -32,13 +31,10 @@ sub register ($c) {
 		{ error => "'serial' attribute required in request" } )
 		unless defined($serial);
 
-	my $relay_exists = $c->relay->lookup($serial);
-	unless ($relay_exists) {
-		$c->relay->create(
-			$serial,           $body->{version}, $body->{ipaddr},
-			$body->{ssh_port}, $body->{alias},
-		);
-	}
+	$c->relay->register(
+		$serial,           $body->{version}, $body->{ipaddr},
+		$body->{ssh_port}, $body->{alias},
+	);
 
 	my $attempt = $c->relay->connect_user_relay( $user_id, $serial );
 
@@ -48,7 +44,6 @@ sub register ($c) {
 
 	$c->status(204);
 }
-
 
 =head2 list
 
@@ -76,4 +71,3 @@ v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
 one at http://mozilla.org/MPL/2.0/.
 
 =cut
-

--- a/Conch/lib/Conch/Model/Relay.pm
+++ b/Conch/lib/Conch/Model/Relay.pm
@@ -14,8 +14,6 @@ use Mojo::Base -base, -signatures;
 use Conch::Class::Relay;
 use Conch::Time;
 
-use Try::Tiny;
-
 has 'pg';
 
 =head2 register
@@ -28,18 +26,19 @@ an existing relay's version, IP address, SSH port, alias, and updated timestamp
 sub register ( $self, $serial, $version, $ipaddr, $ssh_port, $alias ) {
 	$self->pg->db->query(
 		q{
-      INSERT INTO relay
-        ( id, version, ipaddr, ssh_port, alias, updated )
-      VALUES
-        ( ?, ?, ?, ?, ?, ? )
-      ON CONFLICT (id) DO UPDATE
-      SET id = excluded.id,
-          version = excluded.version,
-          ipaddr = excluded.ipaddr,
-          ssh_port = excluded.ssh_port,
-          alias = excluded.alias,
-          updated = excluded.updated
-    },
+		INSERT INTO relay
+			( id, version, ipaddr, ssh_port, alias, updated )
+		VALUES
+			( ?, ?, ?, ?, ?, ? )
+		ON CONFLICT (id) DO UPDATE
+		SET
+			id       = excluded.id,
+			version  = excluded.version,
+			ipaddr   = excluded.ipaddr,
+			ssh_port = excluded.ssh_port,
+			alias    = excluded.alias,
+			updated  = excluded.updated
+		},
 		$serial,
 		$version,
 		$ipaddr,
@@ -56,7 +55,8 @@ Look up a relay by ID.
 =cut
 
 sub lookup ( $self, $relay_id ) {
-	my $maybe_relay = $self->pg->db->select( 'relay', undef, { id => $relay_id } )->hash;
+	my $maybe_relay =
+		$self->pg->db->select( 'relay', undef, { id => $relay_id } )->hash;
 	return $maybe_relay && Conch::Class::Relay->new($maybe_relay);
 }
 
@@ -67,24 +67,23 @@ Associate relay with a user.
 =cut
 
 sub connect_user_relay ( $self, $user_id, $relay_id ) {
-	my $ret;
-	try {
-		# 'first_seen' column will only be written on create. It should remain
-		# unchanged on updates
-		$ret = $self->pg->db->query(
-			q{
-        INSERT INTO user_relay_connection
-          ( user_id, relay_id, last_seen )
-        VALUES
-          ( ?, ?, ? )
-        ON CONFLICT (user_id, relay_id) DO UPDATE
-        SET user_id = excluded.user_id,
-            relay_id = excluded.relay_id,
-            last_seen = excluded.last_seen
-      }, $user_id, $relay_id, 'NOW()'
-		)->rows;
-	};
-	return $ret;
+
+	# 'first_seen' column will only be written on create. It should remain
+	# unchanged on updates
+	return $self->pg->db->query(
+		q{
+		INSERT INTO user_relay_connection
+			( user_id, relay_id, last_seen )
+		SELECT ?, relay.id, NOW()
+		FROM relay
+		WHERE relay.id = ?
+		ON CONFLICT (user_id, relay_id) DO UPDATE
+		SET
+			user_id   = excluded.user_id,
+			relay_id  = excluded.relay_id,
+			last_seen = excluded.last_seen
+		}, $user_id, $relay_id
+	)->rows;
 }
 
 =head2 connect_device_relay
@@ -94,24 +93,23 @@ Associate relay with a device
 =cut
 
 sub connect_device_relay ( $self, $device_id, $relay_id ) {
-	my $ret;
-	try {
-		# 'first_seen' column will only be written on create. It should remain
-		# unchanged on updates
-		$ret = $self->pg->db->query(
-			q{
-        INSERT INTO device_relay_connection
-          ( device_id, relay_id, last_seen )
-        VALUES
-          ( ?, ?, ? )
-        ON CONFLICT (device_id, relay_id) DO UPDATE
-        SET device_id = excluded.device_id,
-            relay_id = excluded.relay_id,
-            last_seen = excluded.last_seen
-      }, $device_id, $relay_id, 'NOW()'
-		)->rows;
-	};
-	return $ret;
+
+	# 'first_seen' column will only be written on create. It should remain
+	# unchanged on updates
+	return $self->pg->db->query(
+		q{
+		INSERT INTO device_relay_connection
+			( device_id, relay_id, last_seen )
+		SELECT ?, relay.id, NOW()
+		FROM relay
+		WHERE relay.id = ?
+		ON CONFLICT (device_id, relay_id) DO UPDATE
+		SET
+			device_id = excluded.device_id,
+			relay_id  = excluded.relay_id,
+			last_seen = excluded.last_seen
+		}, $device_id, $relay_id
+	)->rows;
 }
 
 =head2 list
@@ -122,13 +120,11 @@ Provide a list of all relays in the database as Class::Relay objects
 
 sub list ( $self ) {
 	my @relays;
-	try {
-		for my $r ( $self->pg->db->select('relay')->hashes->@* ) {
-			$r->{created} = Conch::Time->new( $r->{created} ) if $r->{created};
-			$r->{updated} = Conch::Time->new( $r->{updated} ) if $r->{updated};
-			push @relays, Conch::Class::Relay->new($r);
-		}
-	};
+	for my $r ( $self->pg->db->select('relay')->hashes->@* ) {
+		$r->{created} = Conch::Time->new( $r->{created} ) if $r->{created};
+		$r->{updated} = Conch::Time->new( $r->{updated} ) if $r->{updated};
+		push @relays, Conch::Class::Relay->new($r);
+	}
 	return @relays;
 }
 

--- a/Conch/t/integration/00_only_1_user_loaded.t
+++ b/Conch/t/integration/00_only_1_user_loaded.t
@@ -135,7 +135,8 @@ subtest 'User' => sub {
 			"dot.setting" => "set",
 		}
 	);
-	$t->delete_ok("/user/me/settings/dot.setting")->status_is(204)->content_is('');
+	$t->delete_ok("/user/me/settings/dot.setting")->status_is(204)
+		->content_is('');
 
 };
 
@@ -263,8 +264,24 @@ subtest 'Register relay' => sub {
 };
 
 subtest 'Relay List' => sub {
-	$t->get_ok('/relay')->status_is(200);
-	$t->json_is('/0/id' => 'deadbeef');
+	$t->get_ok('/relay')->status_is(200)->json_is( '/0/id' => 'deadbeef' )
+		->json_is( '/0/version', '0.0.1' );
+	subtest 'Update relay' => sub {
+
+		$t->post_ok(
+			'/relay/deadbeef/register',
+			json => {
+				serial   => 'deadbeef',
+				version  => '0.0.2',
+				idaddr   => '127.0.0.1',
+				ssh_port => '22',
+				alias    => 'test relay'
+			}
+		)->status_is(204);
+
+		$t->get_ok('/relay')->status_is(200)->json_is( '/0/id', 'deadbeef' )
+			->json_is( '/0/version', '0.0.2', 'Version updated' );
+	};
 };
 
 subtest 'Device Report' => sub {
@@ -272,9 +289,9 @@ subtest 'Device Report' => sub {
 		io->file('t/integration/resource/passing-device-report.json')->slurp;
 	$t->post_ok( '/device/TEST', $report )->status_is(409)
 		->json_like( '/error', qr/Hardware Product '.+' does not exist/ );
-	
-	$t->post_ok( '/device/TEST', json => { serial_number => 'TEST' })
-		->status_is(400)->json_like('/error', qr/Attribute .* is required/);
+
+	$t->post_ok( '/device/TEST', json => { serial_number => 'TEST' } )
+		->status_is(400)->json_like( '/error', qr/Attribute .* is required/ );
 };
 
 subtest 'Single device' => sub {
@@ -342,7 +359,8 @@ subtest 'Hardware Product' => sub {
 
 subtest 'Log out' => sub {
 	$t->post_ok("/logout")->status_is(204);
-	$t->get_ok("/workspace")->status_is(401)->json_is( '/error' => 'unauthorized' );
+	$t->get_ok("/workspace")->status_is(401)
+		->json_is( '/error' => 'unauthorized' );
 };
 
 done_testing();

--- a/Conch/t/model/Relay.t
+++ b/Conch/t/model/Relay.t
@@ -38,7 +38,30 @@ my $relay_model = new_ok(
 );
 
 my $relay_serial = 'deadbeef';
-ok( $relay_model->create( $relay_serial, 'v1', '127.0.0.1', 22, 'test' ) );
+subtest "registering relay" => sub {
+	is( $relay_model->lookup($relay_serial), undef, "Relay does not yet exist" );
+	ok( $relay_model->register( $relay_serial, 'v1', '127.0.0.1', 22, 'test' ) );
+
+	my $new_relay = $relay_model->lookup($relay_serial);
+
+	is( $new_relay->id, $relay_serial, "New relay registered" );
+	is( $new_relay->version, 'v1', "Relay version registered" );
+	is( $new_relay->ipaddr, '127.0.0.1', "Relay IP registered" );
+	is( $new_relay->ssh_port, 22, "Relay SSH port registered" );
+	is( $new_relay->alias, 'test', "Relay alias registered" );
+
+	ok( $relay_model->register( $relay_serial, 'v2', '127.0.0.2', 42, 'test2' ) );
+
+	my $updated_relay = $relay_model->lookup($relay_serial);
+	is( $updated_relay->id, $relay_serial, "New relay registered" );
+	is( $updated_relay->version, 'v2', "Relay version registered" );
+	is( $updated_relay->ipaddr, '127.0.0.2', "Relay IP registered" );
+	is( $updated_relay->ssh_port, 42, "Relay SSH port registered" );
+	is( $updated_relay->alias, 'test2', "Relay alias registered" );
+
+	ok( $new_relay->created eq $updated_relay->created, "Relay created timestamp unchanged" );
+	ok( $new_relay->updated ne $updated_relay->updated, "Relay updated timestamp changed" );
+};
 
 subtest "connect device relay" => sub {
 	my $device_model = new_ok( "Conch::Model::Device", [ pg => $pg ] );
@@ -60,10 +83,10 @@ subtest "connect user relay" => sub {
 
 subtest "list" => sub {
 	my @relays = $relay_model->list();
-	is(scalar @relays, 1, "Relay count");
-	is($relays[0]->id, "deadbeef", "ID checks out");
-	isa_ok($relays[0]->created, 'Conch::Time');
-	isa_ok($relays[0]->updated, 'Conch::Time');
+	is( scalar @relays, 1,          "Relay count" );
+	is( $relays[0]->id, "deadbeef", "ID checks out" );
+	isa_ok( $relays[0]->created, 'Conch::Time' );
+	isa_ok( $relays[0]->updated, 'Conch::Time' );
 };
 
 done_testing();


### PR DESCRIPTION
Relays that have been recorded in the DB should update with any new details and update the the `updated` timestamp every time it registers.

Second commit fixes removes some error handling that silently swallows query errors. We should make noise when a table a query is broken. Updated the queries to handle the cases the error handling was trying to catch (ha).