### PR TITLE
fix: Add rack_unit to hardware profile, fix typo

### DIFF
--- a/Conch/json-schema/v1.yaml
+++ b/Conch/json-schema/v1.yaml
@@ -374,6 +374,7 @@ definitions:
           - nics_num
           - psu_total
           - purpose
+          - rack_unit
           - ram_total
           - sas_num
           - sas_size
@@ -410,6 +411,8 @@ definitions:
             type: integer
           purpose:
             type: string
+          rack_unit:
+            type: integer
           ram_total:
             type: integer
           sas_num:

--- a/Conch/lib/Conch/Class/HardwareProductProfile.pm
+++ b/Conch/lib/Conch/Class/HardwareProductProfile.pm
@@ -32,6 +32,8 @@ with 'Conch::Class::Role::JsonV1';
 
 =head2 purpose
 
+=head2 rack_unit
+
 =head2 ram_total
 
 =head2 sas_num
@@ -69,6 +71,7 @@ has [
 		nics_num
 		psu_total
 		purpose
+		rack_unit
 		ram_total
 		sas_num
 		sas_size
@@ -101,6 +104,7 @@ sub as_v1_json {
 		nics_num      => $self->nics_num,
 		psu_total     => $self->psu_total,
 		purpose       => $self->purpose,
+		rack_unit     => $self->rack_unit,
 		ram_total     => $self->ram_total,
 		sas_num       => $self->sas_num,
 		sas_size      => $self->sas_size,

--- a/Conch/lib/Conch/Model/HardwareProduct.pm
+++ b/Conch/lib/Conch/Model/HardwareProduct.pm
@@ -34,6 +34,7 @@ my $fields = q{
   hw_profile.nics_num AS hw_profile_nics_num,
   hw_profile.psu_total AS hw_profile_psu_total,
   hw_profile.purpose AS hw_profile_purpose,
+  hw_profile.rack_unit AS hw_profile_rack_unit,
   hw_profile.ram_total AS hw_profile_ram_total,
   hw_profile.sas_num AS hw_profile_sas_num,
   hw_profile.sas_size AS hw_profile_sas_size,
@@ -155,6 +156,7 @@ sub _build_hardware_product ($hw) {
 		nics_num      => $hw->{hw_profile_nics_num},
 		psu_total     => $hw->{hw_profile_psu_total},
 		purpose       => $hw->{hw_profile_purpose},
+		rack_unit     => $hw->{hw_profile_rack_unit},
 		ram_total     => $hw->{hw_profile_ram_total},
 		sas_num       => $hw->{hw_profile_sas_num},
 		sas_size      => $hw->{hw_profile_sas_size},
@@ -165,7 +167,7 @@ sub _build_hardware_product ($hw) {
 		ssd_num       => $hw->{hw_profile_ssd_num},
 		ssd_size      => $hw->{hw_profile_ssd_size},
 		ssd_slots     => $hw->{hw_profile_ssd_slots},
-		usb_numb      => $hw->{hw_profile_usb_num},
+		usb_num       => $hw->{hw_profile_usb_num},
 		zpool         => $zpool_profile
 	);
 

--- a/Conch/t/model/HardwareProduct.t
+++ b/Conch/t/model/HardwareProduct.t
@@ -8,7 +8,7 @@ use_ok("Conch::Model::HardwareProduct");
 use Data::UUID;
 
 my $pgtmp = mk_tmp_db() or die;
-my $pg    = Conch::Pg->new( $pgtmp->uri );
+my $pg = Conch::Pg->new( $pgtmp->uri );
 
 my $hardware_vendor_id = $pg->db->insert(
 	'hardware_vendor',
@@ -31,27 +31,30 @@ my $zpool_profile_id = $pg->db->insert(
 	{ returning => ['id'] }
 )->hash->{id};
 
+my %hw_profile_values = (
+	rack_unit     => 1,
+	purpose       => 'test',
+	bios_firmware => 'test',
+	cpu_num       => 2,
+	cpu_type      => 'test',
+	dimms_num     => 3,
+	ram_total     => 4,
+	nics_num      => 5,
+	usb_num       => 6
+);
+
 my $hardware_profile_id = $pg->db->insert(
 	'hardware_product_profile',
 	{
-		product_id    => $hardware_product_id,
-		zpool_id      => $zpool_profile_id,
-		rack_unit     => 1,
-		purpose       => 'test',
-		bios_firmware => 'test',
-		cpu_num       => 2,
-		cpu_type      => 'test',
-		dimms_num     => 3,
-		ram_total     => 4,
-		nics_num      => 5,
-		usb_num       => 6
-
+		product_id => $hardware_product_id,
+		zpool_id   => $zpool_profile_id,
+		%hw_profile_values
 	},
 	{ returning => ['id'] }
 )->hash->{id};
 
 new_ok('Conch::Model::HardwareProduct');
-my $hw_product_model = new_ok( "Conch::Model::HardwareProduct");
+my $hw_product_model = new_ok("Conch::Model::HardwareProduct");
 
 subtest 'list hardware products' => sub {
 	my $hw_products = $hw_product_model->list;
@@ -63,9 +66,9 @@ subtest 'list hardware products' => sub {
 	isa_ok( $hw_product->profile,        'Conch::Class::HardwareProductProfile' );
 	isa_ok( $hw_product->profile->zpool, 'Conch::Class::ZpoolProfile' );
 
-	is($hw_product->profile->id, $hardware_profile_id, "Profile IDs match");
-	is($hw_product->profile->bios_firmware, "test", "BIOS Firmware");
-	is($hw_product->profile->zpool->id, $zpool_profile_id, "Zpool profile ID");
+	is( $hw_product->profile->id, $hardware_profile_id, "Profile IDs match" );
+	is( $hw_product->profile->bios_firmware, "test", "BIOS Firmware" );
+	is( $hw_product->profile->zpool->id, $zpool_profile_id, "Zpool profile ID" );
 };
 
 subtest 'lookup hardware product' => sub {
@@ -74,10 +77,10 @@ subtest 'lookup hardware product' => sub {
 	isa_ok( $hw_product->profile,        'Conch::Class::HardwareProductProfile' );
 	isa_ok( $hw_product->profile->zpool, 'Conch::Class::ZpoolProfile' );
 
-	is($hw_product->profile->id, $hardware_profile_id, "Profile IDs match");
-	is($hw_product->profile->bios_firmware, "test", "BIOS Firmware");
-	is($hw_product->profile->zpool->id, $zpool_profile_id, "Zpool profile ID");
+	is( $hw_product->profile->id, $hardware_profile_id, "Profile IDs match" );
+	my %profile_values = %{ $hw_product->profile }{ keys %hw_profile_values };
+	is_deeply( { %profile_values }, { %hw_profile_values });
+	is( $hw_product->profile->zpool->id, $zpool_profile_id, "Zpool profile ID" );
 };
 
 done_testing();
-


### PR DESCRIPTION
`rack_unit`, the number of rack units a hardware product requires, has been a non-null value in the database since the beginning but has never been exposed in the API by accident.

Also fixes a super dumb typo that caused a new validation to fail.