### PR TITLE
feat: improve logging of responses

### DIFF
--- a/Conch/lib/Conch/Controller/Login.pm
+++ b/Conch/lib/Conch/Controller/Login.pm
@@ -33,6 +33,7 @@ sub authenticate ($c) {
 		my $ret = $u->validate_password($password);
 		if ($ret) {
 			$c->stash(user_id => $u->id);
+			$c->stash(user => $u);
 		}
 		return $ret;
 	}
@@ -45,6 +46,7 @@ sub authenticate ($c) {
 	my $user = Conch::Model::User->lookup( $c->pg, $user_id );
 	if ($user) {
 		$c->stash( user_id => $user_id );
+		$c->stash(user => $user);
 		return 1;
 	}
 	else {


### PR DESCRIPTION
Too often, the code base issues error responses without actually logging what happened. The logs show the 400 or whatever status code we send but no context.

This PR adds new logs about every response whether its an error or not. The URL, http status code, client source data, and user info are logged to info. If an error occurred, the log is emitted to 'warn' along with its json payload.