### PR TITLE
feat: Integrate Validation State reporting into existing UI

### DIFF
--- a/Conch/ui/src/models/Validation.js
+++ b/Conch/ui/src/models/Validation.js
@@ -1,0 +1,25 @@
+import m from "mithril";
+
+const Validation = {
+    list: [],
+    idToName: {},
+    load() {
+        return m
+            .request({
+                method: "get",
+                url: "/validation",
+            })
+            .then(validations => {
+                Validation.list = validations;
+                Validation.idToName = validations.reduce(
+                    (acc, { id, name }) => {
+                        acc[id] = name;
+                        return acc;
+                    },
+                    {}
+                );
+            });
+    },
+};
+
+export default Validation;

--- a/Conch/ui/src/models/ValidationPlan.js
+++ b/Conch/ui/src/models/ValidationPlan.js
@@ -1,0 +1,25 @@
+import m from "mithril";
+
+const ValidationPlan = {
+    list: [],
+    idToName: {},
+    load() {
+        return m
+            .request({
+                method: "get",
+                url: "/validation_plan",
+            })
+            .then(validations => {
+                ValidationPlan.list = validations;
+                ValidationPlan.idToName = validations.reduce(
+                    (acc, { id, name }) => {
+                        acc[id] = name;
+                        return acc;
+                    },
+                    {}
+                );
+            });
+    },
+};
+
+export default ValidationPlan;

--- a/Conch/ui/src/models/ValidationState.js
+++ b/Conch/ui/src/models/ValidationState.js
@@ -1,0 +1,29 @@
+import m from "mithril";
+
+const ValidationState = {
+    currentList: [],
+
+    loadForWorkspace(wId) {
+        return m
+            .request({
+                method: "get",
+                url: `/workspace/${wId}/validation_state`,
+            })
+            .then(validationStates => {
+                ValidationState.currentList = validationStates;
+            });
+    },
+
+    loadForDevice(dId) {
+        return m
+            .request({
+                method: "get",
+                url: `/device/${dId}/validation_state`,
+            })
+            .then(validationStates => {
+                ValidationState.currentList = validationStates;
+            });
+    },
+};
+
+export default ValidationState;


### PR DESCRIPTION
Add new validation state results to the existing Problem and Device pages. This reuses the existing design elements, which are less than ideal, but serves the purpose of exposing the new validation results in the UI. Better designs later.