### PR TITLE
feat: Add JWT as a method of authentication

### DIFF
--- a/Conch/conch.conf.dist
+++ b/Conch/conch.conf.dist
@@ -4,6 +4,12 @@
 	# rotating in new passphrases and out old ones.
 	secrets => ["hunter2"],
 
+	jwt => {
+		# time in seconds for a JWT to be valid before requiring refresh or re-auth
+		global_admin_expiry => 2592000, # 30 days
+		normal_expiry => 86400, # 1 day
+	},
+
 	# URI format is postgresql://[user[:password]@][netloc][:port][/dbname][?param1=value1&...]
 	pg => 'postgresql://conch@/conch',
 
@@ -17,7 +23,14 @@
 	features => {
 		audit          => 0,
 		rollbar        => 0,
-		new_validation => 1
+		new_validation => 1,
+
+		# Stop issuing 'conch' cookies. This does not prevent existing conch
+		# cookies from being validated (as long as the secrets are the same).
+		# Once all conch clients have been migrated, this should be set to 1.
+		# After a month (the expiry time for conch cookies) all existing
+		# 'conch' cookie code should be removed
+		stop_conch_cookie_issue => 0,
 	},
 
 	audit => {

--- a/Conch/cpanfile
+++ b/Conch/cpanfile
@@ -22,6 +22,7 @@ requires 'Mojolicious';
 requires 'Mojo::Pg';
 requires 'Mojo::JSON_XS';
 requires 'Mojo::Server::PSGI';
+requires 'Mojo::JWT';
 requires 'Mojolicious::Plugin::Bcrypt';
 requires 'Mojolicious::Plugin::Util::RandomString';
 requires 'Mojolicious::Plugin::NYTProf';

--- a/Conch/cpanfile.snapshot
+++ b/Conch/cpanfile.snapshot
@@ -2316,6 +2316,15 @@ DISTRIBUTIONS
       Mojolicious 5.66
       Test::More 0
       perl 5.010001
+  Mojo-JWT-0.07
+    pathname: J/JB/JBERGER/Mojo-JWT-0.07.tar.gz
+    provides:
+      Mojo::JWT 0.07
+    requirements:
+      Digest::SHA 0
+      MIME::Base64 3.11
+      Module::Build::Tiny 0
+      Mojolicious 5.00
   Mojo-Pg-4.08
     pathname: S/SR/SRI/Mojo-Pg-4.08.tar.gz
     provides:
@@ -3669,10 +3678,10 @@ DISTRIBUTIONS
       perl 5.006
       strict 0
       warnings 0
-  Test-PostgreSQL-1.25
-    pathname: T/TJ/TJC/Test-PostgreSQL-1.25.tar.gz
+  Test-PostgreSQL-1.26
+    pathname: T/TJ/TJC/Test-PostgreSQL-1.26.tar.gz
     provides:
-      Test::PostgreSQL 1.25
+      Test::PostgreSQL 1.26
     requirements:
       DBD::Pg 0
       DBI 0
@@ -3841,44 +3850,44 @@ DISTRIBUTIONS
       perl 5.006
       strict 0
       warnings 0
-  Type-Tiny-1.002001
-    pathname: T/TO/TOBYINK/Type-Tiny-1.002001.tar.gz
+  Type-Tiny-1.002002
+    pathname: T/TO/TOBYINK/Type-Tiny-1.002002.tar.gz
     provides:
-      Devel::TypeTiny::Perl56Compat 1.002001
-      Devel::TypeTiny::Perl58Compat 1.002001
-      Error::TypeTiny 1.002001
-      Error::TypeTiny::Assertion 1.002001
-      Error::TypeTiny::Compilation 1.002001
-      Error::TypeTiny::WrongNumberOfParameters 1.002001
-      Eval::TypeTiny 1.002001
-      Reply::Plugin::TypeTiny 1.002001
-      Test::TypeTiny 1.002001
-      Type::Coercion 1.002001
-      Type::Coercion::FromMoose 1.002001
-      Type::Coercion::Union 1.002001
-      Type::Library 1.002001
-      Type::Params 1.002001
-      Type::Parser 1.002001
-      Type::Registry 1.002001
-      Type::Tiny 1.002001
-      Type::Tiny::Class 1.002001
-      Type::Tiny::Duck 1.002001
-      Type::Tiny::Enum 1.002001
-      Type::Tiny::Intersection 1.002001
-      Type::Tiny::Role 1.002001
-      Type::Tiny::Union 1.002001
-      Type::Utils 1.002001
-      Types::Common::Numeric 1.002001
-      Types::Common::String 1.002001
-      Types::Standard 1.002001
-      Types::Standard::ArrayRef 1.002001
-      Types::Standard::CycleTuple 1.002001
-      Types::Standard::Dict 1.002001
-      Types::Standard::HashRef 1.002001
-      Types::Standard::Map 1.002001
-      Types::Standard::ScalarRef 1.002001
-      Types::Standard::Tuple 1.002001
-      Types::TypeTiny 1.002001
+      Devel::TypeTiny::Perl56Compat 1.002002
+      Devel::TypeTiny::Perl58Compat 1.002002
+      Error::TypeTiny 1.002002
+      Error::TypeTiny::Assertion 1.002002
+      Error::TypeTiny::Compilation 1.002002
+      Error::TypeTiny::WrongNumberOfParameters 1.002002
+      Eval::TypeTiny 1.002002
+      Reply::Plugin::TypeTiny 1.002002
+      Test::TypeTiny 1.002002
+      Type::Coercion 1.002002
+      Type::Coercion::FromMoose 1.002002
+      Type::Coercion::Union 1.002002
+      Type::Library 1.002002
+      Type::Params 1.002002
+      Type::Parser 1.002002
+      Type::Registry 1.002002
+      Type::Tiny 1.002002
+      Type::Tiny::Class 1.002002
+      Type::Tiny::Duck 1.002002
+      Type::Tiny::Enum 1.002002
+      Type::Tiny::Intersection 1.002002
+      Type::Tiny::Role 1.002002
+      Type::Tiny::Union 1.002002
+      Type::Utils 1.002002
+      Types::Common::Numeric 1.002002
+      Types::Common::String 1.002002
+      Types::Standard 1.002002
+      Types::Standard::ArrayRef 1.002002
+      Types::Standard::CycleTuple 1.002002
+      Types::Standard::Dict 1.002002
+      Types::Standard::HashRef 1.002002
+      Types::Standard::Map 1.002002
+      Types::Standard::ScalarRef 1.002002
+      Types::Standard::Tuple 1.002002
+      Types::TypeTiny 1.002002
     requirements:
       Exporter::Tiny 0.026
       ExtUtils::MakeMaker 6.17

--- a/Conch/json-schema/v1.yaml
+++ b/Conch/json-schema/v1.yaml
@@ -8,6 +8,14 @@ definitions:
     properties:
       error:
         type: string
+  Login:
+    type: object
+    additionalProperties: false
+    required:
+      - jwt_token
+    properties:
+      jwt_token:
+        type: string
   DetailedDevice:
     type: object
     additionalProperties: false

--- a/Conch/lib/Conch/Controller/Login.pm
+++ b/Conch/lib/Conch/Controller/Login.pm
@@ -12,53 +12,147 @@ package Conch::Controller::Login;
 
 use Mojo::Base 'Mojolicious::Controller', -signatures;
 use Mojo::IOLoop;
-use Data::Printer;
+use Mojo::JWT;
+use Try::Tiny;
 
 use Conch::Model::User;
+use Conch::Model::SessionToken;
+use Conch::UUID 'is_uuid';
 
+=head2 create_jwt
+
+Create a JWT and return it in the response in two parts: the signature in a
+cookie named 'jwt_sig' and a resposne body named 'jwt_token'. 'jwt_token'
+includes two claims: 'uid', for the user ID, and 'jti', for the token ID.
+
+=cut
+
+sub create_jwt ( $c, $user_id ) {
+	my $jwt_config = $c->app->config('jwt') || {};
+
+	my $expires = time;
+	if ( $c->is_global_admin ) {
+
+		# default 1 month (30 days)
+		$expires += $jwt_config->{global_admin_expiry} || 2592000;
+	}
+	else {
+		# default 1 day
+		$expires += $jwt_config->{normal_expiry} || 86400;
+	}
+
+	my $token = Conch::Model::SessionToken->create( $user_id, $expires );
+	my $jwt = Mojo::JWT->new(
+		claims => {
+			uid => $user_id,
+			jti => $token
+		},
+		secret  => $c->config('secrets')->[0],
+		expires => $expires
+	)->encode;
+
+	my ( $header, $payload, $sig ) = split /\./, $jwt;
+
+	$c->cookie(
+		jwt_sig => $sig,
+		{ expires => time + 3600, secure => $c->req->is_secure, httponly => 1 }
+	);
+	return $c->status( 200, { jwt_token => "$header.$payload" } );
+}
 
 =head2 authenticate
 
-Handle the details for authenticating a user, via either HTTP Basic Auth or an
+Handle the details for authenticating a user, with one of the following options:
+
+1. HTTP Basic Auth
+2. JWT split between Authorization Bearer header value and jwt_sig cookie
+3. JWT combined with a Authorizaiton Beaer header using format "$jwt_token.$jwt_sig"
 existing session for the user
+4. Old 'conch' session cookie
 
 =cut
 
 sub authenticate ($c) {
 	if ( my $basic_auth = $c->req->url->to_abs->userinfo ) {
 		my ( $user, $password ) = split /:/, $basic_auth;
-		my $u = Conch::Model::User->lookup( $user );
-		return 0 unless $u;
+		my $u = Conch::Model::User->lookup($user);
+
+		unless ($u) {
+			$c->status( 401, { error => 'unauthorized' } );
+			return 0;
+		}
 
 		my $ret = $u->validate_password($password);
 		if ($ret) {
-			$c->stash(user_id => $u->id);
-			$c->stash(user => $u);
+			$c->stash( user_id => $u->id );
+			$c->stash( user    => $u );
+			return 1;
 		}
-		return $ret;
+		else {
+			$c->status( 401, { error => 'unauthorized' } );
+			return 0;
+		}
 	}
 
-	my $user_id = $c->session('user');
-	unless ($user_id) {
-		$c->status(401, { error => 'unauthorized'});
+	my $user_id;
+	if ( $c->req->headers->authorization
+		&& $c->req->headers->authorization =~ /^Bearer (.+)/ )
+	{
+		my $token = $1;
+		my $sig   = $c->cookie('jwt_sig');
+		if ($sig) {
+			$token = "$token.$sig";
+		}
+		my $jwt;
+
+		# Attempt to decode with every configured secret, in case JWT token was
+		# signed with a rotated secret
+		for my $secret ( $c->config('secrets')->@* ) {
+
+			# Mojo::JWT->decode blows up if the token is invalid
+			try {
+				$jwt = Mojo::JWT->new( secret => $secret )->decode($token);
+			};
+			last if $jwt;
+		}
+		unless ( $jwt
+			&& $jwt->{exp} > time
+			&& Conch::Model::SessionToken->check_token( $jwt->{uid}, $jwt->{jti} ) )
+		{
+			$c->status( 401, { error => 'unauthorized' } );
+			return 0;
+		}
+		$user_id = $jwt->{uid};
+		$c->stash( 'token_id' => $jwt->{jti} );
+
+		if ( $user_id && $sig ) {
+			$c->cookie(
+				jwt_sig => $sig,
+				{ expires => time + 3600, secure => $c->req->is_secure, httponly => 1 }
+			);
+		}
+	}
+
+	$user_id ||= $c->session('user');
+	unless ( $user_id && is_uuid $user_id) {
+		$c->status( 401, { error => 'unauthorized' } );
 		return 0;
 	}
-	my $user = Conch::Model::User->lookup( $user_id );
+	my $user = Conch::Model::User->lookup($user_id);
 	if ($user) {
 		$c->stash( user_id => $user_id );
-		$c->stash(user => $user);
+		$c->stash( user    => $user );
 		return 1;
 	}
 	else {
-		$c->status(401, { error => 'unauthorized'});
+		$c->status( 401, { error => 'unauthorized' } );
 		return 0;
 	}
 }
 
-
 =head2 session_login
 
-Handles the act of logging in, given a user and password
+Handles the act of logging in, given a user and password. Returns a JWT token.
 
 =cut
 
@@ -73,14 +167,18 @@ sub session_login ($c) {
 	return $c->status( 401, { error => 'Invalid login' } ) unless $user;
 
 	if ( $user->validate_password( $body->{password} ) ) {
-		$c->session( 'user' => $user->id );
-		$c->status( 200, { status => 'successfully logged in' } );
+
+		my $feature_flags = $c->app->config('feature') || {};
+		unless ( $feature_flags->{stop_conch_cookie_issue} ) {
+			$c->session( 'user' => $user->id );
+		}
+
+		return $c->create_jwt( $user->id );
 	}
 	else {
 		return $c->status( 401, { error => 'Invalid login' } );
 	}
 }
-
 
 =head2 session_logout
 
@@ -90,9 +188,18 @@ Logs a user out by expiring their session
 
 sub session_logout ($c) {
 	$c->session( expires => 1 );
+
+	Conch::Model::SessionToken->use_token( $c->stash('user_id'),
+		$c->stash('token_id') )
+		if $c->stash('token_id');
+
+	$c->cookie(
+		jwt_sig => '',
+		{ expires => 1, secure => $c->req->is_secure, httponly => 1 }
+	) if $c->cookie('jwt_sig');
+
 	$c->status(204);
 }
-
 
 =head2 reset_password
 
@@ -100,7 +207,6 @@ Resets a user's password, given an email address, and sends the user an email
 with their new password.
 
 =cut
-
 
 sub reset_password ($c) {
 	my $body = $c->req->json;
@@ -129,8 +235,23 @@ sub reset_password ($c) {
 	return $c->status(204);
 }
 
-1;
+=head2 refresh_token
 
+Refresh a user's JWT token. Deletes the old token.
+
+=cut
+
+sub refresh_token ($c) {
+	my $valid_token = Conch::Model::SessionToken->use_token( $c->stash('user_id'),
+		$c->stash('token_id') );
+
+	return $c->status( 403, { error => 'Invalid token ID' } )
+		unless $valid_token;
+
+	return $c->create_jwt( $c->stash('user_id') );
+}
+
+1;
 
 __DATA__
 
@@ -140,9 +261,8 @@ __DATA__
 
 Copyright Joyent, Inc.
 
-This Source Code Form is subject to the terms of the Mozilla Public License, 
+This Source Code Form is subject to the terms of the Mozilla Public License,
 v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
 one at http://mozilla.org/MPL/2.0/.
 
 =cut
-

--- a/Conch/lib/Conch/Controller/Login.pm
+++ b/Conch/lib/Conch/Controller/Login.pm
@@ -242,6 +242,13 @@ Refresh a user's JWT token. Deletes the old token.
 =cut
 
 sub refresh_token ($c) {
+	# Allow users with 'conch' cookie to get a JWT without requiring
+	# re-authentication. Expires 'conch' cookie
+	if (my $user_id = $c->session('user') ){
+		$c->session( expires => 1 );
+		return $c->create_jwt($user_id);
+	}
+
 	my $valid_token = Conch::Model::SessionToken->use_token( $c->stash('user_id'),
 		$c->stash('token_id') );
 

--- a/Conch/lib/Conch/Controller/User.pm
+++ b/Conch/lib/Conch/Controller/User.pm
@@ -17,13 +17,25 @@ use Conch::Model::User;
 use Conch::Model::SessionToken;
 use Conch::UUID qw( is_uuid );
 
-=head2 revoke_tokens
+=head2 revoke_own_tokens
 
-Override the settings for a user with the provided payload
+Revoke the user's own session tokens.
+B<NOTE>: This will cause the next request to fail authentication.
 
 =cut
 
-sub revoke_tokens ($c) {
+sub revoke_own_tokens ($c) {
+	Conch::Model::SessionToken->revoke_user_tokens( $c->stash('user_id' ) );
+	$c->status(204);
+}
+
+=head2 revoke_user_tokens
+
+Revoke a specified user's session tokens. Global admin only.
+
+=cut
+
+sub revoke_user_tokens ($c) {
 	return $c->status( 403, { error => 'Must be global admin' } )
 		unless $c->is_global_admin;
 

--- a/Conch/lib/Conch/Controller/User.pm
+++ b/Conch/lib/Conch/Controller/User.pm
@@ -11,9 +11,37 @@ Conch::Controller::User
 package Conch::Controller::User;
 
 use Mojo::Base 'Mojolicious::Controller', -signatures;
-use Conch::Model::User;
 use Mojo::Exception;
 
+use Conch::Model::User;
+use Conch::Model::SessionToken;
+use Conch::UUID qw( is_uuid );
+
+=head2 revoke_tokens
+
+Override the settings for a user with the provided payload
+
+=cut
+
+sub revoke_tokens ($c) {
+	return $c->status( 403, { error => 'Must be global admin' } )
+		unless $c->is_global_admin;
+
+	my $user_param = $c->param('id');
+	my $user;
+	if ( is_uuid($user_param) ) {
+		$user = Conch::Model::User->lookup($user_param);
+	}
+	elsif ( $user_param =~ s/^email\=// ) {
+		$user = Conch::Model::User->lookup_by_email($user_param);
+	}
+	return $c->status( 404, { error => "user $user_param not found" } )
+		unless $user;
+
+	Conch::Model::SessionToken->revoke_user_tokens( $user->id );
+
+	$c->status(204);
+}
 
 =head2 set_settings
 
@@ -33,7 +61,6 @@ sub set_settings ($c) {
 
 	$c->status(200);
 }
-
 
 =head2 set_setting
 
@@ -66,7 +93,6 @@ sub set_setting ($c) {
 	}
 }
 
-
 =head2 get_settings
 
 Get the key/values of every setting for a User
@@ -86,7 +112,6 @@ sub get_settings ($c) {
 
 	$c->status( 200, \%output );
 }
-
 
 =head2 get_setting
 
@@ -108,7 +133,6 @@ sub get_setting ($c) {
 
 	$c->status( 200, { $key => $settings->{$key} } );
 }
-
 
 =head2 delete_setting
 
@@ -138,7 +162,6 @@ sub delete_setting ($c) {
 
 1;
 
-
 __DATA__
 
 =pod
@@ -152,4 +175,3 @@ v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
 one at http://mozilla.org/MPL/2.0/.
 
 =cut
-

--- a/Conch/lib/Conch/Model/SessionToken.pm
+++ b/Conch/lib/Conch/Model/SessionToken.pm
@@ -53,7 +53,8 @@ Check if a session token is valid for the user ID. Returns 1 if valid, 0 otherwi
 
 sub check_token ( $class, $user_id, $token ) {
 
-	Conch::Pg->new->db->query( 'select delete_expired_tokens()' );
+	Conch::Pg->new->db->delete( 'user_session_token',
+		{ expires => { '<=' => 'now()' } } );
 
 	return Conch::Pg->new->db->query(
 		q{
@@ -68,7 +69,6 @@ sub check_token ( $class, $user_id, $token ) {
 	)->rows;
 }
 
-
 =head2 use_token
 
 Use a token by permanetly deleting it from the database. Will return 1 if the
@@ -78,7 +78,8 @@ token was present and valid, 0 otherwise.
 
 sub use_token ( $class, $user_id, $token ) {
 
-	Conch::Pg->new->db->query( 'select delete_expired_tokens()' );
+	Conch::Pg->new->db->delete( 'user_session_token',
+		{ expires => { '<=' => 'now()' } } );
 
 	return Conch::Pg->new->db->query(
 		q{

--- a/Conch/lib/Conch/Model/SessionToken.pm
+++ b/Conch/lib/Conch/Model/SessionToken.pm
@@ -1,0 +1,120 @@
+=pod
+
+=head1 NAME
+
+Conch::Model::SessionToken
+
+=head1 METHODS
+
+=cut
+
+package Conch::Model::SessionToken;
+use Mojo::Base -base, -signatures;
+
+use Conch::UUID qw(is_uuid);
+use Session::Token;
+
+has [
+	qw(
+		email
+		id
+		name
+		password_hash
+		)
+];
+
+=head2 create
+
+Create and record a session token
+
+=cut
+
+sub create ( $class, $user_id, $expires ) {
+	my $token = Session::Token->new->get;
+
+	Conch::Pg->new->db->query(
+		q{
+			insert into user_session_token
+				(user_id, token_hash, expires)
+			values( ?, digest(?, 'sha256'), to_timestamp(?)::timestamptz)
+		},
+		$user_id,
+		$token,
+		$expires,
+	);
+	return $token;
+}
+
+=head2 check_token
+
+Check if a session token is valid for the user ID. Returns 1 if valid, 0 otherwise
+
+=cut
+
+sub check_token ( $class, $user_id, $token ) {
+
+	Conch::Pg->new->db->query( 'select delete_expired_tokens()' );
+
+	return Conch::Pg->new->db->query(
+		q{
+			select 1
+			from user_session_token
+			where
+				user_id = ? and
+				token_hash = digest(?, 'sha256')
+		},
+		$user_id,
+		$token
+	)->rows;
+}
+
+
+=head2 use_token
+
+Use a token by permanetly deleting it from the database. Will return 1 if the
+token was present and valid, 0 otherwise.
+
+=cut
+
+sub use_token ( $class, $user_id, $token ) {
+
+	Conch::Pg->new->db->query( 'select delete_expired_tokens()' );
+
+	return Conch::Pg->new->db->query(
+		q{
+			delete from user_session_token
+			where
+				user_id = ? and
+				token_hash = digest(?, 'sha256')
+		},
+		$user_id,
+		$token
+	)->rows;
+}
+
+=head2 revoke_user_tokens
+
+Revoke all user session tokens by permanently deleting the from the database
+
+=cut
+
+sub revoke_user_tokens ( $class, $user_id ) {
+	Conch::Pg->new->db->delete( 'user_session_token', { user_id => $user_id } )
+		->rows;
+}
+
+1;
+
+__DATA__
+
+=pod
+
+=head1 LICENSING
+
+Copyright Joyent, Inc.
+
+This Source Code Form is subject to the terms of the Mozilla Public License,
+v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+one at http://mozilla.org/MPL/2.0/.
+
+=cut

--- a/Conch/lib/Conch/Route.pm
+++ b/Conch/lib/Conch/Route.pm
@@ -70,6 +70,7 @@ sub all_routes {
 	my $secured = $r->under->to('login#authenticate');
 	$secured->get( '/login', sub { shift->status(204) } );
 	$secured->get( '/me',    sub { shift->status(204) } );
+	$secured->post('/refresh_token')->to('login#refresh_token');
 
 	$secured->post(
 		'/feedback',
@@ -82,7 +83,7 @@ sub all_routes {
 	workspace_routes($secured);
 	device_routes($secured);
 	relay_routes($secured);
-	user_routes( $secured->under('/user/me') );
+	user_routes( $secured->under('/user') );
 	hardware_product_routes($secured);
 	validation_routes($secured);
 

--- a/Conch/lib/Conch/Route/User.pm
+++ b/Conch/lib/Conch/Route/User.pm
@@ -27,7 +27,8 @@ Sets up routes for the /user namespace
 sub user_routes {
 	my $r = shift;
 
-	$r->post('/#id/revoke')->to('user#revoke_tokens');
+	$r->post('/me/revoke')->to('user#revoke_own_tokens');
+	$r->post('/#id/revoke')->to('user#revoke_user_tokens');
 
 	$r->get('/me/settings')->to('user#get_settings');
 	$r->post('/me/settings')->to('user#set_settings');

--- a/Conch/lib/Conch/Route/User.pm
+++ b/Conch/lib/Conch/Route/User.pm
@@ -27,12 +27,14 @@ Sets up routes for the /user namespace
 sub user_routes {
 	my $r = shift;
 
-	$r->get('/settings')->to('user#get_settings');
-	$r->post('/settings')->to('user#set_settings');
+	$r->post('/#id/revoke')->to('user#revoke_tokens');
 
-	$r->get('/settings/#key')->to('user#get_setting');
-	$r->post('/settings/#key')->to('user#set_setting');
-	$r->delete('/settings/#key')->to('user#delete_setting');
+	$r->get('/me/settings')->to('user#get_settings');
+	$r->post('/me/settings')->to('user#set_settings');
+
+	$r->get('/me/settings/#key')->to('user#get_setting');
+	$r->post('/me/settings/#key')->to('user#set_setting');
+	$r->delete('/me/settings/#key')->to('user#delete_setting');
 }
 
 1;

--- a/Conch/t/integration/05_v1_schema.t
+++ b/Conch/t/integration/05_v1_schema.t
@@ -62,7 +62,7 @@ $t->post_ok(
 		user     => 'conch',
 		password => 'conch'
 	}
-)->status_is(200);
+)->status_is(200)->json_schema_is('Login');
 BAIL_OUT("Login failed") if $t->tx->res->code != 200;
 
 isa_ok( $t->tx->res->cookie('conch'), 'Mojo::Cookie::Response' );

--- a/Conch/t/model/SessionToken.t
+++ b/Conch/t/model/SessionToken.t
@@ -1,0 +1,62 @@
+use Mojo::Base -strict;
+use Test::More;
+use Test::Exception;
+use Test::ConchTmpDB;
+
+use Conch::Pg;
+
+use_ok("Conch::Model::SessionToken");
+
+use Conch::Model::User;
+use Conch::Model::SessionToken;
+
+my $pgtmp = mk_tmp_db() or die;
+my $pg = Conch::Pg->new( $pgtmp->uri );
+
+my $user = Conch::Model::User->create( 'foo@bar.com', 'password' );
+
+my $token;
+subtest "Create new token" => sub {
+	lives_ok {
+		$token =
+			Conch::Model::SessionToken->create( $user->id, time + 10 )
+	};
+	ok( $token, 'Token created' );
+};
+
+subtest "Check token" => sub {
+	my $check = Conch::Model::SessionToken->check_token( $user->id, $token );
+	ok( $check, 'Token valid' );
+
+	my $bad_check = Conch::Model::SessionToken->check_token( $user->id, $token."a" );
+	ok( !$bad_check, 'Token was not valid' );
+};
+
+
+subtest "Use token" => sub {
+	my $used = Conch::Model::SessionToken->use_token( $user->id, $token );
+	ok( $used, 'Token used' );
+
+	my $re_used = Conch::Model::SessionToken->use_token( $user->id, $token );
+	ok( !$re_used, 'Token not present and cannot be reused' );
+};
+
+subtest "Using expired token" => sub {
+	my $expired_token = Conch::Model::SessionToken->create( $user->id, time - 1 );
+	my $expired =
+		Conch::Model::SessionToken->check_token( $user->id, $expired_token );
+	ok( !$expired, 'Token expired and not present' );
+};
+
+subtest "Revoking user tokens" => sub {
+	my $new_token = Conch::Model::SessionToken->create( $user->id, time + 10 );
+	my $revoked_count =
+		Conch::Model::SessionToken->revoke_user_tokens( $user->id );
+	ok( $revoked_count, 'Non-zero count of revoked tokens' );
+
+	my $revoked_used =
+		Conch::Model::SessionToken->check_token( $user->id, $new_token );
+	ok( !$revoked_used, 'Revoked token cannot be used and not present' );
+};
+
+done_testing();

--- a/sql/migrations/0030-user-session-token.sql
+++ b/sql/migrations/0030-user-session-token.sql
@@ -7,12 +7,7 @@ SELECT run_migration(30, $$
 		primary key (user_id, token_hash)
 	);
 
-	-- fast deleting of expired otkens
+	-- fast deleting of expired tokens
 	create index on user_session_token (expires asc);
-
-	create function delete_expired_tokens() returns void
-		as 'delete from user_session_token where expires <= now()'
-	language sql;
-
 $$);
 

--- a/sql/migrations/0030-user-session-token.sql
+++ b/sql/migrations/0030-user-session-token.sql
@@ -1,0 +1,18 @@
+SELECT run_migration(30, $$
+
+	create table user_session_token (
+		user_id    uuid        not null references user_account(id),
+		token_hash bytea       not null,
+		expires    timestamptz not null,
+		primary key (user_id, token_hash)
+	);
+
+	-- fast deleting of expired otkens
+	create index on user_session_token (expires asc);
+
+	create function delete_expired_tokens() returns void
+		as 'delete from user_session_token where expires <= now()'
+	language sql;
+
+$$);
+


### PR DESCRIPTION
Add JSON Web Tokens (JWT) as an alternative method of authentication. This change is backwards compatible with previous authentication methods.

I chose to add this rather than creating loop-holes for splitting out UI development into a separate repo. This is what we all want anyways, so why not?

Here's a couple of important points:

* Cookie and Basic auth left as-is. They can be removed later if desired.
* JWT are canonically encoded in Base64 and returned in the JSON response of a successful login in the `token` attribute. Authentication with a JWT is made with the `Authentication: Bearer <token>` header.
* Like cookies, we use the `secrets` in the configuration file to provide the secure HMAC signature. Similarly, secrets can be rotated and JWTs with old but still available secrets will work. Changing all secrets invalidates all JWTs.
* JWTs do not expire.

I expect discussion about the last point, and held off on implementing anything before discussing. Here are some points:

* Non-expiring JWTs mean the CLI doesn't need to be re-profiled after 30 days (desirable?)
* We can expire tokens in client implementation. For example, in the UI, we can drop a stored token after _x_ minutes/hours of inactivity.
* If we decide to add expiration, `GET /login` with a valid token can re-issue a new token
* Revoking all tokens can be done by changing the configured `secrets`. 

Let me know your thoughts.