### PR TITLE
fix: Auth.requireLogin needs to conditionally evaluate callback

### DIFF
--- a/Conch/ui/src/models/Auth.js
+++ b/Conch/ui/src/models/Auth.js
@@ -5,7 +5,7 @@ const Auth = {
     password: "",
     _loggedIn: false,
     requireLogin(next) {
-        if (Auth._loggedIn) return next;
+        if (Auth._loggedIn) return next();
         m
             .request({
                 method: "GET",
@@ -19,7 +19,7 @@ const Auth = {
             })
             .then(_res => {
                 Auth._loggedIn = true;
-                return next;
+                return next();
             })
             .catch(e => {
                 if (e.status === 401) {

--- a/Conch/ui/src/views/Device.js
+++ b/Conch/ui/src/views/Device.js
@@ -12,7 +12,7 @@ import Workspace from "../models/Workspace";
 
 const allDevices = {
     oninit({ attrs }) {
-        Auth.requireLogin(
+        Auth.requireLogin(() =>
             Workspace.withWorkspace(workspaceId => {
                 Device.loadDeviceIds(workspaceId);
             })
@@ -46,7 +46,7 @@ const makeSelection = {
 };
 
 function loadDeviceDetails(id) {
-    return Auth.requireLogin(
+    return Auth.requireLogin(() =>
         Promise.all([
             Device.loadDevice(id),
             Device.loadRackLocation(id),
@@ -286,15 +286,17 @@ const deviceReport = {
                         t("Message"),
                         t("Hint"),
                     ],
-                    validationState.results.map(r => [
-                        r.status == "pass" ? m("i") : Icons.warning,
-                        r.category,
-                        Validation.idToName[r.validation_id],
-                        r.component_id,
-                        r.status.toUpperCase(),
-                        r.message,
-                        r.hint,
-                    ]).sort()
+                    validationState.results
+                        .map(r => [
+                            r.status == "pass" ? m("i") : Icons.warning,
+                            r.category,
+                            Validation.idToName[r.validation_id],
+                            r.component_id,
+                            r.status.toUpperCase(),
+                            r.message,
+                            r.hint,
+                        ])
+                        .sort()
                 )
         );
         const validations = Table(

--- a/Conch/ui/src/views/Problem.js
+++ b/Conch/ui/src/views/Problem.js
@@ -25,7 +25,7 @@ function categoryTitle(category) {
 const selectProblemDevice = {
     loading: true,
     oninit: ({ state }) => {
-        Auth.requireLogin(
+        Auth.requireLogin(() =>
             Workspace.withWorkspace(workspaceId =>
                 Problem.loadDeviceProblems(workspaceId).then(
                     () => (state.loading = false)
@@ -77,7 +77,7 @@ const showDevice = {
     loading: true,
     oninit({ attrs, state }) {
         if (attrs.id) {
-            Auth.requireLogin(
+            Auth.requireLogin(() =>
                 Promise.all([
                     Validation.load(),
                     ValidationState.loadForDevice(attrs.id).then(
@@ -160,7 +160,9 @@ const showDevice = {
             ? m(
                   "a.pure-button",
                   {
-                      href: `/rack/${Problem.current.location.rack.id}?device=${attrs.id}`,
+                      href: `/rack/${Problem.current.location.rack.id}?device=${
+                          attrs.id
+                      }`,
                       oncreate: m.route.link,
                   },
                   t("Show Device in Rack")

--- a/Conch/ui/src/views/Rack.js
+++ b/Conch/ui/src/views/Rack.js
@@ -13,7 +13,7 @@ import Table from "./component/Table";
 const allRacks = {
     loading: true,
     oninit: ({ state }) => {
-        Auth.requireLogin(
+        Auth.requireLogin(() =>
             Workspace.withWorkspace(workspaceId => {
                 Promise.all([
                     Relay.loadActiveRelays(workspaceId),
@@ -66,7 +66,7 @@ const makeSelection = {
 
 const rackLayout = {
     oninit({ attrs }) {
-        Auth.requireLogin(
+        Auth.requireLogin(() =>
             Workspace.withWorkspace(workspaceId => {
                 Rack.load(workspaceId, attrs.id);
                 Rack.highlightDevice = attrs.device;
@@ -209,7 +209,9 @@ var rackLayoutTable = {
                     onclick() {
                         Feedback.sendFeedback(
                             "[NOTICE] User Flagged Device",
-                            `Device ${occupant.id} in slot ${slotId} was flagged by the user.`,
+                            `Device ${
+                                occupant.id
+                            } in slot ${slotId} was flagged by the user.`,
                             () => {
                                 alert(
                                     t("Administrators notified about device")

--- a/Conch/ui/src/views/Relay/Detail.js
+++ b/Conch/ui/src/views/Relay/Detail.js
@@ -46,8 +46,9 @@ export default {
                           m(
                               "a.pure-button",
                               {
-                                  href: `/rack/${Relay.current.location
-                                      .rack_id}`,
+                                  href: `/rack/${
+                                      Relay.current.location.rack_id
+                                  }`,
                                   oncreate: m.route.link,
                                   title: t("Show Rack"),
                               },

--- a/Conch/ui/src/views/Status.js
+++ b/Conch/ui/src/views/Status.js
@@ -35,7 +35,7 @@ function deviceList(title, isProblem, devices) {
 export default {
     loading: true,
     oninit: ({ state }) => {
-        Auth.requireLogin(
+        Auth.requireLogin(() =>
             Workspace.withWorkspace(workspaceId => {
                 Promise.all([
                     Device.loadDevices(workspaceId),


### PR DESCRIPTION
This fixes exceptions thrown when an unauthenticated user loaded a non-login URL.

These exceptions were transparent to the user (they were immediately sent to the login screen), but still annoyingly reported to Rollbar.