### PR TITLE
fix: use placeholders for SQL statements

### DIFF
--- a/Conch/lib/Conch/Model/DeviceLocation.pm
+++ b/Conch/lib/Conch/Model/DeviceLocation.pm
@@ -24,7 +24,7 @@ Find a DeviceLocation by Device ID or return undef.
 =cut
 sub lookup ( $self, $device_id ) {
 	my $ret = Conch::Pg->new->db->query(
-		qq{
+		q{
     SELECT
       loc.rack_unit AS location_rack_unit,
 

--- a/Conch/lib/Conch/Model/DeviceRole.pm
+++ b/Conch/lib/Conch/Model/DeviceRole.pm
@@ -117,7 +117,7 @@ Returns a DeviceRole given an existing uuid
 sub from_id ($class, $id) {
 	my $ret;
 	try {
-		$ret = Conch::Pg->new->db->query(qq|
+		$ret = Conch::Pg->new->db->query(q|
 			select r.*, array(
 				select drs.service_id
 				from device_role_services drs
@@ -149,7 +149,7 @@ Return all DeviceRoles
 sub all ($class) {
 	my $ret;
 	try {
-		$ret = Conch::Pg->new->db->query(qq|
+		$ret = Conch::Pg->new->db->query(q|
 			select r.*, array(
 				select drs.service_id
 				from device_role_services drs
@@ -191,7 +191,7 @@ sub add_service ($self, $service_uuid) {
 	return $self unless $self->id;
 	my $ret;
 	try {
-		$ret = Conch::Pg->new->db->query(qq|
+		$ret = Conch::Pg->new->db->query(q|
 			insert into device_role_services(role_id, service_id)
 			values( ?, ?)
 			on conflict do nothing
@@ -225,7 +225,7 @@ sub remove_service ($self, $service_uuid) {
 	return $self unless $self->id;
 	my $ret;
 	try {
-		$ret = Conch::Pg->new->db->query(qq|
+		$ret = Conch::Pg->new->db->query(q|
 			delete from device_role_services
 			where role_id = ? and service_id = ?
 		|, $self->id, $service_uuid);

--- a/Conch/lib/Conch/Model/ValidationResult.pm
+++ b/Conch/lib/Conch/Model/ValidationResult.pm
@@ -137,7 +137,9 @@ sub grouped_by_validation_states ( $class, $validation_states ) {
 	my @validation_state_ids = keys %groups;
 
 	my $fields = join( ', ', map { 'r.' . $_ } @$attrs );
-	my $values = join( ', ', map { "('$_'::uuid)" } @validation_state_ids );
+	my $p_index = 1;
+	my $values =
+		join( ', ', map { '($' . $p_index++ . '::uuid)' } @validation_state_ids );
 	Conch::Pg->new->db->query(
 		qq{
 			select m.validation_state_id state_id, $fields
@@ -146,7 +148,7 @@ sub grouped_by_validation_states ( $class, $validation_states ) {
 				on m.validation_state_id = tmp.id
 			join validation_result r
 				on r.id = m.validation_result_id
-			}
+			}, @validation_state_ids
 		)->hashes->map(
 		sub {
 			my %ret      = shift->%*;

--- a/Conch/lib/Conch/Model/ValidationState.pm
+++ b/Conch/lib/Conch/Model/ValidationState.pm
@@ -127,21 +127,22 @@ Return all latest completed states for each plans for a given Device
 
 sub latest_completed_states_for_device ( $class, $device_id, @statuses ) {
 	my $fields = join( ', ', @$attrs );
+	my $p_index = 1;
 	my $status_condition =
 		@statuses
-		? "status in (" . join( ', ', map { "'$_'" } @statuses ) . ")"
-		: " 1 = 1 ";
+		? "and status in (" . join( ', ', map { '$'.$p_index++ } @statuses ) . ")"
+		: "";
 	return Conch::Pg->new->db->query(
 		qq{
 		select distinct on (validation_plan_id) $fields
 		from validation_state
 		where
-			device_id = ? and
-			completed is not null and
+			device_id = \$$p_index and
+			completed is not null
 			$status_condition
 		order by validation_plan_id, completed desc
 		},
-		$device_id
+		( @statuses, $device_id )
 	)->hashes->map( sub { $class->new( shift->%* ) } )->to_array;
 }
 
@@ -155,26 +156,28 @@ sub latest_completed_states_for_devices ( $class, $device_ids, @statuses ) {
 	return [] unless scalar @$device_ids;
 
 	my $fields = join( ', ', map { "vs.$_" } @$attrs );
-	my $values = join( ', ', map { "('$_')" } @$device_ids );
+
+	my $p_index = 1;
+	my $device_values = join( ', ', map { '($'.$p_index++.')' } @$device_ids );
 	my $status_condition =
 		@statuses
-		? "vs.status in (" . join( ', ', map { "'$_'" } @statuses ) . ")"
-		: "1 = 1";
+		? "and vs.status in (" . join( ', ', map { '$'.$p_index++ } @statuses ) . ")"
+		: "";
 
 	return Conch::Pg->new->db->query(
 		qq{
 		select distinct on (vs.device_id, vs.validation_plan_id) $fields
 		from validation_state vs
-		join ( values $values) tmp (id)
+		join ( values $device_values) tmp (id)
 			on vs.device_id = tmp.id
 		where
-			vs.completed is not null and
+			vs.completed is not null
 			$status_condition
 		order by
 			vs.device_id,
 			vs.validation_plan_id,
 			vs.completed desc
-		},
+		}, (@$device_ids, @statuses)
 	)->hashes->map( sub { $class->new( shift->%* ) } )->to_array;
 }
 

--- a/Conch/lib/Conch/Model/WorkspaceDevice.pm
+++ b/Conch/lib/Conch/Model/WorkspaceDevice.pm
@@ -22,7 +22,7 @@ List all devices located in workspace.
 sub list ( $self, $ws_id, $last_seen_seconds = undef ) {
 	my $last_seen_clause =
 		$last_seen_seconds
-		? "AND device.last_seen > NOW() - INTERVAL '$last_seen_seconds seconds'"
+		? "AND device.last_seen > NOW() - ? * interval '1 second'"
 		: '';
 
 	my $ret = Conch::Pg->new->db->query(
@@ -48,7 +48,7 @@ sub list ( $self, $ws_id, $last_seen_seconds = undef ) {
 			)
 		  )
   		$last_seen_clause
-	}, $ws_id
+	}, ($ws_id, $last_seen_seconds || () )
 	)->hashes;
 
 	my @devices;

--- a/Conch/lib/Conch/Model/WorkspaceRack.pm
+++ b/Conch/lib/Conch/Model/WorkspaceRack.pm
@@ -213,7 +213,7 @@ workspace assignment.
 =cut
 sub rack_in_parent_workspace ( $self, $ws_id, $rack_id ) {
 	return Conch::Pg->new->db->query(
-		qq{
+		q{
       WITH parent_workspace (id) AS (
         SELECT ws.parent_workspace_id
         FROM workspace ws
@@ -296,7 +296,7 @@ sub remove_from_workspace ( $self, $ws_id, $rack_id ) {
 
 	# Remove rack ID from workspace and all children workspaces
 	$db->query(
-		qq{
+		q{
       WITH RECURSIVE workspace_and_children (id) AS (
           SELECT id
           FROM workspace

--- a/Conch/lib/Conch/Model/WorkspaceRelay.pm
+++ b/Conch/lib/Conch/Model/WorkspaceRelay.pm
@@ -50,7 +50,7 @@ sub list ( $self, $ws_id, $interval_minutes = undef ) {
 	# find relay locations based on the device most recently reported through the
 	# relay
 	my $relay_locations = $db->query(
-		qq{
+		q{
         SELECT drc1.relay_id, rack.id as rack_id, rack.name as rack_name,
           room.az as room_name, role.name as role_name
         FROM device_relay_connection drc1
@@ -82,7 +82,7 @@ sub list ( $self, $ws_id, $interval_minutes = undef ) {
 		? "AND updated >= NOW() - INTERVAL '$interval_minutes minutes'"
 		: '';
 	my $relays = $db->query(
-		qq{
+		q{
       SELECT relay.*
       FROM relay
       WHERE id = ANY (?)
@@ -104,7 +104,7 @@ sub list ( $self, $ws_id, $interval_minutes = undef ) {
 	for my $relay (@$relays) {
 		my $devices = [];
 		my $ret     = $db->query(
-			qq{
+			q{
         SELECT device.*
         FROM relay r
         INNER JOIN device_relay_connection dr


### PR DESCRIPTION
Use explicit indexed SQL parameters for model queries where the values aren't hard-coded. Change any use of `qq{...}` to `q{ ...}` in queries to make it explicit when interpolation occurs.