### PR TITLE
Refactor: workspace devices stored procedure, validation states queries

### DIFF
--- a/Conch/lib/Conch/Controller/DeviceValidation.pm
+++ b/Conch/lib/Conch/Controller/DeviceValidation.pm
@@ -25,7 +25,7 @@ sub list_validation_states ($c) {
 	my @statuses;
 	@statuses = map { lc($_) } split /,\s*/, $c->param('status')
 		if $c->param('status');
-	
+
 	if (
 		@statuses
 		&& notall {
@@ -46,13 +46,9 @@ sub list_validation_states ($c) {
 
 	my $device = $c->stash('current_device');
 
-	my $validation_states =
-		Conch::Model::ValidationState->latest_completed_states_for_device(
-		$device->id, @statuses );
-
 	my $validation_state_groups =
-		Conch::Model::ValidationResult->grouped_by_validation_states(
-		$validation_states);
+		Conch::Model::ValidationState->latest_completed_grouped_states_for_device(
+		$device->id, @statuses );
 
 	my @output = map {
 		{ $_->{state}->TO_JSON->%*, results => $_->{results} };

--- a/Conch/lib/Conch/Controller/WorkspaceValidation.pm
+++ b/Conch/lib/Conch/Controller/WorkspaceValidation.pm
@@ -43,16 +43,10 @@ sub workspace_validation_states ($c) {
 		);
 	}
 
-	my $workspace_devices = Conch::Model::WorkspaceDevice->new->list(
-		$c->stash('current_workspace')->id );
-
-	my $validation_states =
-		Conch::Model::ValidationState->latest_completed_states_for_devices(
-		[ map { $_->id } @$workspace_devices ], @statuses );
-
 	my $validation_state_groups =
-		Conch::Model::ValidationResult->grouped_by_validation_states(
-		$validation_states);
+		Conch::Model::ValidationState
+		->latest_completed_grouped_states_for_workspace(
+		$c->stash('current_workspace')->id, @statuses );
 
 	my @output = map {
 		{ $_->{state}->TO_JSON->%*, results => $_->{results} };
@@ -71,7 +65,7 @@ __DATA__
 
 Copyright Joyent, Inc.
 
-This Source Code Form is subject to the terms of the Mozilla Public License, 
+This Source Code Form is subject to the terms of the Mozilla Public License,
 v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
 one at http://mozilla.org/MPL/2.0/.
 

--- a/Conch/lib/Conch/Model/WorkspaceDevice.pm
+++ b/Conch/lib/Conch/Model/WorkspaceDevice.pm
@@ -22,31 +22,12 @@ List all devices located in workspace.
 sub list ( $self, $ws_id, $last_seen_seconds = undef ) {
 	my $last_seen_clause =
 		$last_seen_seconds
-		? "AND device.last_seen > NOW() - ? * interval '1 second'"
+		? "WHERE last_seen > NOW() - ? * interval '1 second'"
 		: '';
 
 	my $ret = Conch::Pg->new->db->query(
 		qq{
-		WITH target_workspace (id) AS ( values(?::uuid) )
-		SELECT device.*
-		FROM device
-		JOIN device_location loc
-		  ON loc.device_id = device.id
-		JOIN datacenter_rack rack
-		  ON rack.id = loc.rack_id
-		WHERE device.deactivated IS NULL
-		  AND (
-			rack.datacenter_room_id IN (
-			  SELECT datacenter_room_id
-			  FROM workspace_datacenter_room
-			  WHERE workspace_id = (SELECT id FROM target_workspace)
-			)
-			OR rack.id IN (
-			  SELECT datacenter_rack_id
-			  FROM workspace_datacenter_rack
-			  WHERE workspace_id = (SELECT id FROM target_workspace)
-			)
-		  )
+		select * from workspace_devices(?)
   		$last_seen_clause
 	}, ($ws_id, $last_seen_seconds || () )
 	)->hashes;

--- a/sql/migrations/0031-workspace-devices-fn.sql
+++ b/sql/migrations/0031-workspace-devices-fn.sql
@@ -1,0 +1,41 @@
+SELECT run_migration(31, $$
+    -- Adds a function to retrieve all of the devices in the workspaces by
+    -- virtue of their rack location
+    -- IMPORTANT: If the device table ever changes, this function MUST be
+    -- updated (`create or replace function...`) with the new fields.
+	CREATE OR REPLACE FUNCTION workspace_devices(IN workspace_id uuid)
+	RETURNS TABLE(
+		id text, system_uuid uuid, hardware_product uuid, state text, health text,
+		graduated timestamptz, deactivated timestamptz, last_seen timestamptz,
+		created timestamptz, updated timestamptz, uptime_since timestamptz,
+		validated timestamptz, latest_triton_reboot timestamptz, triton_uuid uuid,
+		asset_tag text, triton_setup timestamptz, role uuid
+	) AS
+	$BODY$
+
+	BEGIN
+		RETURN QUERY EXECUTE'
+		SELECT device.*
+		FROM device
+		JOIN device_location loc
+		ON loc.device_id = device.id
+		JOIN datacenter_rack rack
+		ON rack.id = loc.rack_id
+		WHERE device.deactivated IS NULL
+		AND (
+			rack.datacenter_room_id IN (
+				SELECT datacenter_room_id
+				FROM workspace_datacenter_room
+				WHERE workspace_id = $1
+			)
+			OR rack.id IN (
+				SELECT datacenter_rack_id
+				FROM workspace_datacenter_rack
+				WHERE workspace_id = $1
+			)
+		);' USING $1;
+	END;
+	$BODY$
+LANGUAGE plpgsql STABLE;
+
+$$);


### PR DESCRIPTION
I still wasn't happy with the performance of the GET workspace/:id/validation_states endpoint, so I dug into it a bit more. It's comprised of three queries: getting all of the workspace devices, getting the latest validation states for each device, and getting the validation results for each. From developing on production DB, I discovered one big query was far more efficient than the 3 separate ones—even though they're very similar. In fact, the big query to get everything at once took about 200 ms, where one of the three queries took over 600 ms! (go PG query planner!)

In order to manage this better, this also pulls the query to get all workspace devices (a common operation) into a stored procedure. I tried to get better performance for this query, too, but couldn't get any better that it is already.