### PR TITLE
chore: add NYTProf plugin

### DIFF
--- a/Conch/conch.conf.dist
+++ b/Conch/conch.conf.dist
@@ -11,6 +11,49 @@
       listen => ['http://*:5000'],
       # operates behind a reverse proxy
       proxy => 1,
-    }
+    },
+
+    nytprof => {
+ 
+    # path to your nytprofhtml script (installed as part of Devel::NYTProf
+    # distribution). the plugin will do its best to try to find this so this
+    # is optional, just set if you have a none standard path
+    nytprofhtml_path => 'local/bin/nytprofhtml',
+ 
+    # path to store Devel::NYTProf output profiles and generated html pages.
+    # options, defaults to "/path/to/your/app/root/dir/nytprof"
+    profiles_dir => 'nytprof/',
+ 
+    # set this to true to allow the plugin to run when in production mode
+    # the default value is 0 so you can deploy your app to prod without
+    # having to make any changes to config/plugin register
+    allow_production => 1,
+ 
+    # Devel::NYTProf environment options, see the documentation at
+    # https://metacpan.org/pod/Devel::NYTProf#NYTPROF-ENVIRONMENT-VARIABLE
+    # for a complete list. N.B. you can't supply start or file as these
+    # are used internally in the plugin so will be ignored if passed
+    env => {
+      blocks => 1
+    },
+ 
+    # when to enable Devel::NYTProf profiling - the pre_hook will run
+    # to enable_profile and the post_hook will run to disable_profile
+    # and finish_profile. the values show here are the defaults so you
+    # do not need to provide these options
+    #
+    # bear in mind the caveats in the Mojolicious docs regarding hooks
+    # and that they may not fire in the order you expect - this can
+    # affect the NYTProf output and cause some things not to appear
+    # (or appear in the wrong order). the defaults below should be 
+    # sufficient for profiling your code, however you can change these
+    #
+    # N.B. there is nothing stopping you reversing the order of the
+    # hooks, which would cause the Mojolicious framework code to be
+    # profiled, or providing hooks that are the same or even invalid. these
+    # config options should probably be used with some care
+    pre_hook  => 'before_routes',
+    post_hook => 'around_dispatch',
+  }
 
 }

--- a/Conch/cpanfile
+++ b/Conch/cpanfile
@@ -17,6 +17,7 @@ requires 'Mojo::Pg';
 requires 'Mojo::Server::PSGI';
 requires 'Mojolicious::Plugin::Bcrypt';
 requires 'Mojolicious::Plugin::Util::RandomString';
+requires 'Mojolicious::Plugin::NYTProf';
 
 ### Legacy Deps
 #

--- a/Conch/cpanfile.snapshot
+++ b/Conch/cpanfile.snapshot
@@ -9,6 +9,18 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 0
       Test::More 0.47
       perl 5.006
+  Algorithm-Combinatorics-0.27
+    pathname: F/FX/FXN/Algorithm-Combinatorics-0.27.tar.gz
+    provides:
+      Algorithm::Combinatorics 0.27
+      Algorithm::Combinatorics::Iterator 0.27
+      Algorithm::Combinatorics::JustCoderef 0.27
+    requirements:
+      ExtUtils::MakeMaker 0
+      FindBin 0
+      Scalar::Util 0
+      Test::More 0
+      XSLoader 0
   Algorithm-Diff-1.1903
     pathname: T/TY/TYEMQ/Algorithm-Diff-1.1903.tar.gz
     provides:
@@ -1325,6 +1337,31 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 0
       Sub::Exporter::Progressive 0.001011
       perl 5.006
+  Devel-NYTProf-6.04
+    pathname: T/TI/TIMB/Devel-NYTProf-6.04.tar.gz
+    provides:
+      Devel::NYTProf 6.04
+      Devel::NYTProf::Apache 4.00
+      Devel::NYTProf::Constants undef
+      Devel::NYTProf::Core 6.04
+      Devel::NYTProf::Data 4.02
+      Devel::NYTProf::FileHandle undef
+      Devel::NYTProf::FileInfo undef
+      Devel::NYTProf::ReadStream 4.00
+      Devel::NYTProf::Reader 4.06
+      Devel::NYTProf::Run undef
+      Devel::NYTProf::SubCallInfo undef
+      Devel::NYTProf::SubInfo undef
+      Devel::NYTProf::Util 4.00
+    requirements:
+      ExtUtils::MakeMaker 0
+      File::Which 1.09
+      Getopt::Long 0
+      JSON::MaybeXS 0
+      List::Util 0
+      Test::Differences 0.60
+      Test::More 0.84
+      XSLoader 0
   Devel-OverloadInfo-0.004
     pathname: I/IL/ILMARI/Devel-OverloadInfo-0.004.tar.gz
     provides:
@@ -2409,6 +2446,22 @@ DISTRIBUTIONS
       Mojolicious 4.0
       strict 0
       warnings 0
+  Mojolicious-Plugin-NYTProf-0.20
+    pathname: L/LE/LEEJO/Mojolicious-Plugin-NYTProf-0.20.tar.gz
+    provides:
+      Mojolicious::Plugin::NYTProf 0.20
+    requirements:
+      Algorithm::Combinatorics 0.27
+      Devel::NYTProf 5.07
+      ExtUtils::MakeMaker 0
+      File::Spec::Functions 3.30
+      File::Temp 0.22
+      File::Which 1.09
+      Mojolicious 6.00
+      Test::Exception 0.32
+      Test::More 0
+      Time::HiRes 1.9719
+      perl 5.010001
   Mojolicious-Plugin-Util-RandomString-0.06
     pathname: A/AK/AKRON/Mojolicious-Plugin-Util-RandomString-0.06.tar.gz
     provides:

--- a/Conch/lib/Conch.pm
+++ b/Conch/lib/Conch.pm
@@ -143,6 +143,7 @@ sub startup {
 	$self->plugin('Util::RandomString');
 	$self->plugin('Conch::Plugin::Model');
 	$self->plugin('Conch::Plugin::Mail');
+	$self->plugin(NYTProf => $self->config);
 
 	my $r = $self->routes;
 	all_routes($r);


### PR DESCRIPTION
Adds https://metacpan.org/pod/Mojolicious::Plugin::NYTProf for per-route profiling.

This is pretty cool. When enabled, each request route is profiled with NYTProf. All profiles are rendered as HTML and served at `http://host/nytprof`.

If the `nytprof` key is **not** specified in the configuration file, the plugin disables itself and does not collect or serve profiles. We can run local dev and staging with profiling and disable it in production.