### PR TITLE
Feat: Add marking Device Validated

### DIFF
--- a/Conch/lib/Conch/Controller/Device.pm
+++ b/Conch/lib/Conch/Controller/Device.pm
@@ -18,7 +18,6 @@ use aliased 'Conch::Class::DeviceDetailed';
 
 use Data::Printer;
 
-
 =head2 under
 
 All endpoints exist under /device/:id - C<under> looks up the device referenced
@@ -41,7 +40,6 @@ sub under ($c) {
 		return 0;
 	}
 }
-
 
 =head2 get
 
@@ -78,7 +76,6 @@ sub get ($c) {
 	$c->status( 200, $detailed_device->as_v1_json );
 }
 
-
 =head2 graduate
 
 Sets the C<graduated> field on a device, unless that field has already been set
@@ -97,7 +94,6 @@ sub graduate($c) {
 	$c->redirect_to( $c->url_for("/device/$device_id")->to_abs );
 }
 
-
 =head2 set_triton_reboot
 
 Sets the C<triton_reboot> field on a device
@@ -111,7 +107,6 @@ sub set_triton_reboot ($c) {
 	$c->status(303);
 	$c->redirect_to( $c->url_for( '/device/' . $device->id )->to_abs );
 }
-
 
 =head2 set_triton_uuid
 
@@ -136,7 +131,6 @@ sub set_triton_uuid ($c) {
 	$c->status(303);
 	$c->redirect_to( $c->url_for( '/device/' . $device->id )->to_abs );
 }
-
 
 =head2 set_triton_setup
 
@@ -169,7 +163,6 @@ sub set_triton_setup ($c) {
 	$c->redirect_to( $c->url_for("/device/$device_id")->to_abs );
 }
 
-
 =head2 set_asset_tag
 
 Sets the C<asset_tag> field on a device
@@ -193,6 +186,25 @@ sub set_asset_tag ($c) {
 	$c->redirect_to( $c->url_for( '/device/' . $device->id )->to_abs );
 }
 
+=head2 set_validated
+
+Sets the C<validated> field on a device unless that field has already been set
+
+=cut
+
+sub set_validated($c) {
+	my $device    = $c->stash('current_device');
+	my $device_id = $device->id;
+	return $c->status( 409,
+		{ error => "Device $device_id has already marked validated" } )
+		if defined( $device->validated );
+
+	$device->set_validated();
+
+	$c->status(303);
+	$c->redirect_to( $c->url_for("/device/$device_id")->to_abs );
+}
+
 1;
 
 __DATA__
@@ -208,4 +220,3 @@ v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
 one at http://mozilla.org/MPL/2.0/.
 
 =cut
-

--- a/Conch/lib/Conch/Controller/DeviceSettings.pm
+++ b/Conch/lib/Conch/Controller/DeviceSettings.pm
@@ -46,8 +46,18 @@ sub set_single ($c) {
 "Setting key in request object must match name in the URL ('$setting_key')"
 		}
 	) unless $setting_value;
+
 	$c->device_settings->set_settings( $c->stash('current_device')->id,
 		{ $setting_key => $setting_value } );
+
+	# TODO: This hard-coded setting dispatch is added for backwards
+	# compatibility with Conch v1.0.0.  It is to be removed once Conch-Relay
+	# and Conch-Rebooter are updated to use /device/:id/validated or the
+	# orchestration system is implemented
+	if ($setting_key eq 'device.validated') {
+		$c->stash('current_device')->set_validated();
+	}
+
 	$c->status(200);
 }
 

--- a/Conch/lib/Conch/Model/Device.pm
+++ b/Conch/lib/Conch/Model/Device.pm
@@ -47,7 +47,7 @@ has [
 =cut
 sub new ( $class, %args ) {
 	map { $args{$_} = Conch::Time->new( $args{$_} ) if $args{$_} }
-		qw(created graduated last_seen latest_triton_reboot triton_setup updated uptime_since);
+		qw(created graduated last_seen latest_triton_reboot triton_setup updated uptime_since validated);
 	$class->SUPER::new(%args);
 }
 
@@ -328,6 +328,28 @@ sub set_asset_tag ( $self, $asset_tag ) {
 
 	$self->asset_tag( $ret->{asset_tag} );
 	$self->updated( $ret->{updated} );
+	return 1;
+}
+
+=head2 set_validated
+
+Mark the validated timestamp for the device
+
+=cut
+sub set_validated ( $self ) {
+	my $ret = $self->pg->db->update(
+		'device',
+		{
+			validated => 'NOW()',
+			updated   => 'NOW()'
+		},
+		{ id        => $self->id },
+		{ returning => [qw(validated updated)] }
+	)->hash;
+	return undef unless $ret;
+
+	$self->validated( Conch::Time->new($ret->{validated}) );
+	$self->updated( Conch::Time->new($ret->{updated}) );
 	return 1;
 }
 

--- a/Conch/lib/Conch/Route/Device.pm
+++ b/Conch/lib/Conch/Route/Device.pm
@@ -38,6 +38,7 @@ sub device_routes {
 	$with_device->post('/triton_uuid')->to('device#set_triton_uuid');
 	$with_device->post('/triton_reboot')->to('device#set_triton_reboot');
 	$with_device->post('/asset_tag')->to('device#set_asset_tag');
+	$with_device->post('/validated')->to('device#set_validated');
 
 	$with_device->get('/location')->to('device_location#get');
 	$with_device->post('/location')->to('device_location#set');

--- a/Conch/t/model/Device.t
+++ b/Conch/t/model/Device.t
@@ -137,6 +137,17 @@ subtest "Device Modifiers" => sub {
 		is( Conch::Model::Device->lookup( $pg, $d->id )->asset_tag,
 			$asset_tag, "asset_tag matches expectations" );
 	};
+
+	subtest "validated" => sub {
+		is( $d->validated, undef,
+			"validated is not already set" );
+
+		is( $d->set_validated(), 1);
+		ok( $d->validated, "validated is set on the object" );
+
+		is( Conch::Model::Device->lookup( $pg, $d->id )->validated,
+			$d->validated, "validated is set in the db" );
+	};
 };
 
 my @test_sql_files = qw(


### PR DESCRIPTION
In v1.0.0, we marked the `validated` field on the `device` table entry whenever the magic setting `device.validated` was set. This adds the less magic endpoint `POST /device/:id/validated`, which works like any of the other `POST /device/:id/:device_attribute` endpoint. It returns returns a 303 redirect to the device resource after setting `validated`. If the `validated` field has already been set, it returns with a 409. 

For backwards compatibility while we update Conch-Relay and Conch-Rebooter, the two systems that need this system, we add a special dispatch in device settings to mark the `validated` field if the setting is `device.validated`. This code should be removed after Conch-Relay and Conch-Rebooter are updated. This issue is tracked by #160.
