### PR TITLE
chore: use Cpanel::JSON::XS via Mojo::JSON_XS

### DIFF
--- a/Conch/bin/conch
+++ b/Conch/bin/conch
@@ -17,6 +17,8 @@ use warnings;
 
 use FindBin;
 BEGIN { unshift @INC, "$FindBin::Bin/../lib" }
+# Must load before `use Mojo::JSON` is used
+use Mojo::JSON_XS;
 use Mojolicious::Commands;
 
 # Start command line interface for application

--- a/Conch/cpanfile
+++ b/Conch/cpanfile
@@ -14,6 +14,7 @@ requires 'Class::StrongSingleton';
 # mojolicious
 requires 'Mojolicious';
 requires 'Mojo::Pg';
+requires 'Mojo::JSON_XS';
 requires 'Mojo::Server::PSGI';
 requires 'Mojolicious::Plugin::Bcrypt';
 requires 'Mojolicious::Plugin::Util::RandomString';

--- a/Conch/cpanfile.snapshot
+++ b/Conch/cpanfile.snapshot
@@ -473,10 +473,10 @@ DISTRIBUTIONS
       SQL::Translator 0
       Test::More 0
       ok 0
-  DBIx-Class-0.082840
-    pathname: R/RI/RIBASUSHI/DBIx-Class-0.082840.tar.gz
+  DBIx-Class-0.082841
+    pathname: R/RI/RIBASUSHI/DBIx-Class-0.082841.tar.gz
     provides:
-      DBIx::Class 0.082840
+      DBIx::Class 0.082841
       DBIx::Class::AccessorGroup undef
       DBIx::Class::Admin undef
       DBIx::Class::CDBICompat undef
@@ -610,45 +610,45 @@ DISTRIBUTIONS
       DBIx::Class 0
       ExtUtils::MakeMaker 6.36
       Test::More 0
-  DBIx-Class-Schema-Loader-0.07047
-    pathname: I/IL/ILMARI/DBIx-Class-Schema-Loader-0.07047.tar.gz
+  DBIx-Class-Schema-Loader-0.07048
+    pathname: I/IL/ILMARI/DBIx-Class-Schema-Loader-0.07048.tar.gz
     provides:
-      DBIx::Class::Schema::Loader 0.07047
-      DBIx::Class::Schema::Loader::Base 0.07047
+      DBIx::Class::Schema::Loader 0.07048
+      DBIx::Class::Schema::Loader::Base 0.07048
       DBIx::Class::Schema::Loader::Column undef
-      DBIx::Class::Schema::Loader::DBI 0.07047
-      DBIx::Class::Schema::Loader::DBI::ADO 0.07047
-      DBIx::Class::Schema::Loader::DBI::ADO::MS_Jet 0.07047
-      DBIx::Class::Schema::Loader::DBI::ADO::Microsoft_SQL_Server 0.07047
-      DBIx::Class::Schema::Loader::DBI::Component::QuotedDefault 0.07047
-      DBIx::Class::Schema::Loader::DBI::DB2 0.07047
-      DBIx::Class::Schema::Loader::DBI::Firebird 0.07047
-      DBIx::Class::Schema::Loader::DBI::Informix 0.07047
-      DBIx::Class::Schema::Loader::DBI::InterBase 0.07047
-      DBIx::Class::Schema::Loader::DBI::MSSQL 0.07047
-      DBIx::Class::Schema::Loader::DBI::ODBC 0.07047
-      DBIx::Class::Schema::Loader::DBI::ODBC::ACCESS 0.07047
-      DBIx::Class::Schema::Loader::DBI::ODBC::Firebird 0.07047
-      DBIx::Class::Schema::Loader::DBI::ODBC::Microsoft_SQL_Server 0.07047
-      DBIx::Class::Schema::Loader::DBI::ODBC::SQL_Anywhere 0.07047
-      DBIx::Class::Schema::Loader::DBI::Oracle 0.07047
-      DBIx::Class::Schema::Loader::DBI::Pg 0.07047
-      DBIx::Class::Schema::Loader::DBI::SQLAnywhere 0.07047
-      DBIx::Class::Schema::Loader::DBI::SQLite 0.07047
-      DBIx::Class::Schema::Loader::DBI::Sybase 0.07047
-      DBIx::Class::Schema::Loader::DBI::Sybase::Common 0.07047
-      DBIx::Class::Schema::Loader::DBI::Sybase::Microsoft_SQL_Server 0.07047
-      DBIx::Class::Schema::Loader::DBI::Writing 0.07047
-      DBIx::Class::Schema::Loader::DBI::mysql 0.07047
+      DBIx::Class::Schema::Loader::DBI 0.07048
+      DBIx::Class::Schema::Loader::DBI::ADO 0.07048
+      DBIx::Class::Schema::Loader::DBI::ADO::MS_Jet 0.07048
+      DBIx::Class::Schema::Loader::DBI::ADO::Microsoft_SQL_Server 0.07048
+      DBIx::Class::Schema::Loader::DBI::Component::QuotedDefault 0.07048
+      DBIx::Class::Schema::Loader::DBI::DB2 0.07048
+      DBIx::Class::Schema::Loader::DBI::Firebird 0.07048
+      DBIx::Class::Schema::Loader::DBI::Informix 0.07048
+      DBIx::Class::Schema::Loader::DBI::InterBase 0.07048
+      DBIx::Class::Schema::Loader::DBI::MSSQL 0.07048
+      DBIx::Class::Schema::Loader::DBI::ODBC 0.07048
+      DBIx::Class::Schema::Loader::DBI::ODBC::ACCESS 0.07048
+      DBIx::Class::Schema::Loader::DBI::ODBC::Firebird 0.07048
+      DBIx::Class::Schema::Loader::DBI::ODBC::Microsoft_SQL_Server 0.07048
+      DBIx::Class::Schema::Loader::DBI::ODBC::SQL_Anywhere 0.07048
+      DBIx::Class::Schema::Loader::DBI::Oracle 0.07048
+      DBIx::Class::Schema::Loader::DBI::Pg 0.07048
+      DBIx::Class::Schema::Loader::DBI::SQLAnywhere 0.07048
+      DBIx::Class::Schema::Loader::DBI::SQLite 0.07048
+      DBIx::Class::Schema::Loader::DBI::Sybase 0.07048
+      DBIx::Class::Schema::Loader::DBI::Sybase::Common 0.07048
+      DBIx::Class::Schema::Loader::DBI::Sybase::Microsoft_SQL_Server 0.07048
+      DBIx::Class::Schema::Loader::DBI::Writing 0.07048
+      DBIx::Class::Schema::Loader::DBI::mysql 0.07048
       DBIx::Class::Schema::Loader::DBObject undef
       DBIx::Class::Schema::Loader::DBObject::Informix undef
       DBIx::Class::Schema::Loader::DBObject::Sybase undef
       DBIx::Class::Schema::Loader::Optional::Dependencies undef
-      DBIx::Class::Schema::Loader::RelBuilder 0.07047
-      DBIx::Class::Schema::Loader::RelBuilder::Compat::v0_040 0.07047
-      DBIx::Class::Schema::Loader::RelBuilder::Compat::v0_05 0.07047
-      DBIx::Class::Schema::Loader::RelBuilder::Compat::v0_06 0.07047
-      DBIx::Class::Schema::Loader::RelBuilder::Compat::v0_07 0.07047
+      DBIx::Class::Schema::Loader::RelBuilder 0.07048
+      DBIx::Class::Schema::Loader::RelBuilder::Compat::v0_040 0.07048
+      DBIx::Class::Schema::Loader::RelBuilder::Compat::v0_05 0.07048
+      DBIx::Class::Schema::Loader::RelBuilder::Compat::v0_06 0.07048
+      DBIx::Class::Schema::Loader::RelBuilder::Compat::v0_07 0.07048
       DBIx::Class::Schema::Loader::Table undef
       DBIx::Class::Schema::Loader::Table::Informix undef
       DBIx::Class::Schema::Loader::Table::Sybase undef
@@ -683,6 +683,7 @@ DISTRIBUTIONS
       Test::More 0.94
       Test::Warn 0.21
       Try::Tiny 0
+      curry 1.000000
       namespace::clean 0.23
       perl 5.008001
   DBIx-Class-TimeStamp-0.14
@@ -1662,10 +1663,10 @@ DISTRIBUTIONS
       JSON::PP 2.27300
       Scalar::Util 0
       perl 5.006
-  JSON-Validator-2.00
-    pathname: J/JH/JHTHORSEN/JSON-Validator-2.00.tar.gz
+  JSON-Validator-2.02
+    pathname: J/JH/JHTHORSEN/JSON-Validator-2.02.tar.gz
     provides:
-      JSON::Validator 2.00
+      JSON::Validator 2.02
       JSON::Validator::Error undef
       JSON::Validator::OpenAPI undef
       JSON::Validator::OpenAPI::Dancer2 undef
@@ -1998,29 +1999,29 @@ DISTRIBUTIONS
       perl 5.008
       strict 0
       warnings 0
-  Log-Report-1.25
-    pathname: M/MA/MARKOV/Log-Report-1.25.tar.gz
+  Log-Report-1.26
+    pathname: M/MA/MARKOV/Log-Report-1.26.tar.gz
     provides:
-      Dancer2::Logger::LogReport 1.25
-      Dancer2::Plugin::LogReport 1.25
-      Dancer2::Plugin::LogReport::Message 1.25
-      Dancer::Logger::LogReport 1.25
-      Log::Report 1.25
-      Log::Report::DBIC::Profiler 1.25
-      Log::Report::Die 1.25
-      Log::Report::Dispatcher 1.25
-      Log::Report::Dispatcher::Callback 1.25
-      Log::Report::Dispatcher::File 1.25
-      Log::Report::Dispatcher::Log4perl 1.25
-      Log::Report::Dispatcher::LogDispatch 1.25
-      Log::Report::Dispatcher::Perl 1.25
-      Log::Report::Dispatcher::Syslog 1.25
-      Log::Report::Dispatcher::Try 1.25
-      Log::Report::Domain 1.25
-      Log::Report::Exception 1.25
-      Log::Report::Message 1.25
-      Log::Report::Translator 1.25
-      MojoX::Log::Report 1.25
+      Dancer2::Logger::LogReport 1.26
+      Dancer2::Plugin::LogReport 1.26
+      Dancer2::Plugin::LogReport::Message 1.26
+      Dancer::Logger::LogReport 1.26
+      Log::Report 1.26
+      Log::Report::DBIC::Profiler 1.26
+      Log::Report::Die 1.26
+      Log::Report::Dispatcher 1.26
+      Log::Report::Dispatcher::Callback 1.26
+      Log::Report::Dispatcher::File 1.26
+      Log::Report::Dispatcher::Log4perl 1.26
+      Log::Report::Dispatcher::LogDispatch 1.26
+      Log::Report::Dispatcher::Perl 1.26
+      Log::Report::Dispatcher::Syslog 1.26
+      Log::Report::Dispatcher::Try 1.26
+      Log::Report::Domain 1.26
+      Log::Report::Exception 1.26
+      Log::Report::Message 1.26
+      Log::Report::Translator 1.26
+      MojoX::Log::Report 1.26
     requirements:
       Devel::GlobalDestruction 0.09
       Encode 2.00
@@ -2108,6 +2109,27 @@ DISTRIBUTIONS
       Fennec::Lite 0
       Test::Exception 0
       Test::More 0
+  Minion-8.10
+    pathname: S/SR/SRI/Minion-8.10.tar.gz
+    provides:
+      LinkCheck undef
+      LinkCheck::Controller::Links undef
+      LinkCheck::Task::CheckLinks undef
+      Minion 8.10
+      Minion::Backend undef
+      Minion::Backend::Pg undef
+      Minion::Command::minion undef
+      Minion::Command::minion::job undef
+      Minion::Command::minion::worker undef
+      Minion::Job undef
+      Minion::Worker undef
+      Minion::_Guard 8.10
+      Mojolicious::Plugin::Minion undef
+      Mojolicious::Plugin::Minion::Admin undef
+    requirements:
+      ExtUtils::MakeMaker 0
+      Mojolicious 7.56
+      perl 5.010001
   Mock-Quick-1.111
     pathname: E/EX/EXODIST/Mock-Quick-1.111.tar.gz
     provides:
@@ -2261,23 +2283,34 @@ DISTRIBUTIONS
       perl 5.006
       strict 0
       warnings 0
-  Mojo-Pg-4.04
-    pathname: S/SR/SRI/Mojo-Pg-4.04.tar.gz
+  Mojo-JSON_XS-1.003
+    pathname: N/NI/NICZERO/Mojo-JSON_XS-1.003.tar.gz
     provides:
-      Mojo::Pg 4.04
+      Mojo::JSON_XS 1.003
+    requirements:
+      Cpanel::JSON::XS 3.0109
+      ExtUtils::MakeMaker 6.3
+      Mojolicious 5.66
+      Test::More 0
+      perl 5.010001
+  Mojo-Pg-4.08
+    pathname: S/SR/SRI/Mojo-Pg-4.08.tar.gz
+    provides:
+      Mojo::Pg 4.08
       Mojo::Pg::Database undef
       Mojo::Pg::Migrations undef
       Mojo::Pg::PubSub undef
       Mojo::Pg::Results undef
       Mojo::Pg::Transaction undef
+      SQL::Abstract::Pg undef
     requirements:
       DBD::Pg 3.005001
       ExtUtils::MakeMaker 0
       Mojolicious 7.53
-      SQL::Abstract 1.81
+      SQL::Abstract 1.85
       perl 5.010001
-  Mojolicious-7.61
-    pathname: S/SR/SRI/Mojolicious-7.61.tar.gz
+  Mojolicious-7.60
+    pathname: S/SR/SRI/Mojolicious-7.60.tar.gz
     provides:
       Mojo undef
       Mojo::Asset undef
@@ -2346,7 +2379,7 @@ DISTRIBUTIONS
       Mojo::UserAgent::Transactor undef
       Mojo::Util undef
       Mojo::WebSocket undef
-      Mojolicious 7.61
+      Mojolicious 7.60
       Mojolicious::Command undef
       Mojolicious::Command::cgi undef
       Mojolicious::Command::cpanify undef
@@ -3153,10 +3186,10 @@ DISTRIBUTIONS
     requirements:
       Exporter 5.57
       perl 5.006
-  SQL-Abstract-1.84
-    pathname: I/IL/ILMARI/SQL-Abstract-1.84.tar.gz
+  SQL-Abstract-1.85
+    pathname: I/IL/ILMARI/SQL-Abstract-1.85.tar.gz
     provides:
-      SQL::Abstract 1.84
+      SQL::Abstract 1.85
       SQL::Abstract::Test undef
       SQL::Abstract::Tree undef
     requirements:
@@ -3169,6 +3202,7 @@ DISTRIBUTIONS
       Scalar::Util 0
       Sub::Quote 2.000001
       Text::Balanced 2.00
+      perl 5.006
   SQL-Translator-0.11024
     pathname: I/IL/ILMARI/SQL-Translator-0.11024.tar.gz
     provides:
@@ -3881,6 +3915,20 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       perl 5.008001
+  YAML-Tiny-1.70
+    pathname: E/ET/ETHER/YAML-Tiny-1.70.tar.gz
+    provides:
+      YAML::Tiny 1.70
+    requirements:
+      B 0
+      Carp 0
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      Fcntl 0
+      Scalar::Util 0
+      perl 5.008001
+      strict 0
+      warnings 0
   aliased-0.34
     pathname: E/ET/ETHER/aliased-0.34.tar.gz
     provides:
@@ -3906,6 +3954,14 @@ DISTRIBUTIONS
       perl 5.008001
       strict 0
       warnings 0
+  curry-1.001000
+    pathname: M/MS/MSTROUT/curry-1.001000.tar.gz
+    provides:
+      curry 1.001000
+      curry::weak 1.001000
+    requirements:
+      ExtUtils::MakeMaker 0
+      perl 5.006
   indirect-0.38
     pathname: V/VP/VPIT/indirect-0.38.tar.gz
     provides:


### PR DESCRIPTION
This added a small performance bump when rendering and consuming JSON. `Mojo::JSON_XS` monkey patches `Mojo::JSON`. This is required because several Mojo methods hard-code the use of `Mojo::JSON` for encoding JSON. It is also convenient; we don't need to change any behaviors to get the speedup.