### PR TITLE
refactor: in Conch::Time, use the lenient parsing of Time::Moment rather than our own custom parser

### DIFF
--- a/Conch/lib/Conch/Time.pm
+++ b/Conch/lib/Conch/Time.pm
@@ -31,12 +31,6 @@ use overload
 	eq   => 'compare',
 	ne   => sub { !compare(@_) };
 
-use constant PG_TIMESTAMP_FORMAT => qr/
-	^(\d{4,})-(\d{2,})-(\d{2,})\s
-	(\d{2,}):(\d{2,}):(\d{2,})\.?(\d+)
-	?([-\+])([\d:]+)$
-/x;
-
 
 
 has 'moment';
@@ -48,33 +42,9 @@ has 'moment';
 =cut
 
 sub new ( $class, $timestamptz ) {
-	my @c = ( $timestamptz =~ PG_TIMESTAMP_FORMAT );
-	Mojo::Exception->throw('Invalid Postgres timestamp')
-		unless @c;
-
-	$c[6] = 0 unless $c[6];
-
-	my $off_minutes;
-	if ($c[8] =~ /:/) {
-		my ($hours, $minutes) = $c[8] =~ /^(\d\d)[:]?(\d\d)$/;
-
-		$off_minutes = ($hours*60);
-		$off_minutes = $off_minutes + $minutes if $minutes;
-	} else {
-		$off_minutes = $c[8] * 60;
-	}
-
-	my $m = Time::Moment->new(
-		year       => $c[0],
-		month      => $c[1],
-		day        => $c[2],
-		hour       => $c[3],
-		minute     => $c[4],
-		second     => $c[5],
-		nanosecond => $c[6]*1000,
-		offset     => "${c[7]}${off_minutes}",
+	return $class->SUPER::new(
+		moment => Time::Moment->from_string($timestamptz, lenient => 1)
 	);
-	return $class->SUPER::new(moment => $m);
 }
 
 

--- a/Conch/t/conch_time.t
+++ b/Conch/t/conch_time.t
@@ -8,6 +8,13 @@ use Time::HiRes;
 use_ok("Conch::Time");
 use Conch::Time;
 
+use constant PG_TIMESTAMP_FORMAT => qr/
+	^(\d{4,})-(\d{2,})-(\d{2,})\s
+	(\d{2,}):(\d{2,}):(\d{2,})\.?(\d+)
+	?([-\+])([\d:]+)$
+/x;
+
+
 my $pgtmp = mk_tmp_db() or die;
 my $dbh   = DBI->connect( $pgtmp->dsn );
 my $pg    = Mojo::Pg->new( $pgtmp->uri );
@@ -102,7 +109,7 @@ isnt(Conch::Time->now(), Conch::Time->now(), "Multiple now()s are unique");
 
 like(
 	Conch::Time->new("2018-01-02 00:00:00+00")->timestamptz, 
-	Conch::Time->PG_TIMESTAMP_FORMAT,
+	PG_TIMESTAMP_FORMAT,
 	"Roundtrip timestamptz"
 );
 


### PR DESCRIPTION
All tests pass on SmartOS 17.4.0