### PR TITLE
validation: Add FirmwareCurrent validation

### DIFF
--- a/Conch/conch.conf.dist
+++ b/Conch/conch.conf.dist
@@ -70,6 +70,7 @@
 				{ name => 'dimm_count',            version => 1 },
 				{ name => 'disk_smart_status',     version => 1 },
 				{ name => 'disk_temperature',      version => 1 },
+				{ name => 'firmware_current',      version => 1 },
 				{ name => 'links_up',              version => 1 },
 				{ name => 'nics_num',              version => 1 },
 				{ name => 'product_name',          version => 1 },

--- a/Conch/lib/Conch/Validation/FirmwareCurrent.pm
+++ b/Conch/lib/Conch/Validation/FirmwareCurrent.pm
@@ -1,0 +1,44 @@
+package Conch::Validation::FirmwareCurrent;
+
+use Mojo::Base 'Conch::Validation';
+
+has 'name'        => 'firmware_current';
+has 'version'     => 1;
+has 'category'    => 'BIOS';
+has 'description' => q(
+Validate that firmware is 'current' in device settings
+);
+
+sub validate {
+	my ( $self ) = @_;
+
+	my $firmware_value = $self->device_settings->{firmware};
+
+	if ($firmware_value) {
+		$self->register_result(
+			expected => 'current',
+			got      => $firmware_value
+		);
+	}
+	else {
+		$self->fail("No 'firmware' setting in device settings",
+			hint => 'Device may not have started initial setup yet' );
+	}
+}
+
+1;
+
+__DATA__
+
+=pod
+
+=head1 LICENSING
+
+Copyright Joyent, Inc.
+
+This Source Code Form is subject to the terms of the Mozilla Public License,
+v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+one at http://mozilla.org/MPL/2.0/.
+
+=cut
+

--- a/Conch/t/validations/firmware_current_v1.t
+++ b/Conch/t/validations/firmware_current_v1.t
@@ -1,0 +1,41 @@
+use Test::More;
+use Test::Conch::Validation;
+
+test_validation(
+	'Conch::Validation::FirmwareCurrent',
+	cases => [
+		{
+			description => 'No device settings fails',
+			failure_num => 1,
+		},
+	]
+);
+
+test_validation(
+	'Conch::Validation::FirmwareCurrent',
+	device_settings => {
+		firmware => 'updating'
+	},
+	cases => [
+		{
+			description => '"updating" firmware fails',
+			failure_num => 1,
+		},
+	]
+);
+
+test_validation(
+	'Conch::Validation::FirmwareCurrent',
+	device_settings => {
+		firmware => 'current'
+	},
+	cases => [
+		{
+			description => '"current" firmware fails',
+			success_num => 1,
+		},
+	]
+);
+
+done_testing();
+


### PR DESCRIPTION
Adds a validation to verify the `firmware` key in device settings has the value "current".

@bdha, @daleghent, and @jemershaw, I'd like you to go over this PR to see how the validation is structured, tested, and added to the validation plan. Please don't hesitate to ask me any questions, as there won't be many opportunities to do so :) 