### PR TITLE
feat: add GitVersion plugin

### DIFF
--- a/Conch/lib/Conch.pm
+++ b/Conch/lib/Conch.pm
@@ -145,6 +145,7 @@ sub startup {
 
 	$self->plugin('Util::RandomString');
 	$self->plugin('Conch::Plugin::Mail');
+	$self->plugin('Conch::Plugin::GitVersion');
 	$self->plugin(NYTProf => $self->config);
 
 	if($self->config('audit')) {

--- a/Conch/lib/Conch/Plugin/GitVersion.pm
+++ b/Conch/lib/Conch/Plugin/GitVersion.pm
@@ -1,0 +1,37 @@
+=pod
+
+=head1 NAME
+
+Conch::Plugin::GitVersion
+
+=head1 DESCRIPTION
+
+Mojo plugin registering the git version tag and hash for the repository
+
+=head1 METHODS
+
+=cut
+
+package Conch::Plugin::GitVersion;
+
+use Mojo::Base 'Mojolicious::Plugin', -signatures;
+
+=head2 register
+
+Register C<version_tag> and C<version_hash>.
+
+=cut
+
+sub register ( $self, $app, $conf ) {
+	my $git_tag = `git describe`;
+	chomp $git_tag;
+	my $git_hash = `git rev-parse HEAD`;
+	chomp $git_hash;
+
+	$app->helper(
+		version_tag  => sub { $git_tag },
+		version_hash => sub { $git_hash }
+	);
+}
+
+1;

--- a/Conch/lib/Conch/Route.pm
+++ b/Conch/lib/Conch/Route.pm
@@ -26,7 +26,6 @@ our @EXPORT = qw(
 	all_routes
 );
 
-
 =head2 all_routes
 
 Set up the full route structure
@@ -43,10 +42,8 @@ sub all_routes {
 	);
 
 	$unsecured->get( '/', sub { shift->reply->static('../public/index.html') } );
-	$unsecured->get( '/doc', 
-		sub { shift->reply->static('../public/doc/index.html') }
-	);
-
+	$unsecured->get( '/doc',
+		sub { shift->reply->static('../public/doc/index.html') } );
 
 	$unsecured->get(
 		'/ping',
@@ -55,11 +52,12 @@ sub all_routes {
 		}
 	);
 
-	my $git_rev = `git describe`;
-	chomp($git_rev);
-	$unsecured->get('/version' => sub { 
-		shift->status(200, { version => $git_rev });
-	});
+	$unsecured->get(
+		'/version' => sub {
+			my $c = shift;
+			$c->status( 200, { version => $c->version_tag } );
+		}
+	);
 
 	$unsecured->post('/login')->to('login#session_login');
 	$unsecured->post('/logout')->to('login#session_logout');
@@ -99,4 +97,3 @@ v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
 one at http://mozilla.org/MPL/2.0/.
 
 =cut
-


### PR DESCRIPTION
Add a simple plugin to calculate and cache the git version variables, tag and hash for now.