### PR TITLE
refactor: simplify Validation schema

### DIFF
--- a/Conch/docs/validation/BaseValidation.md
+++ b/Conch/docs/validation/BaseValidation.md
@@ -14,12 +14,12 @@ Conch::Validation - base class for writing Conch Validations
     has description => q/Description of the validation/;
 
     # Optional schema to validate $input_data before `validate` is run.
-    # Specified in the JSON-schema format.
+    # Specified in simplified JSON-schema format.
     has schema => sub {
             {
-                    required => [ 'hello' ],
-                    properties => {
-                            hello => { type => 'string' }
+                    hello => {
+                            world => { type => 'string' },
+                            required => ['world']
                     }
             }
     };
@@ -44,9 +44,13 @@ Conch::Validation - base class for writing Conch Validations
 Validations. Validations extend this class by implementing a `validate`
 method.  This method receives the input data (a `HASHREF`) to be validatated.
 This input data hash may be validated by setting the `schema` attribute with a
-schema definition in the [JSON-schema](http://json-schema.org) format (Note: A
-root-level `'object'` type is assumed in the schema. Only top-level
-properties need to be defined).
+schema definition in the [JSON-schema](http://json-schema.org) format.
+
+\_Note\_: A root-level `'object'` type is assumed in the schema. Only top-level
+properties need to be defined. All top-level properties are assumed to be
+required by default, but you may define the exact set of required properties by
+specifying a \`required\` attribute on the top-level with a list of required
+properties names
 
 The validation logic in the `validate` method will evaluate the input data and
 register one or more validation results with the
@@ -127,7 +131,7 @@ during execution as [Mojo::Exception](https://metacpan.org/pod/Mojo::Exception)
 
 ### Check\_Against\_Schema
 
-Check the Validation input data against the JSON schema, if specified.
+Check the Validation input data against JSON schema, if specified.
 
 ### Validate
 
@@ -231,7 +235,7 @@ This declarative syntax allows for result de-duplication and consistent messages
     $self->register_result( expected => 'second', got => 'first', cmp => 'lt' );
 
     # using 'like' to match with a regex
-    $self->register_result( expected => qr/.+bar.+/, got => 'foobarbaz', cmp => 'like' );
+    $self->register_result( expected => qr/.+bar.+/, got => 'foobarbaz', cmpself => 'like' );
 
     # using 'oneOf' to select one of multiple values
     $self->register_result( expected => ['a', 'b', 'c' ], got => 'b', cmp => 'oneOf' );
@@ -319,10 +323,13 @@ You may also provide the following attributes to override validation results
 
 ### Die
 
-Stop execution of the Validation immediately and record an error.
+Stop execution of the Validation immediately and record an error. The
+attributes 'level' and 'hint' may be specified.
 
 ```perl
     $self->die('This validation cannot continue!') if $bad_condition;
+    $self->die('This validation cannot continue!', hint => 'Here's how to fix it' );
+    $self->die('This exception happend 3 frames up', level => 3 );
 ```
 
 ### Fail

--- a/Conch/lib/Conch/Validation.pm
+++ b/Conch/lib/Conch/Validation.pm
@@ -15,12 +15,12 @@ Conch::Validation - base class for writing Conch Validations
 	has description => q/Description of the validation/;
 
 	# Optional schema to validate $input_data before `validate` is run.
-	# Specified in the JSON-schema format.
+	# Specified in simplified JSON-schema format.
 	has schema => sub {
 		{
-			required => [ 'hello' ],
-			properties => {
-				hello => { type => 'string' }
+			hello => {
+				world => { type => 'string' },
+				required => ['world']
 			}
 		}
 	};
@@ -45,9 +45,13 @@ C<Conch::Validation> provides the base class to define and execute Conch
 Validations. Validations extend this class by implementing a C<validate>
 method.  This method receives the input data (a C<HASHREF>) to be validatated.
 This input data hash may be validated by setting the C<schema> attribute with a
-schema definition in the L<JSON-schema|http://json-schema.org> format (Note: A
-root-level C<'object'> type is assumed in the schema. Only top-level
-properties need to be defined).
+schema definition in the L<JSON-schema|http://json-schema.org> format.
+
+_Note_: A root-level C<'object'> type is assumed in the schema. Only top-level
+properties need to be defined. All top-level properties are assumed to be
+required by default, but you may define the exact set of required properties by
+specifying a `required` attribute on the top-level with a list of required
+properties names
 
 The validation logic in the C<validate> method will evaluate the input data and
 register one or more validation results with the
@@ -207,7 +211,8 @@ sub run_unsafe ( $self, $data ) {
 
 =head2 check_against_schema
 
-Check the Validation input data against the JSON schema, if specified.
+Check the Validation input data against JSON schema, if specified.
+
 
 =cut
 
@@ -220,7 +225,7 @@ sub check_against_schema ( $self, $data ) {
 
 	# Shallow copy the schema and pull out the 'required' list
 	my $schema   = { $self->schema->%* };
-	my $required = delete $schema->{required};
+	my $required = delete $schema->{required} || [ keys %{ $schema } ];
 	my $full_schema =
 		{ type => 'object', properties => $schema, required => $required };
 

--- a/Conch/lib/Conch/Validation/BiosFirmwareVersion.pm
+++ b/Conch/lib/Conch/Validation/BiosFirmwareVersion.pm
@@ -12,7 +12,6 @@ profile
 
 has schema => sub {
 	{
-		required     => [qw(bios_version)],
 		bios_version => {
 			type => 'string',
 		}

--- a/Conch/lib/Conch/Validation/CpuCount.pm
+++ b/Conch/lib/Conch/Validation/CpuCount.pm
@@ -11,7 +11,6 @@ Validate the reported number of CPUs match the hardware product profile
 
 has schema => sub {
 	{
-		required  => ['processor'],
 		processor => {
 			type       => 'object',
 			properties => {

--- a/Conch/lib/Conch/Validation/CpuTemperature.pm
+++ b/Conch/lib/Conch/Validation/CpuTemperature.pm
@@ -12,7 +12,6 @@ hardware product profile
 
 has schema => sub {
 	{
-		required => [ 'temp' ],
 		temp => {
 			type       => 'object',
 			required => [ 'cpu0', 'cpu1' ],

--- a/Conch/lib/Conch/Validation/DeviceProductName.pm
+++ b/Conch/lib/Conch/Validation/DeviceProductName.pm
@@ -11,7 +11,6 @@ Valdidate reported product name matches product name expected in rack layout
 
 has schema => sub {
 	{
-		required => ['product_name'],
 		product_name => {
 			type => 'string'
 		}

--- a/Conch/lib/Conch/Validation/DimmCount.pm
+++ b/Conch/lib/Conch/Validation/DimmCount.pm
@@ -9,7 +9,6 @@ has 'description' => 'Verify the number of DIMMs reported';
 
 has schema => sub {
 	{
-		required => ['memory'],
 		memory   => {
 			type       => 'object',
 			properties => {

--- a/Conch/lib/Conch/Validation/RamTotal.pm
+++ b/Conch/lib/Conch/Validation/RamTotal.pm
@@ -11,7 +11,6 @@ Validate the reported RAM match the hardware product profile
 
 has schema => sub {
 	{
-		required => ['memory'],
 		memory   => {
 			type       => 'object',
 			required => ['total'],

--- a/Conch/lib/Conch/Validation/SwitchPeers.pm
+++ b/Conch/lib/Conch/Validation/SwitchPeers.pm
@@ -13,7 +13,6 @@ expected peer port according to the rack layout
 
 has schema => sub {
 	{
-		required   => ['interfaces'],
 		interfaces => {
 			type => 'object',
 		}


### PR DESCRIPTION
This simplifies the validation schema by making all top-level keys in the schema 'required' when creating the JSON schema for validation.

I had this idea while writing the validation tutorial. Makes it a bit more simple.