### PR TITLE
fix: change GET /version to be statically configurable

### DIFF
--- a/Conch/conch.conf.dist
+++ b/Conch/conch.conf.dist
@@ -6,6 +6,9 @@
     # URI format is postgresql://[user[:password]@][netloc][:port][/dbname][?param1=value1&...]
     pg => 'postgresql://conch@/conch',
 
+    # Version of conch. To be filled by configuration management
+    version => 'v2.0.0-dev',
+
     # See all settings at https://metacpan.org/pod/Mojo::Server::Hypnotoad#SETTINGS
     hypnotoad => {
       listen => ['http://*:5000'],

--- a/Conch/lib/Conch/Route.pm
+++ b/Conch/lib/Conch/Route.pm
@@ -51,10 +51,9 @@ sub all_routes {
 		}
 	);
 
-	my $git_rev = `git describe`;
-	chomp($git_rev);
-	$unsecured->get('/version' => sub { 
-		shift->status(200, { version => $git_rev });
+	$unsecured->get('/version' => sub {
+		my $c = shift;
+		$c->status(200, { version => $c->app->config('version') });
 	});
 
 	$unsecured->post('/login')->to('login#session_login');


### PR DESCRIPTION
The value will be set by configuration management (Ansible) when
deploying new versions. This removes any need for git to be available or
in the path

A corresponding change has been made in our infrastructure repo (link withheld).