### PR TITLE
fix: require that Content-Type with application/json is specified

### DIFF
--- a/Conch/lib/Conch.pm
+++ b/Conch/lib/Conch.pm
@@ -156,8 +156,13 @@ sub startup {
 			# and text/plain Content Types without triggering CORS checks in the browser.
 			# Appropriate CORS headers must still be added by the serving proxy
 			# to be effective against CSRF.
-			if ( $headers->content_length && ! $headers->content_type =~ /application\/json/ ) {
-				return $c->status(415);
+			if($headers->content_length) {
+				unless ($headers->content_type) {
+					return $c->status(415);
+				}
+				if($headers->content_type !~ /application\/json/i) {
+					return $c->status(415);
+				}
 			}
 		}
 	);

--- a/Conch/lib/Conch.pm
+++ b/Conch/lib/Conch.pm
@@ -147,6 +147,21 @@ sub startup {
 		}
 	);
 
+	$self->hook(
+		before_routes => sub {
+			my $c = shift;
+			my $headers = $c->req->headers;
+			# Preventative check against CSRF. Cross-origin requests can only
+			# specify application/x-www-form-urlencoded, multipart/form-data,
+			# and text/plain Content Types without triggering CORS checks in the browser.
+			# Appropriate CORS headers must still be added by the serving proxy
+			# to be effective against CSRF.
+			if ( $headers->content_length && ! $headers->content_type =~ /application\/json/ ) {
+				return $c->status(415);
+			}
+		}
+	);
+
 	# Render exceptions and Not Found as JSON
 	$self->hook(
 		before_render => sub {

--- a/Conch/t/integration/00_only_1_user_loaded.t
+++ b/Conch/t/integration/00_only_1_user_loaded.t
@@ -287,7 +287,7 @@ subtest 'Relay List' => sub {
 subtest 'Device Report' => sub {
 	my $report =
 		io->file('t/integration/resource/passing-device-report.json')->slurp;
-	$t->post_ok( '/device/TEST', $report )->status_is(409)
+	$t->post_ok( '/device/TEST', { 'Content-Type' => 'application/json' }, $report )->status_is(409)
 		->json_like( '/error', qr/Hardware Product '.+' does not exist/ );
 
 	$t->post_ok( '/device/TEST', json => { serial_number => 'TEST' } )

--- a/Conch/t/integration/01_hardware_products_loaded.t
+++ b/Conch/t/integration/01_hardware_products_loaded.t
@@ -70,7 +70,7 @@ subtest 'Relay List' => sub {
 subtest 'Device Report' => sub {
 	my $report =
 		io->file('t/integration/resource/passing-device-report.json')->slurp;
-	$t->post_ok( '/device/TEST', $report )->status_is(409)
+	$t->post_ok( '/device/TEST', { 'Content-Type' => 'application/json' }, $report )->status_is(409)
 		->json_like( '/error', qr/Hardware Product '.+' does not exist/ );
 };
 

--- a/Conch/t/integration/02_hardware_product_profiles_loaded.t
+++ b/Conch/t/integration/02_hardware_product_profiles_loaded.t
@@ -70,7 +70,7 @@ subtest 'Relay List' => sub {
 subtest 'Device Report' => sub {
 	my $report =
 		io->file('t/integration/resource/passing-device-report.json')->slurp;
-	$t->post_ok( '/device/TEST', $report )->status_is( 200,
+	$t->post_ok( '/device/TEST', { 'Content-Type' => 'application/json' }, $report )->status_is( 200,
 'Device reports process despite hardware profiles not having a zpool profile'
 	)->json_is( '/health', 'PASS' );
 };

--- a/Conch/t/integration/03_zpool_profiles_loaded.t
+++ b/Conch/t/integration/03_zpool_profiles_loaded.t
@@ -71,7 +71,7 @@ subtest 'Relay List' => sub {
 subtest 'Device Report' => sub {
 	my $report =
 		io->file('t/integration/resource/passing-device-report.json')->slurp;
-	$t->post_ok( '/device/TEST', $report )->status_is(200)
+	$t->post_ok( '/device/TEST', { 'Content-Type' => 'application/json' }, $report )->status_is(200)
 		->json_is( '/health', 'PASS' );
 };
 

--- a/Conch/t/integration/04_test_datacenter_loaded.t
+++ b/Conch/t/integration/04_test_datacenter_loaded.t
@@ -151,7 +151,7 @@ subtest 'Register relay' => sub {
 subtest 'Device Report' => sub {
 	my $report =
 		io->file('t/integration/resource/passing-device-report.json')->slurp;
-	$t->post_ok( '/device/TEST', $report )->status_is(200)
+	$t->post_ok( '/device/TEST', { 'Content-Type' => 'application/json' }, $report )->status_is(200)
 		->json_is( '/health', 'PASS' );
 };
 
@@ -485,7 +485,7 @@ subtest 'Device location' => sub {
 		json => { rack_id => $rack_id, rack_unit => 3 } )->status_is(303)
 		->header_like( Location => qr!/device/TEST/location$! );
 
-	$t->delete_ok('/device/TEST/location', 'can delete device location')->status_is(204);
+	$t->delete_ok('/device/TEST/location')->status_is(204, 'can delete device location');
 };
 
 

--- a/Conch/t/integration/05_v1_schema.t
+++ b/Conch/t/integration/05_v1_schema.t
@@ -128,7 +128,7 @@ subtest 'Set up a test device' => sub {
 
 	my $report =
 		io->file('t/integration/resource/passing-device-report.json')->slurp;
-	$t->post_ok( '/device/TEST', $report )->status_is(200)
+	$t->post_ok( '/device/TEST', { 'Content-Type' => 'application/json' }, $report )->status_is(200)
 		->json_is( '/health', 'PASS' );
 };
 


### PR DESCRIPTION
Require that all requests with payloads (POST, etc) specify that the `Content-Type` header specifies 'application/json'. This provides additional protection against CSRF, as attackers can specify `plain/text` as the content type without the browser triggering a CORS header check (and Mojo doesn't care what the declared content is). Requiring `application/json` forces browsers to check CORS before issuing requests, preventing CSRF attacks.