### PR TITLE
Add SMF method script for conch

### DIFF
--- a/smf/conch
+++ b/smf/conch
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+export PATH=$PATH:/opt/local/bin:/opt/local/sbin
+cd /opt/conch/Conch
+
+case "$1" in
+  start)
+    /opt/local/lib/perl5/site_perl/bin/carton exec hypnotoad bin/conch
+    ;;
+  stop)
+    /opt/local/lib/perl5/site_perl/bin/carton exec hypnotoad -s bin/conch
+    ;;
+  restart)
+    /opt/local/lib/perl5/site_perl/bin/carton exec hypnotoad bin/conch
+    ;;
+  *)
+    echo "Usage:  {start|stop|restart}"
+    exit 1
+    ;;
+esac

--- a/smf/conch
+++ b/smf/conch
@@ -1,17 +1,17 @@
 #!/bin/bash
 
-export PATH=$PATH:/opt/local/bin:/opt/local/sbin
+export PATH=$PATH:/opt/local/bin:/opt/local/sbin:/opt/local/lib/perl5/site_perl/bin
 cd /opt/conch/Conch
 
 case "$1" in
   start)
-    /opt/local/lib/perl5/site_perl/bin/carton exec hypnotoad bin/conch
+    carton exec hypnotoad bin/conch
     ;;
   stop)
-    /opt/local/lib/perl5/site_perl/bin/carton exec hypnotoad -s bin/conch
+    carton exec hypnotoad -s bin/conch
     ;;
   restart)
-    /opt/local/lib/perl5/site_perl/bin/carton exec hypnotoad bin/conch
+    carton exec hypnotoad bin/conch
     ;;
   *)
     echo "Usage:  {start|stop|restart}"

--- a/smf/conch.xml
+++ b/smf/conch.xml
@@ -19,9 +19,9 @@
         </dependency>
 
 
-        <exec_method name='start' type='method' exec='/opt/conch/smf/conch' timeout_seconds='60'/>
+        <exec_method name='start' type='method' exec='/opt/conch/smf/conch start' timeout_seconds='60'/>
         <exec_method name='stop' type='method' exec=':kill' timeout_seconds='60'/>
-        <exec_method name='refresh' type='method' exec=':kill' timeout_seconds='60'/>
+        <exec_method name='refresh' type='method' exec='/opt/conch/smf/conch restart' timeout_seconds='60'/>
 
         <property_group name="startd" type="framework">
             <propval name="duration" type="astring" value="contract"/>

--- a/smf/conch.xml
+++ b/smf/conch.xml
@@ -20,7 +20,7 @@
 
 
         <exec_method name='start' type='method' exec='/opt/conch/smf/conch start' timeout_seconds='60'/>
-        <exec_method name='stop' type='method' exec=':kill' timeout_seconds='60'/>
+        <exec_method name='stop' type='method' exec='/opt/conch/smf/conch stop' timeout_seconds='60'/>
         <exec_method name='refresh' type='method' exec='/opt/conch/smf/conch restart' timeout_seconds='60'/>
 
         <property_group name="startd" type="framework">


### PR DESCRIPTION
Move SMF exec method to a script. See #164 for the first pass at this.

Supports hypnotoad hotload when running `svcadm refresh conch`.