### PR TITLE
chore: update switch agent to apply Dell FTOS 9.11(2.5)

### DIFF
--- a/sql/hardware_profiles.sql
+++ b/sql/hardware_profiles.sql
@@ -1,7 +1,7 @@
 INSERT INTO hardware_product_profile ( product_id, purpose, bios_firmware, cpu_num, cpu_type, 
             dimms_num, ram_total, nics_num, psu_total, rack_unit )
        VALUES ( ( SELECT id FROM hardware_product WHERE name = 'S4048-ON' ),
-            'TOR switch', '9.10(0.1P18)', 1, 'Intel Rangeley',
+            'TOR switch', '9.11(2.5)', 1, 'Intel Rangeley',
             1, 3, 48, 2, 1
        );
 

--- a/sql/migrations/0022-update-ftos-version.sql
+++ b/sql/migrations/0022-update-ftos-version.sql
@@ -1,0 +1,8 @@
+SELECT run_migration(22, $$
+
+    -- Set expected Dell S4048-ON FTOS version to 9.11(2.5)
+    UPDATE hardware_product_profile SET bios_firmware = '9.11(2.5)'
+        WHERE product_id =
+        ( SELECT id FROM hardware_product WHERE name = 'S4048-ON' );
+
+$$);

--- a/sql/test/01-hardware-profiles.sql
+++ b/sql/test/01-hardware-profiles.sql
@@ -1,7 +1,7 @@
 INSERT INTO hardware_product_profile ( product_id, purpose, bios_firmware, cpu_num, cpu_type, 
             dimms_num, ram_total, nics_num, psu_total, rack_unit, usb_num )
        VALUES ( ( SELECT id FROM hardware_product WHERE name = 'S4048-ON' ),
-            'TOR switch', '9.10(0.1P18)', 1, 'Intel Rangeley',
+            'TOR switch', '9.11(2.5)', 1, 'Intel Rangeley',
             1, 3, 48, 2, 1, 0
        );
 


### PR DESCRIPTION
This allows switch FTOS firmware validations to pass by setting the expected version to 9.11(2.5)