### PR TITLE
build: travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ install:
   - "cd Conch; carton install"
 script:
   - "cd Conch; carton exec prove -lpr t/"
+cache:
+  directories:
+    - "Conch/local"
 deploy:
   skip_cleanup: true
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,12 @@ deploy:
   on:
     tags: true
     repo: joyent/conch
+notifications:
+  recipients:
+    - sungo@joyent.com
+      #- lane.seppala@joyent.com
+      #- bdha@joyent.com
+      #- dale.ghent@joyent.com
+  email:
+    on_success: change
+    on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,10 @@ script:
 cache:
   directories:
     - "Conch/local"
+branches:
+  only:
+    - master
 deploy:
-  skip_cleanup: true
   provider: releases
   api_key:
     secure: A8vcNPDVPX+dnPWXrs4yT8HehrYa7bWlv7Zb2wvYjYngY+ztbnKUMSisnWbIWIx8N0gr6Xyb3KcV5S7WxLiNE7K2IAC2cF7O1EmvcaJ778TsBKowLuYdqWiew561beMQuuWoMQuL8jMQhl1bV2SMiR3J2aaYjM2c3jeGZQmQSNHpFp8o55KsXLPQNxX5mQ5mnZf1u5F00X8c30ahPj2tlHrXG5Q183HzPwdBktjbuWSyIdgGPGqtm5/0uJewFUOOcRKRODCPDlclXM2s65QvIeCopoqAr4KWGpmot5lt/qAso5XWtCe6aVGIXptyJBs9Rl0fhFOrbjZN0rkT2xenbxGS8OyrMVNfqSypofig9nU4BXK/fL8kdykiefwGVOqn6vbkjAEfphTVIsjlPfjIactPgORMJtAEIH7Tu/bI1F1T1DEce8m7VPtznH1YStUTWIuH7yMEQY81gQh2Ijn38PaDPgrcxlX4he+BwyRYeg1SO3TVbZheIUFQBSCJCATQtbUQZR9bGQS/bz2jC/eXzFUsY0Lhz2GA8zIX2A/+RLshbmua/erVtBocLUGQrBI/DNaIJ3K/RxivEL5keGKozcmxPO7nOBL4PhirCKiCBS1WMCpUd7G7n6+qOyeyWVrkp34PXWb17Ghbglsbpl9kschRKB1wkel+MV7AeQSYDpU=

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,8 @@ perl:
     - "5.26"
 before_install:
     - cpanm Carton
-    - cpanm String::CamelCase
 install:
-  - "cd Conch; carton install --deployment"
+  - "cd Conch; carton install"
 script:
   - "cd Conch; carton exec prove -lpr t/"
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ perl:
     - "5.26"
 before_install:
     - cpanm Carton
+    - cpanm String::CamelCase
 install:
   - "cd Conch; carton install --deployment"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+os: linux
+sudo: false
+language: perl
+perl:
+    - "5.26"
+before_install:
+    - cpanm Carton
+install:
+  - "cd Conch; carton install --deployment"
+script:
+  - "cd Conch; carton exec prove -lpr t/"
+deploy:
+  skip_cleanup: true
+  provider: releases
+  api_key:
+    secure: A8vcNPDVPX+dnPWXrs4yT8HehrYa7bWlv7Zb2wvYjYngY+ztbnKUMSisnWbIWIx8N0gr6Xyb3KcV5S7WxLiNE7K2IAC2cF7O1EmvcaJ778TsBKowLuYdqWiew561beMQuuWoMQuL8jMQhl1bV2SMiR3J2aaYjM2c3jeGZQmQSNHpFp8o55KsXLPQNxX5mQ5mnZf1u5F00X8c30ahPj2tlHrXG5Q183HzPwdBktjbuWSyIdgGPGqtm5/0uJewFUOOcRKRODCPDlclXM2s65QvIeCopoqAr4KWGpmot5lt/qAso5XWtCe6aVGIXptyJBs9Rl0fhFOrbjZN0rkT2xenbxGS8OyrMVNfqSypofig9nU4BXK/fL8kdykiefwGVOqn6vbkjAEfphTVIsjlPfjIactPgORMJtAEIH7Tu/bI1F1T1DEce8m7VPtznH1YStUTWIuH7yMEQY81gQh2Ijn38PaDPgrcxlX4he+BwyRYeg1SO3TVbZheIUFQBSCJCATQtbUQZR9bGQS/bz2jC/eXzFUsY0Lhz2GA8zIX2A/+RLshbmua/erVtBocLUGQrBI/DNaIJ3K/RxivEL5keGKozcmxPO7nOBL4PhirCKiCBS1WMCpUd7G7n6+qOyeyWVrkp34PXWb17Ghbglsbpl9kschRKB1wkel+MV7AeQSYDpU=
+  on:
+    tags: true
+    repo: joyent/conch


### PR DESCRIPTION
# Basics
- See https://travis-ci.org/joyent/conch for results
- Travis only supports Linux for perl apps. So it won't catch any SmartOS build issues.
- It will build against PRs so, as much as I like the WIP PRs, we might need to do something else. I'm not sure everyone wants build checks everytime we push to WIP branches.
- Builds can also be triggered manually in the UI or their CLI

# Dependencies
- Carton dependencies are cached against the branch they're on. So the first time one builds against a branch, it will take a while because carton needs to install deps. 
- Dependency caching means that if one adds a new module, caches will need to manually invalidated at https://travis-ci.org/joyent/conch/caches

# Releases
- I've not tested the release process in this PR but it's the same as joyent/conch-shell so it should work. I'll test it against master once the PR is merged.
- Github releases will be built for any new tag. 
- The release process is using an API token of mine. So, all releases generated by Travis will look like I did them.
- New releases will be marked as regular releases. If you want a pre-release, you'll need to flip that switch manually in the Github UI.

# Misc
- It is possible to also run tests against the UI but I've not set that up in this PR.


