### PR TITLE
fix: use a simple formatter for converting PG timestamps

### DIFF
--- a/Conch/cpanfile
+++ b/Conch/cpanfile
@@ -4,6 +4,7 @@ requires 'perl', '5.26.0';
 # basics
 requires 'Data::UUID';
 requires 'Data::Printer';
+requires 'DateTime::Format::Strptime';
 requires 'List::Compare';
 requires 'Data::Validate::UUID';
 requires 'Mail::Sendmail';
@@ -37,7 +38,6 @@ requires 'String::CamelCase';
 
 # database
 requires 'DBD::Pg';
-requires 'DateTime::Format::Pg';
 requires 'DBIx::Class';
 requires 'DBIx::Class::Schema::Loader';
 requires 'Config::General';

--- a/Conch/lib/Conch/Time.pm
+++ b/Conch/lib/Conch/Time.pm
@@ -18,28 +18,67 @@ Conch::Time - format Postgres Timestamps as RFC 3337 UTC timestamps
 =head1 METHODS
 
 =cut
+
 package Conch::Time;
 use Mojo::Base -base, -signatures;
+use DateTime::Format::Strptime;
+use Carp 'croak';
+
 use overload
 	'""' => 'to_string',
-	eq => 'compare',
-	ne => sub { !compare(@_) };
+	eq   => 'compare',
+	ne   => sub { !compare(@_) };
 
-use DateTime::Format::Pg;
+=head2 timestamp
 
-=head2 datetime
-
-Underlying L<DateTime> object.
+Underlying RFC 3339 formatted timestamp
 
 =cut
 
-has 'datetime';
+has 'timestamp';
 
 =head2 new
 =cut
+
+my $pg_timestamp_format =
+qr/^(\d{4,})-(\d{2,})-(\d{2,}) (\d{2,}):(\d{2,}):(\d{2,})(\.\d+)?([-\+][\d:]+)$/;
+
 sub new ( $class, $timestamptz ) {
-	my $dt = DateTime::Format::Pg->parse_timestamptz($timestamptz);
-	$class->SUPER::new( datetime => $dt );
+	croak 'Invalid Postgres timestamp'
+		unless $timestamptz && ( $timestamptz =~ m/$pg_timestamp_format/ );
+	my $dt = "$1-$2-$3T$4:$5:$6." . _normalize_millisec($7) . _normalize_tz($8);
+	$class->SUPER::new( timestamp => $dt );
+}
+
+# Given a float, return the number of integer milliseconds it represents
+sub _normalize_millisec {
+	substr( sprintf( '%.3f', shift || 0 ), 2 );
+}
+
+sub _normalize_tz {
+	my $tz = shift;
+	# return 'Z' if the timezone is 00 or 00:00
+	return 'Z' if $tz =~ /^[-\+]00(?!:[1-9]\d)/;
+	# Append :00 if the timezone doesn't specify minutes
+	return $tz . ':00' if $tz =~ /^[-\+]\d\d$/;
+	return $tz;
+}
+
+my $_parser = DateTime::Format::Strptime->new(
+	pattern  => '%Y-%m-%dT%H:%M:%S.%3N%z',
+	on_error => 'croak'
+);
+
+=head2 to_datetime
+
+Return a C<DateTime> object representing the timestamp.
+
+B<NOTE:> This method will negatively impact performance if called frequently.
+
+=cut
+
+sub to_datetime {
+	return $_parser->parse_datetime( shift->timestamp );
 }
 
 =head2 compare
@@ -47,20 +86,21 @@ sub new ( $class, $timestamptz ) {
 Compare two Conch::Time objects. Used to overload C<eq> and C<ne>.
 
 =cut
+
 sub compare {
 	my ( $self, $other ) = @_;
-	$self->datetime eq $other->datetime;
+	$self->timestamp eq $other->timestamp;
 }
 
 =head2 to_string
 
-Render the timestamp as a RFC 3337 string with the UTC suffix C<Z>. Used to
+Render the timestamp as a RFC 3337 timestamp string. Used to
 overload string coercion.
 
 =cut
+
 sub to_string {
-	my $self = shift;
-	$self->datetime->strftime('%Y-%m-%dT%H:%M:%S.%3NZ');
+	shift->timestamp;
 }
 
 1;

--- a/Conch/lib/Conch/Time.pm
+++ b/Conch/lib/Conch/Time.pm
@@ -21,13 +21,17 @@ Conch::Time - format Postgres Timestamps as RFC 3337 UTC timestamps
 
 package Conch::Time;
 use Mojo::Base -base, -signatures;
+
 use DateTime::Format::Strptime;
-use Carp 'croak';
+use Mojo::Exception;
 
 use overload
 	'""' => 'to_string',
 	eq   => 'compare',
 	ne   => sub { !compare(@_) };
+
+use constant PG_TIMESTAMP_FORMAT =>
+	qr/^(\d{4,})-(\d{2,})-(\d{2,}) (\d{2,}):(\d{2,}):(\d{2,})(\.\d+)?([-\+][\d:]+)$/;
 
 =head2 timestamp
 
@@ -40,12 +44,10 @@ has 'timestamp';
 =head2 new
 =cut
 
-my $pg_timestamp_format =
-qr/^(\d{4,})-(\d{2,})-(\d{2,}) (\d{2,}):(\d{2,}):(\d{2,})(\.\d+)?([-\+][\d:]+)$/;
 
 sub new ( $class, $timestamptz ) {
-	croak 'Invalid Postgres timestamp'
-		unless $timestamptz && ( $timestamptz =~ m/$pg_timestamp_format/ );
+	Mojo::Exception->throw('Invalid Postgres timestamp')
+		unless $timestamptz && ( $timestamptz =~ m/${\PG_TIMESTAMP_FORMAT}/ );
 	my $dt = "$1-$2-$3T$4:$5:$6." . _normalize_millisec($7) . _normalize_tz($8);
 	$class->SUPER::new( timestamp => $dt );
 }

--- a/Conch/t/conch_time.t
+++ b/Conch/t/conch_time.t
@@ -12,19 +12,85 @@ my $pgtmp = mk_tmp_db() or die;
 my $dbh   = DBI->connect( $pgtmp->dsn );
 my $pg    = Mojo::Pg->new( $pgtmp->uri );
 
-my $now = $pg->db->query('SELECT NOW()::timestamptz as now ')->hash->{now};
-ok(Conch::Time->new($now));
+subtest 'Test timestamps from real DB' => sub {
+	my $now = $pg->db->query('SELECT NOW()::timestamptz as now ')->hash->{now};
+	ok( my $conch_time = Conch::Time->new($now) );
+	isa_ok( $conch_time->to_datetime, 'DateTime', 'Can produce DateTime object' );
 
-my $dt = $pg->db->query("SELECT '2018-01-02'::timestamptz as datetime")->hash->{datetime};
-ok(Conch::Time->new($dt));
-is(Conch::Time->new($dt)->to_string, '2018-01-02T00:00:00.000Z', 'Formats datetime string as RFC 3339');
-is(''.Conch::Time->new($dt), '2018-01-02T00:00:00.000Z', 'Overloads conversion to string');
+	my $dt = $pg->db->query("SELECT '2018-01-02'::timestamptz as datetime")
+		->hash->{datetime};
+	ok( Conch::Time->new($dt) );
+	is( Conch::Time->new($dt)->to_string,
+		'2018-01-02T00:00:00.000Z', 'Formats datetime string as RFC 3339' );
+	is(
+		'' . Conch::Time->new($dt),
+		'2018-01-02T00:00:00.000Z',
+		'Overloads conversion to string'
+	);
 
-ok(Conch::Time->new($dt) eq Conch::Time->new($dt), 'Equal to Conch::Time with same datetime');
-is(Conch::Time->new($now), Conch::Time->new($now));
+	ok(
+		Conch::Time->new($dt) eq Conch::Time->new($dt),
+		'Equal to Conch::Time with same timestamp'
+	);
+	is( Conch::Time->new($now), Conch::Time->new($now) );
+	ok( Conch::Time->new($now) ne Conch::Time->new($dt),
+		'Different timestamps not equal' );
+	isnt( Conch::Time->new($dt), Conch::Time->new($now) );
+};
 
-ok(Conch::Time->new($now) ne Conch::Time->new($dt), 'Different datetimes not equal');
-isnt(Conch::Time->new($dt), Conch::Time->new($now));
+subtest 'Test parsing of timestamps' => sub {
+	my @cases = (
+		{
+			input    => '2018-01-02 00:00:00+00',
+			expected => '2018-01-02T00:00:00.000Z',
+			message  => 'Replaces +00 timezone with Z'
+		},
+		{
+			input    => '2018-01-02 00:00:00-00',
+			expected => '2018-01-02T00:00:00.000Z',
+			message  => 'Replaces -00 timezone with Z'
+		},
+		{
+			input    => '2018-01-02 00:00:00+00:00',
+			expected => '2018-01-02T00:00:00.000Z',
+			message  => 'Replaces +00:00 timezone with Z'
+		},
+		{
+			input    => '2018-01-02 00:00:00+00:00',
+			expected => '2018-01-02T00:00:00.000Z',
+			message  => 'Replaces -00:00 timezone with Z'
+		},
+		{
+			input    => '2018-01-02 00:00:00+01',
+			expected => '2018-01-02T00:00:00.000+01:00',
+			message  => 'Appends :00 to postive timezones that do not specify minutes'
+		},
+		{
+			input    => '2018-01-02 00:00:00-01',
+			expected => '2018-01-02T00:00:00.000-01:00',
+			message  => 'Appends :00 to negative timezones that do not specify minutes'
+		},
+		{
+			input    => '2018-01-02 00:00:00+01:20',
+			expected => '2018-01-02T00:00:00.000+01:20',
+			message  => 'Does not modify timezones that specify minutes'
+		},
+		{
+			input    => '2018-01-02 00:00:00+00:20',
+			expected => '2018-01-02T00:00:00.000+00:20',
+			message  => 'Does not modify 00 timezones that specify minutes'
+		},
+		{
+			input    => '2018-01-02 00:00:00.987654+00',
+			expected => '2018-01-02T00:00:00.988Z',
+			message  => 'Microseconds rounded to milliseconds'
+		},
+	);
 
+	for (@cases) {
+		is( Conch::Time->new( $_->{input} )->to_string,
+			$_->{expected}, $_->{message} );
+	}
+};
 
 done_testing();


### PR DESCRIPTION
Replace using DateTime with a simple formatter that extracts and normalizes the information from a Postgres timestamptz. The former method significantly impacted performance when formatting thousands of Postgres timestamps. 