### PR TITLE
feat: Endpoints for getting validation states with results

### DIFF
--- a/Conch/json-schema/v1.yaml
+++ b/Conch/json-schema/v1.yaml
@@ -598,6 +598,91 @@ definitions:
       created:
         type: string
         format: date-time
+  ValidationResult:
+    type: object
+    additionalProperties: false
+    required:
+      - id
+      - category
+      - component_id
+      - device_id
+      - hardware_product_id
+      - hint
+      - message
+      - status
+      - validation_id
+    properties:
+      id:
+        type: string
+        format: uuid
+      category:
+        type: string
+      component_id:
+        anyOf:
+          - type: null
+          - type: string
+      device_id:
+        type: string
+      hardware_product_id:
+        type: string
+        format: uuid
+      hint:
+        anyOf:
+          - type: null
+          - type: string
+      message:
+        type: string
+      status:
+        type: string
+        enum:
+          - error
+          - fail
+          - pass
+      validation_id:
+        type: string
+        format: uuid
+  ValidationStatesWithResults:
+    type: array
+    items:
+      $ref: "#/definitions/ValidationStateWithResults"
+  ValidationStateWithResults:
+    type: object
+    additionalProperties: false
+    required:
+      - id
+      - completed
+      - created
+      - device_id
+      - results
+      - status
+      - validation_plan_id
+    properties:
+      id:
+        type: string
+        format: uuid
+      completed:
+        anyOf:
+          - type: null
+          - type: string
+            format: date-time
+      created:
+        type: string
+        format: date-time
+      device_id:
+        type: string
+      results:
+        type: array
+        items:
+          $ref: "#/definitions/ValidationResult"
+      status:
+        type: string
+        enum:
+          - error
+          - fail
+          - pass
+      validation_plan_id:
+        type: string
+        format: uuid
   WorkspaceRelays:
     type: array
     items:

--- a/Conch/lib/Conch/Controller/Validation.pm
+++ b/Conch/lib/Conch/Controller/Validation.pm
@@ -22,9 +22,9 @@ List all available Validations
 =cut
 
 sub list ($c) {
-	my @validations = map { $_->output_hash } Conch::Model::Validation->list->@*;
+	my $validations = Conch::Model::Validation->list;
 
-	$c->status( 200, [@validations] );
+	$c->status( 200, $validations );
 }
 
 1;

--- a/Conch/lib/Conch/Controller/ValidationPlan.pm
+++ b/Conch/lib/Conch/Controller/ValidationPlan.pm
@@ -52,7 +52,7 @@ sub create ($c) {
 	my $validation_plan =
 		Conch::Model::ValidationPlan->create( $body->{name}, $body->{description} );
 
-	$c->status( 201, $validation_plan->output_hash );
+	$c->status( 201, $validation_plan );
 }
 
 =head2 list
@@ -62,9 +62,8 @@ List all available Validation Plans
 =cut
 
 sub list ($c) {
-	my @validation_plans =
-		map { $_->output_hash } Conch::Model::ValidationPlan->list->@*;
-	$c->status( 200, \@validation_plans );
+	my $validation_plans = Conch::Model::ValidationPlan->list;
+	$c->status( 200, $validation_plans );
 }
 
 =head2 under
@@ -100,7 +99,7 @@ Get the Validation Plan specified by ID
 
 sub get ($c) {
 	if ( $c->under ) {
-		$c->status( 200, $c->stash('validation_plan')->output_hash );
+		$c->status( 200, $c->stash('validation_plan') );
 	}
 	else {
 		return 0;
@@ -114,10 +113,9 @@ List all Validations associated with the Validation Plan
 =cut
 
 sub list_validations ($c) {
-	my @validations =
-		map { $_->output_hash } $c->stash('validation_plan')->validations->@*;
+	my $validations = $c->stash('validation_plan')->validations;
 
-	$c->status( 200, \@validations );
+	$c->status( 200, $validations );
 }
 
 =head2 add_validation

--- a/Conch/lib/Conch/Controller/WorkspaceValidation.pm
+++ b/Conch/lib/Conch/Controller/WorkspaceValidation.pm
@@ -1,0 +1,56 @@
+=pod
+
+=head1 NAME
+
+Conch::Controller::WorkspaceValidation
+
+=head1 METHODS
+
+=cut
+
+package Conch::Controller::WorkspaceValidation;
+
+use Mojo::Base 'Mojolicious::Controller', -signatures;
+
+use Conch::Models;
+
+=head2 workspace_validation_states
+
+Get a list of latest validation states with results for all devices in a workspace
+
+=cut
+
+sub workspace_validation_states ($c) {
+	my $workspace_devices = Conch::Model::WorkspaceDevice->new->list(
+		$c->stash('current_workspace')->id );
+
+	my $validation_states =
+		Conch::Model::ValidationState->latest_completed_states_for_devices(
+		[ map { $_->id } @$workspace_devices ] );
+
+	my $validation_state_groups =
+		Conch::Model::ValidationResult->grouped_by_validation_states(
+		$validation_states);
+
+	my @output = map {
+		{ $_->{state}->TO_JSON->%*, results => $_->{results} };
+	} @$validation_state_groups;
+
+	$c->status( 200, \@output );
+}
+
+1;
+
+__DATA__
+
+=pod
+
+=head1 LICENSING
+
+Copyright Joyent, Inc.
+
+This Source Code Form is subject to the terms of the Mozilla Public License, 
+v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+one at http://mozilla.org/MPL/2.0/.
+
+=cut

--- a/Conch/lib/Conch/Model/Validation.pm
+++ b/Conch/lib/Conch/Model/Validation.pm
@@ -51,8 +51,8 @@ sub TO_JSON ($self) {
 		name        => $self->name,
 		version     => $self->version,
 		description => $self->description,
-		created     => Conch::Time->new( $self->created )->rfc3339,
-		updated     => Conch::Time->new( $self->updated )->rfc3339
+		created     => Conch::Time->new( $self->created ),
+		updated     => Conch::Time->new( $self->updated )
 	};
 }
 

--- a/Conch/lib/Conch/Model/Validation.pm
+++ b/Conch/lib/Conch/Model/Validation.pm
@@ -39,13 +39,13 @@ sub new ( $class, %args ) {
 	$class->SUPER::new( %args{@$attrs} );
 }
 
-=head2 output_hash
+=head2 TO_JSON
 
 Render as a hashref for output
 
 =cut
 
-sub output_hash ($self) {
+sub TO_JSON ($self) {
 	{
 		id          => $self->id,
 		name        => $self->name,

--- a/Conch/lib/Conch/Model/ValidationPlan.pm
+++ b/Conch/lib/Conch/Model/ValidationPlan.pm
@@ -15,13 +15,13 @@ use Conch::Pg;
 my $attrs = [qw( id name description created )];
 has $attrs;
 
-=head2 output_hash
+=head2 TO_JSON
 
 Render as a hashref for output
 
 =cut
 
-sub output_hash ($self) {
+sub TO_JSON ($self) {
 	{
 		id          => $self->id,
 		name        => $self->name,

--- a/Conch/lib/Conch/Model/ValidationPlan.pm
+++ b/Conch/lib/Conch/Model/ValidationPlan.pm
@@ -26,7 +26,7 @@ sub TO_JSON ($self) {
 		id          => $self->id,
 		name        => $self->name,
 		description => $self->description,
-		created     => Conch::Time->new( $self->created )->rfc3339
+		created     => Conch::Time->new( $self->created )
 	};
 }
 

--- a/Conch/lib/Conch/Model/ValidationResult.pm
+++ b/Conch/lib/Conch/Model/ValidationResult.pm
@@ -154,7 +154,8 @@ sub grouped_by_validation_states ( $class, $validation_states ) {
 			1;
 		}
 		);
-	return [ values %groups ];
+	return [ sort { $b->{state}->completed cmp $a->{state}->completed }
+			values %groups ];
 }
 
 1;

--- a/Conch/lib/Conch/Model/ValidationState.pm
+++ b/Conch/lib/Conch/Model/ValidationState.pm
@@ -30,9 +30,9 @@ sub TO_JSON ($self) {
 		device_id          => $self->device_id,
 		validation_plan_id => $self->validation_plan_id,
 		status             => $self->status,
-		created            => Conch::Time->new( $self->created )->rfc3339,
+		created            => Conch::Time->new( $self->created ),
 		completed          => $self->completed
-			&& Conch::Time->new( $self->completed )->rfc3339
+			&& Conch::Time->new( $self->completed )
 	};
 }
 

--- a/Conch/lib/Conch/Models.pm
+++ b/Conch/lib/Conch/Models.pm
@@ -19,6 +19,7 @@ use Conch::Model::HardwareProduct;
 use Conch::Model::Relay;
 use Conch::Model::Validation;
 use Conch::Model::ValidationPlan;
+use Conch::Model::ValidationState;
 use Conch::Model::Workspace;
 use Conch::Model::WorkspaceDevice;
 use Conch::Model::WorkspaceRack;

--- a/Conch/lib/Conch/Route/Device.pm
+++ b/Conch/lib/Conch/Route/Device.pm
@@ -77,6 +77,10 @@ sub device_routes {
 		->to('device_validation#validate');
 	$with_device->post('/validation_plan/#validation_plan_id')
 		->to('device_validation#run_validation_plan');
+	$with_device->get('/validation_state')
+		->to('device_validation#list_validation_states');
+	$with_device->get('/validation_result')
+		->to('device_validation#list_validation_results');
 
 	$with_device->get('/role')->to('device#get_role');
 	$with_device->post('/role')->to('device#set_role');

--- a/Conch/lib/Conch/Route/Workspace.pm
+++ b/Conch/lib/Conch/Route/Workspace.pm
@@ -68,6 +68,8 @@ sub workspace_routes {
 
 	$in_workspace->get('/user')->to('workspace_user#list');
 	$in_workspace->post('/user')->to('workspace_user#invite');
+
+	$in_workspace->get('/validation_state')->to('workspace_validation#workspace_validation_states');
 }
 
 1;

--- a/Conch/t/model/ValidationState.t
+++ b/Conch/t/model/ValidationState.t
@@ -225,15 +225,15 @@ subtest 'grouped_by_validation_states' => sub {
 		$groups,
 		[
 			{
-				state   => $validation_state,
-				results => $results
-			},
-			{
 				state   => $new_state,
 				results => $new_results
 			},
-
-		]
+			{
+				state   => $validation_state,
+				results => $results
+			},
+		],
+		'Groups return in sorted order by most recent completed state first'
 	);
 };
 


### PR DESCRIPTION
This adds two endpoints:

* `GET /device/:id/validation_state`
* `GET /workspace/:id/validation_state`

The first gets the most recent validation states (one per validation plan run) for a device. The second gets all most recent validations states for all devices in the workspace. The each validation state includes the associated validation results.

The purpose of this work is to supplant the legacy and problematic endpoint `GET /workspace/:id/problem` in `Conch::Controller::WorkspaceProblem`, which returns a tree structure of "failing" devices. The problem endpoint will be removed once device report ingestion is transitioned away from the legacy validation system.