### PR TITLE
Reintroduce Time::Moment now that it builds on SmartOS

### DIFF
--- a/Conch/cpanfile
+++ b/Conch/cpanfile
@@ -12,6 +12,7 @@ requires 'aliased';
 requires 'Try::Tiny';
 requires 'Class::StrongSingleton';
 requires 'Time::HiRes';
+requires 'Time::Moment', ">= 0.43";
 
 # mojolicious
 requires 'Mojolicious';
@@ -71,4 +72,5 @@ on 'test' => sub {
     requires 'IO::All';
     requires 'JSON::Validator';
     requires 'YAML::XS';
+	requires 'Test::Exception';
 };

--- a/Conch/cpanfile.snapshot
+++ b/Conch/cpanfile.snapshot
@@ -866,17 +866,6 @@ DISTRIBUTIONS
       DateTime 0
       DateTime::Format::Builder 0.6
       Module::Build 0
-  DateTime-Format-Pg-0.16013
-    pathname: D/DM/DMAKI/DateTime-Format-Pg-0.16013.tar.gz
-    provides:
-      DateTime::Format::Pg 0.16013
-    requirements:
-      DateTime 0.10
-      DateTime::Format::Builder 0.72
-      DateTime::TimeZone 0.05
-      ExtUtils::MakeMaker 6.36
-      Module::Build::Tiny 0.035
-      Test::More 0
   DateTime-Format-SQLite-0.11
     pathname: C/CF/CFAERBER/DateTime-Format-SQLite-0.11.tar.gz
     provides:
@@ -1543,14 +1532,13 @@ DISTRIBUTIONS
       File::HomeDir::Windows 1.002
     requirements:
       Carp 0
-      Cwd 3
+      Cwd 3.12
       ExtUtils::MakeMaker 0
       File::Basename 0
       File::Path 2.01
-      File::Spec 3
+      File::Spec 3.12
       File::Temp 0.19
       File::Which 0.05
-      Mac::SystemDirectory 0.04
       POSIX 0
       perl 5.005003
   File-ShareDir-1.104
@@ -2096,17 +2084,6 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       perl 5.006
-  Mac-SystemDirectory-0.10
-    pathname: E/ET/ETHER/Mac-SystemDirectory-0.10.tar.gz
-    provides:
-      Mac::SystemDirectory 0.10
-    requirements:
-      Exporter 0
-      ExtUtils::MakeMaker 0
-      XSLoader 0
-      perl 5.006
-      strict 0
-      warnings 0
   Mail-Sendmail-0.80
     pathname: N/NE/NEILB/Mail-Sendmail-0.80.tar.gz
     provides:
@@ -2146,27 +2123,6 @@ DISTRIBUTIONS
       Fennec::Lite 0
       Test::Exception 0
       Test::More 0
-  Minion-8.11
-    pathname: S/SR/SRI/Minion-8.11.tar.gz
-    provides:
-      LinkCheck undef
-      LinkCheck::Controller::Links undef
-      LinkCheck::Task::CheckLinks undef
-      Minion 8.11
-      Minion::Backend undef
-      Minion::Backend::Pg undef
-      Minion::Command::minion undef
-      Minion::Command::minion::job undef
-      Minion::Command::minion::worker undef
-      Minion::Job undef
-      Minion::Worker undef
-      Minion::_Guard 8.11
-      Mojolicious::Plugin::Minion undef
-      Mojolicious::Plugin::Minion::Admin undef
-    requirements:
-      ExtUtils::MakeMaker 0
-      Mojolicious 7.56
-      perl 5.010001
   Mock-Quick-1.111
     pathname: E/EX/EXODIST/Mock-Quick-1.111.tar.gz
     provides:
@@ -3810,6 +3766,22 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       Test::More 0
+  Time-Moment-0.43
+    pathname: C/CH/CHANSEN/Time-Moment-0.43.tar.gz
+    provides:
+      Time::Moment 0.43
+      Time::Moment::Adjusters 0.43
+    requirements:
+      Carp 0
+      ExtUtils::MakeMaker 6.59
+      ExtUtils::ParseXS 3.18
+      Test::Fatal 0.006
+      Test::More 0.88
+      Test::Number::Delta 1.06
+      Test::Requires 0
+      Time::HiRes 0
+      XSLoader 0.02
+      perl 5.008001
   Time-Warp-0.52
     pathname: S/SZ/SZABGAB/Time-Warp-0.52.tar.gz
     provides:
@@ -3990,20 +3962,6 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       perl 5.008001
-  YAML-Tiny-1.70
-    pathname: E/ET/ETHER/YAML-Tiny-1.70.tar.gz
-    provides:
-      YAML::Tiny 1.70
-    requirements:
-      B 0
-      Carp 0
-      Exporter 0
-      ExtUtils::MakeMaker 0
-      Fcntl 0
-      Scalar::Util 0
-      perl 5.008001
-      strict 0
-      warnings 0
   aliased-0.34
     pathname: E/ET/ETHER/aliased-0.34.tar.gz
     provides:

--- a/Conch/t/conch_time.t
+++ b/Conch/t/conch_time.t
@@ -1,9 +1,9 @@
 use Mojo::Base -strict;
 use Test::More;
 use Test::ConchTmpDB;
+use Test::Exception;
 use Mojo::Pg;
-
-use DDP;
+use Time::HiRes;
 
 use_ok("Conch::Time");
 use Conch::Time;
@@ -15,7 +15,6 @@ my $pg    = Mojo::Pg->new( $pgtmp->uri );
 subtest 'Test timestamps from real DB' => sub {
 	my $now = $pg->db->query('SELECT NOW()::timestamptz as now ')->hash->{now};
 	ok( my $conch_time = Conch::Time->new($now) );
-	isa_ok( $conch_time->to_datetime, 'DateTime', 'Can produce DateTime object' );
 
 	my $dt = $pg->db->query("SELECT '2018-01-02'::timestamptz as datetime")
 		->hash->{datetime};
@@ -80,11 +79,6 @@ subtest 'Test parsing of timestamps' => sub {
 			expected => '2018-01-02T00:00:00.000+00:20',
 			message  => 'Does not modify 00 timezones that specify minutes'
 		},
-		{
-			input    => '2018-01-02 00:00:00.987654+00',
-			expected => '2018-01-02T00:00:00.988Z',
-			message  => 'Microseconds rounded to milliseconds'
-		},
 	);
 
 	for (@cases) {
@@ -93,8 +87,23 @@ subtest 'Test parsing of timestamps' => sub {
 	}
 };
 
-my $d = Conch::Time->_from_hires(1519922279, 0);
-is($d->timestamp, "2018-03-01T16:37:59000Z", "->_from_hires output"); 
+my $d;
+lives_ok {
+	$d = Conch::Time->from_epoch(1519922279, 0);
+} "->from_epoch with static input";
+
+is($d->timestamp, "2018-03-01T16:37:59.000Z", "->_from_epoch output"); 
+
+lives_ok {
+	$d = Conch::Time->from_epoch(Time::HiRes::gettimeofday);
+} "->from_epoch with gettimeofday";
+
 isnt(Conch::Time->now(), Conch::Time->now(), "Multiple now()s are unique");
+
+like(
+	Conch::Time->new("2018-01-02 00:00:00+00")->timestamptz, 
+	Conch::Time->PG_TIMESTAMP_FORMAT,
+	"Roundtrip timestamptz"
+);
 
 done_testing();


### PR DESCRIPTION
See chansen/p5-time-moment#28

This reverts joyent/conch#192.

All tests pass on SmartOS 17.4.0 aka JPC image joyent_20170831T155809Z