### PR TITLE
DB migration to add hardware product spec and SKU fields

### DIFF
--- a/Conch/docs/hw-specs/manta-storage-v3-256g-36-10tb.json
+++ b/Conch/docs/hw-specs/manta-storage-v3-256g-36-10tb.json
@@ -1,0 +1,103 @@
+{
+	"chassis": {
+		"dmi": {
+			"bios": {
+				"vendor_name": "American Megatrends Inc.",
+				"version": "3.0a"
+			},
+			"bmc": {
+				"version": "3.65"
+			},
+			"system": {
+				"vendor_id": "66fed141-85c1-4136-80d7-b1fffbfd2991",
+				"vendor_name": "SuperMicro",
+				"product_name": "Joyent-Storage-Platform-7001"
+			}
+		},
+		"power": {
+			"service_amps":  { "max": 0, "idle": 0 },
+			"service_watts": { "max": 0, "idle": 0 },
+			"psu": [
+				{ "type": "single", "max_wattage": 1280 },
+				{ "type": "single", "max_wattage": 1280 }
+		  ]
+		},
+		"cpu": {
+			"processors": [
+				{ "socket": 0, "vendor": "Intel", "model": "E5-2690 v4", "speed": 2.60, "microcode": "0xb000017" },
+				{ "socket": 1, "vendor": "Intel", "model": "E5-2690 v4", "speed": 2.60, "microcode": "0xb000017" }
+			]
+		},
+		"network": {
+			"cards": [
+				{ "slot": 3,    "vendor": "Intel", "model": "82599ES",  "bus": "PCI-E",   "speed": 10000, "type": "sfp", "ports": 2 },
+				{ "slot": 4,    "vendor": "Intel", "model": "82599ES",  "bus": "PCI-E",   "speed": 10000, "type": "sfp", "ports": 2 },
+				{ "slot": null, "vendor": "Intel", "model": "X540-AT2", "bus": "onboard", "speed": 10000, "type": "ethernet", "ports": 2 },
+				{ "slot": null, "vendor": "Intel", "model": "IPMI",     "bus": "onboard", "speed": 1000,  "type": "ethernet", "ports": 1 }
+			]
+		},
+		"storage": {
+			"hba": [
+				{ "vendor": "LSI", "model": "SAS3008", "bus": 3, "slot": 2, "speed": "12g", "mode": "IT", "firmware_rev": "14.00.00.00", "bios_version": "8.31.03.00" }
+			],
+			"disks": [
+				{ "enclosure": null, "hba": "001", "slot": "003", "vendor": "Kingston", "model": "DataTraveler 2.0", "size": 14500, "firmware_rev": null, "type": null, "transport": "usb" },
+				{ "enclosure": "2", "hba": "0", "slot": "0",  "vendor": "HGST", "model": "HUSMH8010BSS204", "size": 93200,   "firmware_rev": ["C360"], "type": "SAS_SSD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "1",  "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "2",  "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "3",  "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "4",  "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "5",  "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "6",  "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "7",  "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "8",  "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "9",  "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "10", "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "11", "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "12", "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "13", "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "14", "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "15", "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "16", "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "17", "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "18", "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "19", "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "20", "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "21", "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "22", "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "23", "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "3", "hba": "0", "slot": "0",  "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "3", "hba": "0", "slot": "1",  "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "3", "hba": "0", "slot": "2",  "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "3", "hba": "0", "slot": "3",  "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "3", "hba": "0", "slot": "4",  "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "3", "hba": "0", "slot": "5",  "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "3", "hba": "0", "slot": "6",  "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "3", "hba": "0", "slot": "7",  "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "3", "hba": "0", "slot": "8",  "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "3", "hba": "0", "slot": "9",  "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "3", "hba": "0", "slot": "10", "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "3", "hba": "0", "slot": "11", "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" }
+			]
+		},
+		"memory": {
+			"dimms": [
+				{ "slot": "P1_DIMMA1", "bank": 1, "vendor": "Samsung", "model": "M393A4K40CB1-CRC", "speed": 2400, "type": "DDR4", "size": 32 },
+				{ "slot": "P1_DIMMA2", "bank": 1, "vendor": "Samsung", "model": "M393A4K40CB1-CRC", "speed": 2400, "type": "DDR4", "size": 32 },
+				{ "slot": "P1_DIMMC1", "bank": 2, "vendor": "Samsung", "model": "M393A4K40CB1-CRC", "speed": 2400, "type": "DDR4", "size": 32 },
+				{ "slot": "P1_DIMMC2", "bank": 2, "vendor": "Samsung", "model": "M393A4K40CB1-CRC", "speed": 2400, "type": "DDR4", "size": 32 },
+				{ "slot": "P1_DIMME1", "bank": 3, "vendor": "Samsung", "model": "M393A4K40CB1-CRC", "speed": 2400, "type": "DDR4", "size": 32 },
+				{ "slot": "P1_DIMME2", "bank": 3, "vendor": "Samsung", "model": "M393A4K40CB1-CRC", "speed": 2400, "type": "DDR4", "size": 32 },
+				{ "slot": "P1_DIMMG1", "bank": 4, "vendor": "Samsung", "model": "M393A4K40CB1-CRC", "speed": 2400, "type": "DDR4", "size": 32 },
+				{ "slot": "P1_DIMMG2", "bank": 4, "vendor": "Samsung", "model": "M393A4K40CB1-CRC", "speed": 2400, "type": "DDR4", "size": 32 }
+			]
+		},
+		"zpool": {
+			"cache": 0,
+			"log": 1,
+			"spare": 2,
+			"vdev_n": 3,
+			"vdev_t": "raidz2"
+		}
+	}
+}

--- a/sql/migrations/0035-hw-prod-spec-sku.sql
+++ b/sql/migrations/0035-hw-prod-spec-sku.sql
@@ -7,7 +7,7 @@ SELECT run_migration(35, $$
 	alter table hardware_product drop constraint hardware_product_alias_key;
 	alter table hardware_product add column sku text;
 	alter table hardware_product add column product_name text;
-	alter hardware_product add unique(sku);
+	alter table hardware_product add unique(sku);
 
 	update hardware_product set product_name = name;
 $$);

--- a/sql/migrations/0035-hw-prod-spec-sku.sql
+++ b/sql/migrations/0035-hw-prod-spec-sku.sql
@@ -1,0 +1,12 @@
+# name: manta-storage-v3-512g-36-8tb (Conch specific)
+# sku: 600-0025-001
+# product_name: Joyent-S10G4
+
+SELECT run_migration(35, $$
+	alter table hardware_product add column specification jsonb;
+	alter table hardware_product drop constraint hardware_product_alias_key;
+	alter table hardware_product add column sku text;
+	alter table hardware_product add column product_name text;
+	alter hardware_product add unique(sku);
+	update hardware_product set product_name = name;
+$$);

--- a/sql/migrations/0035-hw-prod-spec-sku.sql
+++ b/sql/migrations/0035-hw-prod-spec-sku.sql
@@ -8,5 +8,6 @@ SELECT run_migration(35, $$
 	alter table hardware_product add column sku text;
 	alter table hardware_product add column product_name text;
 	alter hardware_product add unique(sku);
+
 	update hardware_product set product_name = name;
 $$);

--- a/sql/migrations/0035-hw-prod-spec-sku.sql
+++ b/sql/migrations/0035-hw-prod-spec-sku.sql
@@ -1,6 +1,6 @@
-# name: manta-storage-v3-512g-36-8tb (Conch specific)
-# sku: 600-0025-001
-# product_name: Joyent-S10G4
+-- name: manta-storage-v3-512g-36-8tb (Conch specific)
+-- sku: 600-0025-001
+-- product_name: Joyent-S10G4
 
 SELECT run_migration(35, $$
 	alter table hardware_product add column specification jsonb;


### PR DESCRIPTION
We are changing how we manage product names and SKUs internally.

We would also like a more expressive way of defining hardware product specifications (currently stored in the hardware_product_profile table.)

This migration adds a `sku` column, and changes the current `name` column to `product_name`. So we end up with:

* name: manta-storage-v3-512g-36-8tb (Conch specific)
* sku: 600-0025-001
* product_name: Joyent-S10G4

I think we agreed to not manage table contents in migrations, so I'll update the fields after deployment.

We will also need to update DB/API code to ref the new columns.

An example of what we end up with:

```
conch=# select name,alias,sku,product_name from hardware_product where sku is not null;
             name              |         alias         |     sku      | product_name 
-------------------------------+-----------------------+--------------+--------------
 manta-storage-v3-512g-36-8tb  | Mantis Shrimp MkIII   | 600-0025-001 | Joyent-S10G4
 manta-storage-v3-256g-36-10tb | Mantis Shrimp MkIII   | 600-0025-002 | Joyent-S10G4
 manta-storage-v3-256g-36-12tb | Mantis Shrimp MkIII.5 | 600-0036-001 | Joyent-S10G5
(3 rows)
```