### PR TITLE
refactor: in the device report handling, set the jsonb field to the raw body received from the client, rather than bouncing through the json lib twice

### DIFF
--- a/Conch/lib/Conch/Controller/DeviceReport.pm
+++ b/Conch/lib/Conch/Controller/DeviceReport.pm
@@ -28,6 +28,7 @@ Processes the device report using the Legacy report code base
 
 sub process ($c) {
 	my $device_report = $c->validate_input('DeviceReport') or return;
+	my $raw_report = $c->req->body;
 
 	my $hw_product_name = $device_report->{product_name};
 	my $maybe_hw =
@@ -48,7 +49,7 @@ sub process ($c) {
 	my $schema =
 		Conch::Legacy::Schema->connect( $pg->dsn, $pg->username, $pg->password );
 
-	my ( $device, $report_id ) = record_device_report( $schema, $device_report );
+	my ( $device, $report_id ) = record_device_report( $schema, $device_report, $raw_report );
 
 	my $validation_plan;
 	if ( $device_report->{device_type}

--- a/Conch/lib/Conch/Legacy/Control/DeviceReport.pm
+++ b/Conch/lib/Conch/Legacy/Control/DeviceReport.pm
@@ -44,7 +44,7 @@ Record device report and device details from the report
 
 =cut
 sub record_device_report {
-	my ( $schema, $dr ) = @_;
+	my ( $schema, $dr, $raw_report ) = @_;
 	my $hw = $schema->resultset('HardwareProduct')->find(
 		{
 			name => $dr->{product_name}
@@ -98,7 +98,7 @@ sub record_device_report {
 			$device_report = $schema->resultset('DeviceReport')->create(
 				{
 					device_id => $device_id,
-					report    => encode_json $dr
+					report    => $raw_report,
 				}
 			);
 


### PR DESCRIPTION
In debugging a weird issue with JSON marshaling of device reports, @daleghent and I realized that, in the submission of a device report, we marshal and unmarshal the JSON blob several times, ultimately storing a structure in the database that has bounced through the JSON lib several times. What we really want in the database field is the exact JSON provided by the client.

This patch preserves the raw JSON from the client and saves that in the database. All the existing code continues to use an unmarshalled version, as before.