### PR TITLE
Replace Data::Validate::UUID with Conch::UUID

### DIFF
--- a/Conch/cpanfile
+++ b/Conch/cpanfile
@@ -6,7 +6,6 @@ requires 'Data::UUID';
 requires 'Data::Printer';
 requires 'DateTime::Format::Strptime';
 requires 'List::Compare';
-requires 'Data::Validate::UUID';
 requires 'Mail::Sendmail';
 requires 'aliased';
 requires 'Try::Tiny';

--- a/Conch/cpanfile.snapshot
+++ b/Conch/cpanfile.snapshot
@@ -768,14 +768,6 @@ DISTRIBUTIONS
     requirements:
       Digest::MD5 0
       ExtUtils::MakeMaker 0
-  Data-Validate-UUID-0.1.1
-    pathname: D/DR/DRZIGMAN/Data-Validate-UUID-0.1.1.tar.gz
-    provides:
-      Data::Validate::UUID 0.001001
-    requirements:
-      Exporter 0
-      Module::Build 0.28
-      perl 5.006
   DateTime-1.46
     pathname: D/DR/DROLSKY/DateTime-1.46.tar.gz
     provides:

--- a/Conch/lib/Conch/Controller/Device.pm
+++ b/Conch/lib/Conch/Controller/Device.pm
@@ -11,7 +11,7 @@ Conch::Controller::Device
 package Conch::Controller::Device;
 
 use Mojo::Base 'Mojolicious::Controller', -signatures;
-use Data::Validate::UUID 'is_uuid';
+use Conch::UUID 'is_uuid';
 
 use aliased 'Conch::Class::DeviceDetailed';
 

--- a/Conch/lib/Conch/Controller/DeviceLocation.pm
+++ b/Conch/lib/Conch/Controller/DeviceLocation.pm
@@ -11,7 +11,7 @@ Conch::Controller::DeviceLocation
 package Conch::Controller::DeviceLocation;
 
 use Mojo::Base 'Mojolicious::Controller', -signatures;
-use Data::Validate::UUID 'is_uuid';
+use Conch::UUID 'is_uuid';
 
 use Conch::Models;
 

--- a/Conch/lib/Conch/Controller/DeviceReport.pm
+++ b/Conch/lib/Conch/Controller/DeviceReport.pm
@@ -11,7 +11,7 @@ Conch::Controller::DeviceReport
 package Conch::Controller::DeviceReport;
 
 use Mojo::Base 'Mojolicious::Controller', -signatures;
-use Data::Validate::UUID 'is_uuid';
+use Conch::UUID 'is_uuid';
 
 use Try::Tiny;
 

--- a/Conch/lib/Conch/Controller/HardwareProduct.pm
+++ b/Conch/lib/Conch/Controller/HardwareProduct.pm
@@ -11,7 +11,7 @@ Conch::Controller::HardwareProduct
 package Conch::Controller::HardwareProduct;
 
 use Mojo::Base 'Mojolicious::Controller', -signatures;
-use Data::Validate::UUID 'is_uuid';
+use Conch::UUID 'is_uuid';
 
 use Conch::Models;
 

--- a/Conch/lib/Conch/Controller/Relay.pm
+++ b/Conch/lib/Conch/Controller/Relay.pm
@@ -11,7 +11,7 @@ Conch::Controller::Relay
 package Conch::Controller::Relay;
 
 use Mojo::Base 'Mojolicious::Controller', -signatures;
-use Data::Validate::UUID 'is_uuid';
+use Conch::UUID 'is_uuid';
 
 use Conch::Models;
 

--- a/Conch/lib/Conch/Controller/ValidationPlan.pm
+++ b/Conch/lib/Conch/Controller/ValidationPlan.pm
@@ -13,7 +13,7 @@ Controller for managing Validation Plans
 package Conch::Controller::ValidationPlan;
 
 use Mojo::Base 'Mojolicious::Controller', -signatures;
-use Data::Validate::UUID 'is_uuid';
+use Conch::UUID 'is_uuid';
 use Conch::Models;
 
 =head2 create

--- a/Conch/lib/Conch/Controller/Workspace.pm
+++ b/Conch/lib/Conch/Controller/Workspace.pm
@@ -11,7 +11,7 @@ Conch::Controller::Workspace
 package Conch::Controller::Workspace;
 
 use Mojo::Base 'Mojolicious::Controller', -signatures;
-use Data::Validate::UUID 'is_uuid';
+use Conch::UUID 'is_uuid';
 
 use Conch::Models;
 

--- a/Conch/lib/Conch/Controller/WorkspaceRack.pm
+++ b/Conch/lib/Conch/Controller/WorkspaceRack.pm
@@ -11,7 +11,7 @@ Conch::Controller::WorkspaceRack
 package Conch::Controller::WorkspaceRack;
 
 use Mojo::Base 'Mojolicious::Controller', -signatures;
-use Data::Validate::UUID 'is_uuid';
+use Conch::UUID 'is_uuid';
 
 use Conch::Models;
 

--- a/Conch/lib/Conch/Model/Device.pm
+++ b/Conch/lib/Conch/Model/Device.pm
@@ -13,7 +13,7 @@ use Mojo::Base -base, -signatures;
 
 use Conch::Time;
 use Try::Tiny;
-use Data::Validate::UUID qw(is_uuid);
+use Conch::UUID qw(is_uuid);
 
 use aliased 'Conch::Class::DatacenterRack';
 use aliased 'Conch::Class::DatacenterRoom';

--- a/Conch/lib/Conch/Model/User.pm
+++ b/Conch/lib/Conch/Model/User.pm
@@ -11,7 +11,7 @@ package Conch::Model::User;
 use Mojo::Base -base, -signatures;
 
 use Crypt::Eksblowfish::Bcrypt qw(bcrypt en_base64);
-use Data::Validate::UUID qw(is_uuid);
+use Conch::UUID qw(is_uuid);
 use Mojo::JSON 'to_json';
 
 has [

--- a/Conch/lib/Conch/Plugin/JsonValidator.pm
+++ b/Conch/lib/Conch/Plugin/JsonValidator.pm
@@ -50,7 +50,7 @@ use Mojo::Base 'Mojolicious::Plugin', -signatures;
 
 use IO::All;
 use JSON::Validator;
-use Data::Validate::UUID 'is_uuid';
+use Conch::UUID 'is_uuid';
 
 use constant OUTPUT_SCHEMA_FILE => "json-schema/v1.yaml";
 use constant INPUT_SCHEMA_FILE => "json-schema/input.yaml";

--- a/Conch/lib/Conch/UUID.pm
+++ b/Conch/lib/Conch/UUID.pm
@@ -1,0 +1,79 @@
+=pod
+
+=head1 NAME
+
+Conch::UUID - Functions for working with UUIDs in Conch
+
+=head1 SYNOPSIS
+
+    use Conch::UUID qw( is_uuid );
+
+=head1 DESCRIPTION
+
+Currently exports a single function, C<is_uuid>, to determine whether a string
+is in the UUID format. It uses the format specified in RFC 4122
+https://tools.ietf.org/html/rfc4122#section-3
+
+      UUID                   = time-low "-" time-mid "-"
+                               time-high-and-version "-"
+                               clock-seq-and-reserved
+                               clock-seq-low "-" node
+      time-low               = 4hexOctet
+      time-mid               = 2hexOctet
+      time-high-and-version  = 2hexOctet
+      clock-seq-and-reserved = hexOctet
+      clock-seq-low          = hexOctet
+      node                   = 6hexOctet
+      hexOctet               = hexDigit hexDigit
+      hexDigit =
+            "0" / "1" / "2" / "3" / "4" / "5" / "6" / "7" / "8" / "9" /
+            "a" / "b" / "c" / "d" / "e" / "f" /
+            "A" / "B" / "C" / "D" / "E" / "F"
+
+UUID version and variant ('reserved') hex digit standards are ignored.
+
+=cut
+package Conch::UUID;
+
+use strict;
+use warnings;
+
+use Exporter 'import';
+our @EXPORT_OK = qw( is_uuid );
+
+use constant UUID_FORMAT => qr/
+	^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$
+/ix;
+
+=head1 FUNCTIONS
+
+=head2 is_uuid
+
+Return a true or false value based on whether a string is a formatted as a UUID.
+
+	if (is_uuid "D8DC809C-935E-41B8-9E5F-B356A6BFBCA1") {...}
+	unless (is_uuid "BAD-ID") {...}
+
+Case insensitive.
+
+=cut
+
+sub is_uuid ($) {
+    return ( shift =~ UUID_FORMAT );
+}
+
+1;
+
+__DATA__
+
+=pod
+
+=head1 LICENSING
+
+Copyright Joyent, Inc.
+
+This Source Code Form is subject to the terms of the Mozilla Public License,
+v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+one at http://mozilla.org/MPL/2.0/.
+
+=cut

--- a/Conch/t/conch_uuid.t
+++ b/Conch/t/conch_uuid.t
@@ -1,0 +1,16 @@
+use Test::More;
+use strict;
+use warnings;
+
+use_ok('Conch::UUID');
+
+use Conch::UUID 'is_uuid';
+
+ok(   is_uuid('00000000-0000-0000-0000-000000000000'), 'all zero UUID valid');
+ok( ! is_uuid('00000000-0000-0000-0000-00000000000'),  'wrong number of digits invalid');
+ok(   is_uuid('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA'), 'all character UUID valid');
+ok(   is_uuid('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'), 'all lower character UUID valid');
+ok(   is_uuid('235D562B-EE0F-4381-9CCB-14D3A38430BD'), 'random UUID valid');
+ok(   is_uuid '235D562B-EE0F-4381-9CCB-14D3A38430BD',  'subroutine prototype works');
+
+done_testing();

--- a/Conch/t/integration/05_v1_schema.t
+++ b/Conch/t/integration/05_v1_schema.t
@@ -3,7 +3,7 @@ use Mojo::Util 'monkey_patch';
 use Test::MojoSchema;
 use Test::More;
 use Data::UUID;
-use Data::Validate::UUID 'is_uuid';
+use Conch::UUID 'is_uuid';
 use IO::All;
 use JSON::Validator;
 

--- a/Conch/t/integration/orc/build.t
+++ b/Conch/t/integration/orc/build.t
@@ -9,7 +9,7 @@ use Test::Exception;
 use IO::All;
 use JSON::Validator;
 use Data::UUID;
-use Data::Validate::UUID 'is_uuid';
+use Conch::UUID 'is_uuid';
 
 BEGIN {
 	use_ok("Test::ConchTmpDB");

--- a/Conch/t/integration/orc/workflows.t
+++ b/Conch/t/integration/orc/workflows.t
@@ -9,7 +9,7 @@ use Test::Exception;
 use IO::All;
 use JSON::Validator;
 use Data::UUID;
-use Data::Validate::UUID 'is_uuid';
+use Conch::UUID 'is_uuid';
 
 BEGIN {
 	use_ok("Test::ConchTmpDB");


### PR DESCRIPTION
Add a more lenient UUID validation function in a new module, `Conch::UUID`. If we ever need other UUID related functions, they can find a home here.

Addresses an issue where reported system UUIDs were not being recognized as valid.