### PR TITLE
Move conch exec method to script

### DIFF
--- a/smf/conch.xml
+++ b/smf/conch.xml
@@ -19,24 +19,11 @@
         </dependency>
 
 
-        <method_context>
-
-        </method_context>
-<exec_method type="method" name="start" exec="/opt/local/lib/perl5/site_perl/bin/carton exec hypnotoad bin/conch" timeout_seconds="60">
-            <method_context working_directory='/opt/conch/Conch'></method_context>
-        </exec_method>
-
-        <exec_method type="method" name="refresh" exec="/opt/local/lib/perl5/site_perl/bin/carton exec hypnotoad bin/conch" timeout_seconds="60">
-            <method_context working_directory='/opt/conch/Conch'></method_context>
-        </exec_method>
-
-        <exec_method type="method" name="stop" exec="/opt/local/lib/perl5/site_perl/bin/carton exec hypnotoad -s bin/conch" timeout_seconds="60">
-            <method_context working_directory='/opt/conch/Conch'></method_context>
-        </exec_method>
+        <exec_method name='start' type='method' exec='/opt/conch/smf/conch' timeout_seconds='60'/>
+        <exec_method name='stop' type='method' exec=':kill' timeout_seconds='60'/>
+        <exec_method name='refresh' type='method' exec=':kill' timeout_seconds='60'/>
 
         <property_group name="startd" type="framework">
-
-
             <propval name="duration" type="astring" value="contract"/>
             <propval name="ignore_error" type="astring" value="core,signal"/>
         </property_group>


### PR DESCRIPTION
This moves the SMF method from a direct call in the manifest to a script, making it simpler to change the service's behavior. (We no longer need to reimport the manifest when we update something.) 

Anecdotally, I also find it easier to reason about a shell script that commands wedged into the middle of an XML document.

I've tested import, stop, and restart. All seem fine.

Conch no longer complains about being unable to find `git`, as well.