### PR TITLE
DB migration to add hardware product spec and SKU fields

### DIFF
--- a/Conch/docs/hw-specs/manta-storage-v3-256g-36-10tb.json
+++ b/Conch/docs/hw-specs/manta-storage-v3-256g-36-10tb.json
@@ -1,0 +1,103 @@
+{
+	"chassis": {
+		"dmi": {
+			"bios": {
+				"vendor_name": "American Megatrends Inc.",
+				"version": "3.0a"
+			},
+			"bmc": {
+				"version": "3.65"
+			},
+			"system": {
+				"vendor_id": "66fed141-85c1-4136-80d7-b1fffbfd2991",
+				"vendor_name": "SuperMicro",
+				"product_name": "Joyent-Storage-Platform-7001"
+			}
+		},
+		"power": {
+			"service_amps":  { "max": 0, "idle": 0 },
+			"service_watts": { "max": 0, "idle": 0 },
+			"psu": [
+				{ "type": "single", "max_wattage": 1280 },
+				{ "type": "single", "max_wattage": 1280 }
+		  ]
+		},
+		"cpu": {
+			"processors": [
+				{ "socket": 0, "vendor": "Intel", "model": "E5-2690 v4", "speed": 2.60, "microcode": "0xb000017" },
+				{ "socket": 1, "vendor": "Intel", "model": "E5-2690 v4", "speed": 2.60, "microcode": "0xb000017" }
+			]
+		},
+		"network": {
+			"cards": [
+				{ "slot": 3,    "vendor": "Intel", "model": "82599ES",  "bus": "PCI-E",   "speed": 10000, "type": "sfp", "ports": 2 },
+				{ "slot": 4,    "vendor": "Intel", "model": "82599ES",  "bus": "PCI-E",   "speed": 10000, "type": "sfp", "ports": 2 },
+				{ "slot": null, "vendor": "Intel", "model": "X540-AT2", "bus": "onboard", "speed": 10000, "type": "ethernet", "ports": 2 },
+				{ "slot": null, "vendor": "Intel", "model": "IPMI",     "bus": "onboard", "speed": 1000,  "type": "ethernet", "ports": 1 }
+			]
+		},
+		"storage": {
+			"hba": [
+				{ "vendor": "LSI", "model": "SAS3008", "bus": 3, "slot": 2, "speed": "12g", "mode": "IT", "firmware_rev": "14.00.00.00", "bios_version": "8.31.03.00" }
+			],
+			"disks": [
+				{ "enclosure": null, "hba": "001", "slot": "003", "vendor": "Kingston", "model": "DataTraveler 2.0", "size": 14500, "firmware_rev": null, "type": null, "transport": "usb" },
+				{ "enclosure": "2", "hba": "0", "slot": "0",  "vendor": "HGST", "model": "HUSMH8010BSS204", "size": 93200,   "firmware_rev": ["C360"], "type": "SAS_SSD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "1",  "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "2",  "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "3",  "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "4",  "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "5",  "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "6",  "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "7",  "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "8",  "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "9",  "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "10", "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "11", "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "12", "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "13", "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "14", "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "15", "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "16", "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "17", "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "18", "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "19", "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "20", "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "21", "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "22", "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "2", "hba": "0", "slot": "23", "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "3", "hba": "0", "slot": "0",  "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "3", "hba": "0", "slot": "1",  "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "3", "hba": "0", "slot": "2",  "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "3", "hba": "0", "slot": "3",  "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "3", "hba": "0", "slot": "4",  "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "3", "hba": "0", "slot": "5",  "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "3", "hba": "0", "slot": "6",  "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "3", "hba": "0", "slot": "7",  "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "3", "hba": "0", "slot": "8",  "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "3", "hba": "0", "slot": "9",  "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "3", "hba": "0", "slot": "10", "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" },
+				{ "enclosure": "3", "hba": "0", "slot": "11", "vendor": "HGST", "model": "HUH721010AL4204", "size": 9100000, "firmware_rev": ["C384"], "type": "SAS_HDD", "transport": "sas" }
+			]
+		},
+		"memory": {
+			"dimms": [
+				{ "slot": "P1_DIMMA1", "bank": 1, "vendor": "Samsung", "model": "M393A4K40CB1-CRC", "speed": 2400, "type": "DDR4", "size": 32 },
+				{ "slot": "P1_DIMMA2", "bank": 1, "vendor": "Samsung", "model": "M393A4K40CB1-CRC", "speed": 2400, "type": "DDR4", "size": 32 },
+				{ "slot": "P1_DIMMC1", "bank": 2, "vendor": "Samsung", "model": "M393A4K40CB1-CRC", "speed": 2400, "type": "DDR4", "size": 32 },
+				{ "slot": "P1_DIMMC2", "bank": 2, "vendor": "Samsung", "model": "M393A4K40CB1-CRC", "speed": 2400, "type": "DDR4", "size": 32 },
+				{ "slot": "P1_DIMME1", "bank": 3, "vendor": "Samsung", "model": "M393A4K40CB1-CRC", "speed": 2400, "type": "DDR4", "size": 32 },
+				{ "slot": "P1_DIMME2", "bank": 3, "vendor": "Samsung", "model": "M393A4K40CB1-CRC", "speed": 2400, "type": "DDR4", "size": 32 },
+				{ "slot": "P1_DIMMG1", "bank": 4, "vendor": "Samsung", "model": "M393A4K40CB1-CRC", "speed": 2400, "type": "DDR4", "size": 32 },
+				{ "slot": "P1_DIMMG2", "bank": 4, "vendor": "Samsung", "model": "M393A4K40CB1-CRC", "speed": 2400, "type": "DDR4", "size": 32 }
+			]
+		},
+		"zpool": {
+			"cache": 0,
+			"log": 1,
+			"spare": 2,
+			"vdev_n": 3,
+			"vdev_t": "raidz2"
+		}
+	}
+}

--- a/Conch/json-schema/response.yaml
+++ b/Conch/json-schema/response.yaml
@@ -356,6 +356,10 @@ definitions:
       - prefix
       - vendor
       - profile
+      - generation_name
+      - legacy_product_name
+      - sku
+      - specification
     properties:
       id:
         type: string
@@ -369,6 +373,23 @@ definitions:
       vendor:
         type: string
         description: Hardware product vendor name
+      generation_name:
+        anyOf:
+          - type: string
+          - type: null
+      legacy_product_name:
+        anyOf:
+          - type: string
+          - type: null
+      sku:
+        anyOf:
+          - type: string
+          - type: null
+
+      specification:
+        anyOf:
+          - type: string
+          - type: null
       profile:
         type: object
         additionalProperties: false

--- a/Conch/lib/Conch/Class/HardwareProduct.pm
+++ b/Conch/lib/Conch/Class/HardwareProduct.pm
@@ -26,17 +26,29 @@ with 'Conch::Class::Role::ToJson';
 
 =head2 profile
 
+=head2 specification
+
+=head2 sku
+
+=head2 generation_name
+
+=head2 legacy_product_name
+
 =cut
 
 has [
 	qw(
 		id
-		name
 		alias
+		generation_name
+		legacy_product_name
+		name
 		prefix
-		vendor
 		profile
-		)
+		sku
+		specification
+		vendor
+	)
 ];
 
 
@@ -47,12 +59,16 @@ has [
 sub TO_JSON {
 	my $self = shift;
 	{
-		id      => $self->id,
-		name    => $self->name,
-		alias   => $self->alias,
-		prefix  => $self->prefix,
-		vendor  => $self->vendor,
-		profile => $self->profile
+		id                  => $self->id,
+		alias               => $self->alias,
+		generation_name     => $self->generation_name,
+		legacy_product_name => $self->legacy_product_name,
+		name                => $self->name,
+		prefix              => $self->prefix,
+		profile             => $self->profile,
+		sku                 => $self->sku,
+		specification       => $self->specification,
+		vendor              => $self->vendor,
 	};
 }
 

--- a/Conch/lib/Conch/Legacy/Schema/Result/Datacenter.pm
+++ b/Conch/lib/Conch/Legacy/Schema/Result/Datacenter.pm
@@ -67,11 +67,6 @@ __PACKAGE__->table("datacenter");
   data_type: 'text'
   is_nullable: 0
 
-=head2 deactivated
-
-  data_type: 'timestamp with time zone'
-  is_nullable: 1
-
 =head2 created
 
   data_type: 'timestamp with time zone'
@@ -104,8 +99,6 @@ __PACKAGE__->add_columns(
   { data_type => "text", is_nullable => 0 },
   "location",
   { data_type => "text", is_nullable => 0 },
-  "deactivated",
-  { data_type => "timestamp with time zone", is_nullable => 1 },
   "created",
   {
     data_type     => "timestamp with time zone",
@@ -136,21 +129,6 @@ __PACKAGE__->set_primary_key("id");
 
 =head1 RELATIONS
 
-=head2 datacenter_networks
-
-Type: has_many
-
-Related object: L<Conch::Legacy::Schema::Result::DatacenterNetwork>
-
-=cut
-
-__PACKAGE__->has_many(
-  "datacenter_networks",
-  "Conch::Legacy::Schema::Result::DatacenterNetwork",
-  { "foreign.datacenter_id" => "self.id" },
-  { cascade_copy => 0, cascade_delete => 0 },
-);
-
 =head2 datacenter_rooms
 
 Type: has_many
@@ -167,8 +145,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07047 @ 2018-01-29 19:26:35
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:lFLQtVnZDo+cNhzXnCiAGQ
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-06-22 17:47:09
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:b9xeBjXN8apFk03Cd81g1Q
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration
 __PACKAGE__->meta->make_immutable;

--- a/Conch/lib/Conch/Legacy/Schema/Result/DatacenterRackRole.pm
+++ b/Conch/lib/Conch/Legacy/Schema/Result/DatacenterRackRole.pm
@@ -57,6 +57,18 @@ __PACKAGE__->table("datacenter_rack_role");
   data_type: 'integer'
   is_nullable: 0
 
+=head2 created
+
+  data_type: 'timestamp with time zone'
+  default_value: current_timestamp
+  is_nullable: 0
+
+=head2 updated
+
+  data_type: 'timestamp with time zone'
+  default_value: current_timestamp
+  is_nullable: 0
+
 =cut
 
 __PACKAGE__->add_columns(
@@ -71,6 +83,18 @@ __PACKAGE__->add_columns(
   { data_type => "text", is_nullable => 0 },
   "rack_size",
   { data_type => "integer", is_nullable => 0 },
+  "created",
+  {
+    data_type     => "timestamp with time zone",
+    default_value => \"current_timestamp",
+    is_nullable   => 0,
+  },
+  "updated",
+  {
+    data_type     => "timestamp with time zone",
+    default_value => \"current_timestamp",
+    is_nullable   => 0,
+  },
 );
 
 =head1 PRIMARY KEY
@@ -86,6 +110,18 @@ __PACKAGE__->add_columns(
 __PACKAGE__->set_primary_key("id");
 
 =head1 UNIQUE CONSTRAINTS
+
+=head2 C<datacenter_rack_role_name_key>
+
+=over 4
+
+=item * L</name>
+
+=back
+
+=cut
+
+__PACKAGE__->add_unique_constraint("datacenter_rack_role_name_key", ["name"]);
 
 =head2 C<datacenter_rack_role_name_rack_size_key>
 
@@ -122,8 +158,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07047 @ 2018-01-29 19:26:35
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:p8+ZhGz0flzjNuEmuWYVFw
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-06-22 17:47:09
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:i1W7m12iWWr2l5sXh2Uh5g
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration
 __PACKAGE__->meta->make_immutable;

--- a/Conch/lib/Conch/Legacy/Schema/Result/Device.pm
+++ b/Conch/lib/Conch/Legacy/Schema/Result/Device.pm
@@ -58,11 +58,6 @@ __PACKAGE__->table("device");
   is_nullable: 0
   size: 16
 
-=head2 role
-
-  data_type: 'text'
-  is_nullable: 1
-
 =head2 state
 
   data_type: 'text'
@@ -133,6 +128,13 @@ __PACKAGE__->table("device");
   data_type: 'timestamp with time zone'
   is_nullable: 1
 
+=head2 role
+
+  data_type: 'uuid'
+  is_foreign_key: 1
+  is_nullable: 1
+  size: 16
+
 =cut
 
 __PACKAGE__->add_columns(
@@ -142,8 +144,6 @@ __PACKAGE__->add_columns(
   { data_type => "uuid", is_nullable => 1, size => 16 },
   "hardware_product",
   { data_type => "uuid", is_foreign_key => 1, is_nullable => 0, size => 16 },
-  "role",
-  { data_type => "text", is_nullable => 1 },
   "state",
   { data_type => "text", is_nullable => 0 },
   "health",
@@ -180,6 +180,8 @@ __PACKAGE__->add_columns(
   { data_type => "text", is_nullable => 1 },
   "triton_setup",
   { data_type => "timestamp with time zone", is_nullable => 1 },
+  "role",
+  { data_type => "uuid", is_foreign_key => 1, is_nullable => 1, size => 16 },
 );
 
 =head1 PRIMARY KEY
@@ -390,9 +392,59 @@ __PACKAGE__->belongs_to(
   { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
 );
 
+=head2 role
 
-# Created by DBIx::Class::Schema::Loader v0.07047 @ 2018-01-29 19:26:36
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:G166tbrCSikXS3L2cuexqQ
+Type: belongs_to
+
+Related object: L<Conch::Legacy::Schema::Result::DeviceRole>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "role",
+  "Conch::Legacy::Schema::Result::DeviceRole",
+  { id => "role" },
+  {
+    is_deferrable => 0,
+    join_type     => "LEFT",
+    on_delete     => "NO ACTION",
+    on_update     => "NO ACTION",
+  },
+);
+
+=head2 validation_results
+
+Type: has_many
+
+Related object: L<Conch::Legacy::Schema::Result::ValidationResult>
+
+=cut
+
+__PACKAGE__->has_many(
+  "validation_results",
+  "Conch::Legacy::Schema::Result::ValidationResult",
+  { "foreign.device_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
+=head2 validation_states
+
+Type: has_many
+
+Related object: L<Conch::Legacy::Schema::Result::ValidationState>
+
+=cut
+
+__PACKAGE__->has_many(
+  "validation_states",
+  "Conch::Legacy::Schema::Result::ValidationState",
+  { "foreign.device_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
+
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-06-22 17:47:09
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:yslvrRLF4oZiM9y+Aj1f1Q
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration
 __PACKAGE__->meta->make_immutable;

--- a/Conch/lib/Conch/Legacy/Schema/Result/DeviceRole.pm
+++ b/Conch/lib/Conch/Legacy/Schema/Result/DeviceRole.pm
@@ -1,12 +1,12 @@
 use utf8;
-package Conch::Legacy::Schema::Result::DatacenterRoom;
+package Conch::Legacy::Schema::Result::DeviceRole;
 
 # Created by DBIx::Class::Schema::Loader
 # DO NOT MODIFY THE FIRST PART OF THIS FILE
 
 =head1 NAME
 
-Conch::Legacy::Schema::Result::DatacenterRoom
+Conch::Legacy::Schema::Result::DeviceRole
 
 =cut
 
@@ -32,11 +32,11 @@ extends 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("InflateColumn::DateTime", "TimeStamp");
 
-=head1 TABLE: C<datacenter_room>
+=head1 TABLE: C<device_role>
 
 =cut
 
-__PACKAGE__->table("datacenter_room");
+__PACKAGE__->table("device_role");
 
 =head1 ACCESSORS
 
@@ -47,27 +47,17 @@ __PACKAGE__->table("datacenter_room");
   is_nullable: 0
   size: 16
 
-=head2 datacenter
+=head2 description
+
+  data_type: 'text'
+  is_nullable: 1
+
+=head2 hardware_product_id
 
   data_type: 'uuid'
   is_foreign_key: 1
   is_nullable: 0
   size: 16
-
-=head2 az
-
-  data_type: 'text'
-  is_nullable: 0
-
-=head2 alias
-
-  data_type: 'text'
-  is_nullable: 1
-
-=head2 vendor_name
-
-  data_type: 'text'
-  is_nullable: 1
 
 =head2 created
 
@@ -83,6 +73,11 @@ __PACKAGE__->table("datacenter_room");
   is_nullable: 0
   original: {default_value => \"now()"}
 
+=head2 deactivated
+
+  data_type: 'timestamp with time zone'
+  is_nullable: 1
+
 =cut
 
 __PACKAGE__->add_columns(
@@ -93,14 +88,10 @@ __PACKAGE__->add_columns(
     is_nullable => 0,
     size => 16,
   },
-  "datacenter",
+  "description",
+  { data_type => "text", is_nullable => 1 },
+  "hardware_product_id",
   { data_type => "uuid", is_foreign_key => 1, is_nullable => 0, size => 16 },
-  "az",
-  { data_type => "text", is_nullable => 0 },
-  "alias",
-  { data_type => "text", is_nullable => 1 },
-  "vendor_name",
-  { data_type => "text", is_nullable => 1 },
   "created",
   {
     data_type     => "timestamp with time zone",
@@ -115,6 +106,8 @@ __PACKAGE__->add_columns(
     is_nullable   => 0,
     original      => { default_value => \"now()" },
   },
+  "deactivated",
+  { data_type => "timestamp with time zone", is_nullable => 1 },
 );
 
 =head1 PRIMARY KEY
@@ -131,71 +124,56 @@ __PACKAGE__->set_primary_key("id");
 
 =head1 RELATIONS
 
-=head2 datacenter
+=head2 device_role_services
+
+Type: has_many
+
+Related object: L<Conch::Legacy::Schema::Result::DeviceRoleService>
+
+=cut
+
+__PACKAGE__->has_many(
+  "device_role_services",
+  "Conch::Legacy::Schema::Result::DeviceRoleService",
+  { "foreign.role_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
+=head2 devices
+
+Type: has_many
+
+Related object: L<Conch::Legacy::Schema::Result::Device>
+
+=cut
+
+__PACKAGE__->has_many(
+  "devices",
+  "Conch::Legacy::Schema::Result::Device",
+  { "foreign.role" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
+=head2 hardware_product
 
 Type: belongs_to
 
-Related object: L<Conch::Legacy::Schema::Result::Datacenter>
+Related object: L<Conch::Legacy::Schema::Result::HardwareProduct>
 
 =cut
 
 __PACKAGE__->belongs_to(
-  "datacenter",
-  "Conch::Legacy::Schema::Result::Datacenter",
-  { id => "datacenter" },
+  "hardware_product",
+  "Conch::Legacy::Schema::Result::HardwareProduct",
+  { id => "hardware_product_id" },
   { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
-);
-
-=head2 datacenter_racks
-
-Type: has_many
-
-Related object: L<Conch::Legacy::Schema::Result::DatacenterRack>
-
-=cut
-
-__PACKAGE__->has_many(
-  "datacenter_racks",
-  "Conch::Legacy::Schema::Result::DatacenterRack",
-  { "foreign.datacenter_room_id" => "self.id" },
-  { cascade_copy => 0, cascade_delete => 0 },
-);
-
-=head2 workspace_datacenter_rooms
-
-Type: has_many
-
-Related object: L<Conch::Legacy::Schema::Result::WorkspaceDatacenterRoom>
-
-=cut
-
-__PACKAGE__->has_many(
-  "workspace_datacenter_rooms",
-  "Conch::Legacy::Schema::Result::WorkspaceDatacenterRoom",
-  { "foreign.datacenter_room_id" => "self.id" },
-  { cascade_copy => 0, cascade_delete => 0 },
 );
 
 
 # Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-06-22 17:47:09
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:8P3ZBj9o//sEN+iuQB550A
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:+SelsNhIqOrraERbTBrQEw
+
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration
 __PACKAGE__->meta->make_immutable;
 1;
-
-
-__DATA__
-
-=pod
-
-=head1 LICENSING
-
-Copyright Joyent, Inc.
-
-This Source Code Form is subject to the terms of the Mozilla Public License, 
-v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
-one at http://mozilla.org/MPL/2.0/.
-
-=cut
-

--- a/Conch/lib/Conch/Legacy/Schema/Result/DeviceRoleService.pm
+++ b/Conch/lib/Conch/Legacy/Schema/Result/DeviceRoleService.pm
@@ -1,0 +1,124 @@
+use utf8;
+package Conch::Legacy::Schema::Result::DeviceRoleService;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+=head1 NAME
+
+Conch::Legacy::Schema::Result::DeviceRoleService
+
+=cut
+
+use strict;
+use warnings;
+
+use Moose;
+use MooseX::NonMoose;
+use MooseX::MarkAsMethods autoclean => 1;
+extends 'DBIx::Class::Core';
+
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<DBIx::Class::InflateColumn::DateTime>
+
+=item * L<DBIx::Class::TimeStamp>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("InflateColumn::DateTime", "TimeStamp");
+
+=head1 TABLE: C<device_role_services>
+
+=cut
+
+__PACKAGE__->table("device_role_services");
+
+=head1 ACCESSORS
+
+=head2 role_id
+
+  data_type: 'uuid'
+  is_foreign_key: 1
+  is_nullable: 0
+  size: 16
+
+=head2 service_id
+
+  data_type: 'uuid'
+  is_foreign_key: 1
+  is_nullable: 0
+  size: 16
+
+=cut
+
+__PACKAGE__->add_columns(
+  "role_id",
+  { data_type => "uuid", is_foreign_key => 1, is_nullable => 0, size => 16 },
+  "service_id",
+  { data_type => "uuid", is_foreign_key => 1, is_nullable => 0, size => 16 },
+);
+
+=head1 UNIQUE CONSTRAINTS
+
+=head2 C<device_role_services_role_id_service_id_key>
+
+=over 4
+
+=item * L</role_id>
+
+=item * L</service_id>
+
+=back
+
+=cut
+
+__PACKAGE__->add_unique_constraint(
+  "device_role_services_role_id_service_id_key",
+  ["role_id", "service_id"],
+);
+
+=head1 RELATIONS
+
+=head2 role
+
+Type: belongs_to
+
+Related object: L<Conch::Legacy::Schema::Result::DeviceRole>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "role",
+  "Conch::Legacy::Schema::Result::DeviceRole",
+  { id => "role_id" },
+  { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
+);
+
+=head2 service
+
+Type: belongs_to
+
+Related object: L<Conch::Legacy::Schema::Result::DeviceService>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "service",
+  "Conch::Legacy::Schema::Result::DeviceService",
+  { id => "service_id" },
+  { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
+);
+
+
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-06-22 17:47:09
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:HF5Ekw0VCHpRktV6wmMXlQ
+
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+__PACKAGE__->meta->make_immutable;
+1;

--- a/Conch/lib/Conch/Legacy/Schema/Result/DeviceService.pm
+++ b/Conch/lib/Conch/Legacy/Schema/Result/DeviceService.pm
@@ -1,12 +1,12 @@
 use utf8;
-package Conch::Legacy::Schema::Result::DatacenterRoom;
+package Conch::Legacy::Schema::Result::DeviceService;
 
 # Created by DBIx::Class::Schema::Loader
 # DO NOT MODIFY THE FIRST PART OF THIS FILE
 
 =head1 NAME
 
-Conch::Legacy::Schema::Result::DatacenterRoom
+Conch::Legacy::Schema::Result::DeviceService
 
 =cut
 
@@ -32,11 +32,11 @@ extends 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("InflateColumn::DateTime", "TimeStamp");
 
-=head1 TABLE: C<datacenter_room>
+=head1 TABLE: C<device_service>
 
 =cut
 
-__PACKAGE__->table("datacenter_room");
+__PACKAGE__->table("device_service");
 
 =head1 ACCESSORS
 
@@ -47,27 +47,10 @@ __PACKAGE__->table("datacenter_room");
   is_nullable: 0
   size: 16
 
-=head2 datacenter
-
-  data_type: 'uuid'
-  is_foreign_key: 1
-  is_nullable: 0
-  size: 16
-
-=head2 az
+=head2 name
 
   data_type: 'text'
   is_nullable: 0
-
-=head2 alias
-
-  data_type: 'text'
-  is_nullable: 1
-
-=head2 vendor_name
-
-  data_type: 'text'
-  is_nullable: 1
 
 =head2 created
 
@@ -93,14 +76,8 @@ __PACKAGE__->add_columns(
     is_nullable => 0,
     size => 16,
   },
-  "datacenter",
-  { data_type => "uuid", is_foreign_key => 1, is_nullable => 0, size => 16 },
-  "az",
+  "name",
   { data_type => "text", is_nullable => 0 },
-  "alias",
-  { data_type => "text", is_nullable => 1 },
-  "vendor_name",
-  { data_type => "text", is_nullable => 1 },
   "created",
   {
     data_type     => "timestamp with time zone",
@@ -129,73 +106,42 @@ __PACKAGE__->add_columns(
 
 __PACKAGE__->set_primary_key("id");
 
+=head1 UNIQUE CONSTRAINTS
+
+=head2 C<device_service_name_key>
+
+=over 4
+
+=item * L</name>
+
+=back
+
+=cut
+
+__PACKAGE__->add_unique_constraint("device_service_name_key", ["name"]);
+
 =head1 RELATIONS
 
-=head2 datacenter
-
-Type: belongs_to
-
-Related object: L<Conch::Legacy::Schema::Result::Datacenter>
-
-=cut
-
-__PACKAGE__->belongs_to(
-  "datacenter",
-  "Conch::Legacy::Schema::Result::Datacenter",
-  { id => "datacenter" },
-  { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
-);
-
-=head2 datacenter_racks
+=head2 device_role_services
 
 Type: has_many
 
-Related object: L<Conch::Legacy::Schema::Result::DatacenterRack>
+Related object: L<Conch::Legacy::Schema::Result::DeviceRoleService>
 
 =cut
 
 __PACKAGE__->has_many(
-  "datacenter_racks",
-  "Conch::Legacy::Schema::Result::DatacenterRack",
-  { "foreign.datacenter_room_id" => "self.id" },
-  { cascade_copy => 0, cascade_delete => 0 },
-);
-
-=head2 workspace_datacenter_rooms
-
-Type: has_many
-
-Related object: L<Conch::Legacy::Schema::Result::WorkspaceDatacenterRoom>
-
-=cut
-
-__PACKAGE__->has_many(
-  "workspace_datacenter_rooms",
-  "Conch::Legacy::Schema::Result::WorkspaceDatacenterRoom",
-  { "foreign.datacenter_room_id" => "self.id" },
+  "device_role_services",
+  "Conch::Legacy::Schema::Result::DeviceRoleService",
+  { "foreign.service_id" => "self.id" },
   { cascade_copy => 0, cascade_delete => 0 },
 );
 
 
 # Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-06-22 17:47:09
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:8P3ZBj9o//sEN+iuQB550A
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:x0Yb3LXJRX/fz5cWS0kfAQ
+
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration
 __PACKAGE__->meta->make_immutable;
 1;
-
-
-__DATA__
-
-=pod
-
-=head1 LICENSING
-
-Copyright Joyent, Inc.
-
-This Source Code Form is subject to the terms of the Mozilla Public License, 
-v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
-one at http://mozilla.org/MPL/2.0/.
-
-=cut
-

--- a/Conch/lib/Conch/Legacy/Schema/Result/HardwareProduct.pm
+++ b/Conch/lib/Conch/Legacy/Schema/Result/HardwareProduct.pm
@@ -88,6 +88,26 @@ __PACKAGE__->table("hardware_product");
   is_nullable: 0
   original: {default_value => \"now()"}
 
+=head2 specification
+
+  data_type: 'jsonb'
+  is_nullable: 1
+
+=head2 sku
+
+  data_type: 'text'
+  is_nullable: 1
+
+=head2 generation_name
+
+  data_type: 'text'
+  is_nullable: 1
+
+=head2 legacy_product_name
+
+  data_type: 'text'
+  is_nullable: 1
+
 =cut
 
 __PACKAGE__->add_columns(
@@ -122,6 +142,14 @@ __PACKAGE__->add_columns(
     is_nullable   => 0,
     original      => { default_value => \"now()" },
   },
+  "specification",
+  { data_type => "jsonb", is_nullable => 1 },
+  "sku",
+  { data_type => "text", is_nullable => 1 },
+  "generation_name",
+  { data_type => "text", is_nullable => 1 },
+  "legacy_product_name",
+  { data_type => "text", is_nullable => 1 },
 );
 
 =head1 PRIMARY KEY
@@ -138,18 +166,6 @@ __PACKAGE__->set_primary_key("id");
 
 =head1 UNIQUE CONSTRAINTS
 
-=head2 C<hardware_product_alias_key>
-
-=over 4
-
-=item * L</alias>
-
-=back
-
-=cut
-
-__PACKAGE__->add_unique_constraint("hardware_product_alias_key", ["alias"]);
-
 =head2 C<hardware_product_name_key>
 
 =over 4
@@ -161,6 +177,18 @@ __PACKAGE__->add_unique_constraint("hardware_product_alias_key", ["alias"]);
 =cut
 
 __PACKAGE__->add_unique_constraint("hardware_product_name_key", ["name"]);
+
+=head2 C<hardware_product_sku_key>
+
+=over 4
+
+=item * L</sku>
+
+=back
+
+=cut
+
+__PACKAGE__->add_unique_constraint("hardware_product_sku_key", ["sku"]);
 
 =head1 RELATIONS
 
@@ -176,6 +204,21 @@ __PACKAGE__->has_many(
   "datacenter_rack_layouts",
   "Conch::Legacy::Schema::Result::DatacenterRackLayout",
   { "foreign.product_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
+=head2 device_roles
+
+Type: has_many
+
+Related object: L<Conch::Legacy::Schema::Result::DeviceRole>
+
+=cut
+
+__PACKAGE__->has_many(
+  "device_roles",
+  "Conch::Legacy::Schema::Result::DeviceRole",
+  { "foreign.hardware_product_id" => "self.id" },
   { cascade_copy => 0, cascade_delete => 0 },
 );
 
@@ -209,6 +252,21 @@ __PACKAGE__->might_have(
   { cascade_copy => 0, cascade_delete => 0 },
 );
 
+=head2 validation_results
+
+Type: has_many
+
+Related object: L<Conch::Legacy::Schema::Result::ValidationResult>
+
+=cut
+
+__PACKAGE__->has_many(
+  "validation_results",
+  "Conch::Legacy::Schema::Result::ValidationResult",
+  { "foreign.hardware_product_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
 =head2 vendor
 
 Type: belongs_to
@@ -225,8 +283,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07047 @ 2018-01-29 19:26:36
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:tBTjekeVLloh24CSITGpJA
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-06-22 17:47:09
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:UsXVcEzEU4u56W6BSxuKHg
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration
 __PACKAGE__->meta->make_immutable;

--- a/Conch/lib/Conch/Legacy/Schema/Result/UserAccount.pm
+++ b/Conch/lib/Conch/Legacy/Schema/Result/UserAccount.pm
@@ -156,6 +156,21 @@ __PACKAGE__->has_many(
   { cascade_copy => 0, cascade_delete => 0 },
 );
 
+=head2 user_session_tokens
+
+Type: has_many
+
+Related object: L<Conch::Legacy::Schema::Result::UserSessionToken>
+
+=cut
+
+__PACKAGE__->has_many(
+  "user_session_tokens",
+  "Conch::Legacy::Schema::Result::UserSessionToken",
+  { "foreign.user_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
 =head2 user_settings
 
 Type: has_many
@@ -187,8 +202,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07047 @ 2018-01-29 19:26:36
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:EfrL/m+rKeau+rZe9p0c2A
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-06-22 17:47:09
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:Ged9YWlka8O1ewsyGFQfZQ
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration
 __PACKAGE__->meta->make_immutable;

--- a/Conch/lib/Conch/Legacy/Schema/Result/UserSessionToken.pm
+++ b/Conch/lib/Conch/Legacy/Schema/Result/UserSessionToken.pm
@@ -1,0 +1,109 @@
+use utf8;
+package Conch::Legacy::Schema::Result::UserSessionToken;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+=head1 NAME
+
+Conch::Legacy::Schema::Result::UserSessionToken
+
+=cut
+
+use strict;
+use warnings;
+
+use Moose;
+use MooseX::NonMoose;
+use MooseX::MarkAsMethods autoclean => 1;
+extends 'DBIx::Class::Core';
+
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<DBIx::Class::InflateColumn::DateTime>
+
+=item * L<DBIx::Class::TimeStamp>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("InflateColumn::DateTime", "TimeStamp");
+
+=head1 TABLE: C<user_session_token>
+
+=cut
+
+__PACKAGE__->table("user_session_token");
+
+=head1 ACCESSORS
+
+=head2 user_id
+
+  data_type: 'uuid'
+  is_foreign_key: 1
+  is_nullable: 0
+  size: 16
+
+=head2 token_hash
+
+  data_type: 'bytea'
+  is_nullable: 0
+
+=head2 expires
+
+  data_type: 'timestamp with time zone'
+  is_nullable: 0
+
+=cut
+
+__PACKAGE__->add_columns(
+  "user_id",
+  { data_type => "uuid", is_foreign_key => 1, is_nullable => 0, size => 16 },
+  "token_hash",
+  { data_type => "bytea", is_nullable => 0 },
+  "expires",
+  { data_type => "timestamp with time zone", is_nullable => 0 },
+);
+
+=head1 PRIMARY KEY
+
+=over 4
+
+=item * L</user_id>
+
+=item * L</token_hash>
+
+=back
+
+=cut
+
+__PACKAGE__->set_primary_key("user_id", "token_hash");
+
+=head1 RELATIONS
+
+=head2 user
+
+Type: belongs_to
+
+Related object: L<Conch::Legacy::Schema::Result::UserAccount>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "user",
+  "Conch::Legacy::Schema::Result::UserAccount",
+  { id => "user_id" },
+  { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
+);
+
+
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-06-22 17:47:09
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:/JI32lu5jnSyeATRkP9mJA
+
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+__PACKAGE__->meta->make_immutable;
+1;

--- a/Conch/lib/Conch/Legacy/Schema/Result/Validation.pm
+++ b/Conch/lib/Conch/Legacy/Schema/Result/Validation.pm
@@ -1,0 +1,206 @@
+use utf8;
+package Conch::Legacy::Schema::Result::Validation;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+=head1 NAME
+
+Conch::Legacy::Schema::Result::Validation
+
+=cut
+
+use strict;
+use warnings;
+
+use Moose;
+use MooseX::NonMoose;
+use MooseX::MarkAsMethods autoclean => 1;
+extends 'DBIx::Class::Core';
+
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<DBIx::Class::InflateColumn::DateTime>
+
+=item * L<DBIx::Class::TimeStamp>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("InflateColumn::DateTime", "TimeStamp");
+
+=head1 TABLE: C<validation>
+
+=cut
+
+__PACKAGE__->table("validation");
+
+=head1 ACCESSORS
+
+=head2 id
+
+  data_type: 'uuid'
+  default_value: uuid_generate_v4()
+  is_nullable: 0
+  size: 16
+
+=head2 name
+
+  data_type: 'text'
+  is_nullable: 0
+
+=head2 version
+
+  data_type: 'integer'
+  is_nullable: 0
+
+=head2 description
+
+  data_type: 'text'
+  is_nullable: 0
+
+=head2 module
+
+  data_type: 'text'
+  is_nullable: 0
+
+=head2 created
+
+  data_type: 'timestamp with time zone'
+  default_value: current_timestamp
+  is_nullable: 0
+  original: {default_value => \"now()"}
+
+=head2 updated
+
+  data_type: 'timestamp with time zone'
+  default_value: current_timestamp
+  is_nullable: 0
+  original: {default_value => \"now()"}
+
+=head2 deactivated
+
+  data_type: 'timestamp with time zone'
+  is_nullable: 1
+
+=cut
+
+__PACKAGE__->add_columns(
+  "id",
+  {
+    data_type => "uuid",
+    default_value => \"uuid_generate_v4()",
+    is_nullable => 0,
+    size => 16,
+  },
+  "name",
+  { data_type => "text", is_nullable => 0 },
+  "version",
+  { data_type => "integer", is_nullable => 0 },
+  "description",
+  { data_type => "text", is_nullable => 0 },
+  "module",
+  { data_type => "text", is_nullable => 0 },
+  "created",
+  {
+    data_type     => "timestamp with time zone",
+    default_value => \"current_timestamp",
+    is_nullable   => 0,
+    original      => { default_value => \"now()" },
+  },
+  "updated",
+  {
+    data_type     => "timestamp with time zone",
+    default_value => \"current_timestamp",
+    is_nullable   => 0,
+    original      => { default_value => \"now()" },
+  },
+  "deactivated",
+  { data_type => "timestamp with time zone", is_nullable => 1 },
+);
+
+=head1 PRIMARY KEY
+
+=over 4
+
+=item * L</id>
+
+=back
+
+=cut
+
+__PACKAGE__->set_primary_key("id");
+
+=head1 UNIQUE CONSTRAINTS
+
+=head2 C<validation_name_version_key>
+
+=over 4
+
+=item * L</name>
+
+=item * L</version>
+
+=back
+
+=cut
+
+__PACKAGE__->add_unique_constraint("validation_name_version_key", ["name", "version"]);
+
+=head1 RELATIONS
+
+=head2 validation_plan_members
+
+Type: has_many
+
+Related object: L<Conch::Legacy::Schema::Result::ValidationPlanMember>
+
+=cut
+
+__PACKAGE__->has_many(
+  "validation_plan_members",
+  "Conch::Legacy::Schema::Result::ValidationPlanMember",
+  { "foreign.validation_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
+=head2 validation_results
+
+Type: has_many
+
+Related object: L<Conch::Legacy::Schema::Result::ValidationResult>
+
+=cut
+
+__PACKAGE__->has_many(
+  "validation_results",
+  "Conch::Legacy::Schema::Result::ValidationResult",
+  { "foreign.validation_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
+=head2 validation_plans
+
+Type: many_to_many
+
+Composing rels: L</validation_plan_members> -> validation_plan
+
+=cut
+
+__PACKAGE__->many_to_many(
+  "validation_plans",
+  "validation_plan_members",
+  "validation_plan",
+);
+
+
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-06-22 17:47:09
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:c5ZgQ3tlp3cv50iah2et9w
+
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+__PACKAGE__->meta->make_immutable;
+1;

--- a/Conch/lib/Conch/Legacy/Schema/Result/ValidationPlan.pm
+++ b/Conch/lib/Conch/Legacy/Schema/Result/ValidationPlan.pm
@@ -1,0 +1,158 @@
+use utf8;
+package Conch::Legacy::Schema::Result::ValidationPlan;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+=head1 NAME
+
+Conch::Legacy::Schema::Result::ValidationPlan
+
+=cut
+
+use strict;
+use warnings;
+
+use Moose;
+use MooseX::NonMoose;
+use MooseX::MarkAsMethods autoclean => 1;
+extends 'DBIx::Class::Core';
+
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<DBIx::Class::InflateColumn::DateTime>
+
+=item * L<DBIx::Class::TimeStamp>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("InflateColumn::DateTime", "TimeStamp");
+
+=head1 TABLE: C<validation_plan>
+
+=cut
+
+__PACKAGE__->table("validation_plan");
+
+=head1 ACCESSORS
+
+=head2 id
+
+  data_type: 'uuid'
+  default_value: uuid_generate_v4()
+  is_nullable: 0
+  size: 16
+
+=head2 name
+
+  data_type: 'text'
+  is_nullable: 0
+
+=head2 description
+
+  data_type: 'text'
+  is_nullable: 0
+
+=head2 created
+
+  data_type: 'timestamp with time zone'
+  default_value: current_timestamp
+  is_nullable: 0
+  original: {default_value => \"now()"}
+
+=head2 deactivated
+
+  data_type: 'timestamp with time zone'
+  is_nullable: 1
+
+=cut
+
+__PACKAGE__->add_columns(
+  "id",
+  {
+    data_type => "uuid",
+    default_value => \"uuid_generate_v4()",
+    is_nullable => 0,
+    size => 16,
+  },
+  "name",
+  { data_type => "text", is_nullable => 0 },
+  "description",
+  { data_type => "text", is_nullable => 0 },
+  "created",
+  {
+    data_type     => "timestamp with time zone",
+    default_value => \"current_timestamp",
+    is_nullable   => 0,
+    original      => { default_value => \"now()" },
+  },
+  "deactivated",
+  { data_type => "timestamp with time zone", is_nullable => 1 },
+);
+
+=head1 PRIMARY KEY
+
+=over 4
+
+=item * L</id>
+
+=back
+
+=cut
+
+__PACKAGE__->set_primary_key("id");
+
+=head1 RELATIONS
+
+=head2 validation_plan_members
+
+Type: has_many
+
+Related object: L<Conch::Legacy::Schema::Result::ValidationPlanMember>
+
+=cut
+
+__PACKAGE__->has_many(
+  "validation_plan_members",
+  "Conch::Legacy::Schema::Result::ValidationPlanMember",
+  { "foreign.validation_plan_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
+=head2 validation_states
+
+Type: has_many
+
+Related object: L<Conch::Legacy::Schema::Result::ValidationState>
+
+=cut
+
+__PACKAGE__->has_many(
+  "validation_states",
+  "Conch::Legacy::Schema::Result::ValidationState",
+  { "foreign.validation_plan_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
+=head2 validations
+
+Type: many_to_many
+
+Composing rels: L</validation_plan_members> -> validation
+
+=cut
+
+__PACKAGE__->many_to_many("validations", "validation_plan_members", "validation");
+
+
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-06-22 17:47:09
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:Y6DzNfoHR9R95+QkwkO7Tg
+
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+__PACKAGE__->meta->make_immutable;
+1;

--- a/Conch/lib/Conch/Legacy/Schema/Result/ValidationPlanMember.pm
+++ b/Conch/lib/Conch/Legacy/Schema/Result/ValidationPlanMember.pm
@@ -1,0 +1,119 @@
+use utf8;
+package Conch::Legacy::Schema::Result::ValidationPlanMember;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+=head1 NAME
+
+Conch::Legacy::Schema::Result::ValidationPlanMember
+
+=cut
+
+use strict;
+use warnings;
+
+use Moose;
+use MooseX::NonMoose;
+use MooseX::MarkAsMethods autoclean => 1;
+extends 'DBIx::Class::Core';
+
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<DBIx::Class::InflateColumn::DateTime>
+
+=item * L<DBIx::Class::TimeStamp>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("InflateColumn::DateTime", "TimeStamp");
+
+=head1 TABLE: C<validation_plan_member>
+
+=cut
+
+__PACKAGE__->table("validation_plan_member");
+
+=head1 ACCESSORS
+
+=head2 validation_id
+
+  data_type: 'uuid'
+  is_foreign_key: 1
+  is_nullable: 0
+  size: 16
+
+=head2 validation_plan_id
+
+  data_type: 'uuid'
+  is_foreign_key: 1
+  is_nullable: 0
+  size: 16
+
+=cut
+
+__PACKAGE__->add_columns(
+  "validation_id",
+  { data_type => "uuid", is_foreign_key => 1, is_nullable => 0, size => 16 },
+  "validation_plan_id",
+  { data_type => "uuid", is_foreign_key => 1, is_nullable => 0, size => 16 },
+);
+
+=head1 PRIMARY KEY
+
+=over 4
+
+=item * L</validation_id>
+
+=item * L</validation_plan_id>
+
+=back
+
+=cut
+
+__PACKAGE__->set_primary_key("validation_id", "validation_plan_id");
+
+=head1 RELATIONS
+
+=head2 validation
+
+Type: belongs_to
+
+Related object: L<Conch::Legacy::Schema::Result::Validation>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "validation",
+  "Conch::Legacy::Schema::Result::Validation",
+  { id => "validation_id" },
+  { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
+);
+
+=head2 validation_plan
+
+Type: belongs_to
+
+Related object: L<Conch::Legacy::Schema::Result::ValidationPlan>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "validation_plan",
+  "Conch::Legacy::Schema::Result::ValidationPlan",
+  { id => "validation_plan_id" },
+  { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
+);
+
+
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-06-22 17:47:09
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:GyANVxgsZKyhv4Ve4RxrZA
+
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+__PACKAGE__->meta->make_immutable;
+1;

--- a/Conch/lib/Conch/Legacy/Schema/Result/ValidationResult.pm
+++ b/Conch/lib/Conch/Legacy/Schema/Result/ValidationResult.pm
@@ -1,0 +1,247 @@
+use utf8;
+package Conch::Legacy::Schema::Result::ValidationResult;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+=head1 NAME
+
+Conch::Legacy::Schema::Result::ValidationResult
+
+=cut
+
+use strict;
+use warnings;
+
+use Moose;
+use MooseX::NonMoose;
+use MooseX::MarkAsMethods autoclean => 1;
+extends 'DBIx::Class::Core';
+
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<DBIx::Class::InflateColumn::DateTime>
+
+=item * L<DBIx::Class::TimeStamp>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("InflateColumn::DateTime", "TimeStamp");
+
+=head1 TABLE: C<validation_result>
+
+=cut
+
+__PACKAGE__->table("validation_result");
+
+=head1 ACCESSORS
+
+=head2 id
+
+  data_type: 'uuid'
+  default_value: uuid_generate_v4()
+  is_nullable: 0
+  size: 16
+
+=head2 device_id
+
+  data_type: 'text'
+  is_foreign_key: 1
+  is_nullable: 0
+
+=head2 hardware_product_id
+
+  data_type: 'uuid'
+  is_foreign_key: 1
+  is_nullable: 0
+  size: 16
+
+=head2 validation_id
+
+  data_type: 'uuid'
+  is_foreign_key: 1
+  is_nullable: 0
+  size: 16
+
+=head2 message
+
+  data_type: 'text'
+  is_nullable: 0
+
+=head2 hint
+
+  data_type: 'text'
+  is_nullable: 1
+
+=head2 status
+
+  data_type: 'enum'
+  extra: {custom_type_name => "validation_status_enum",list => ["error","pass","fail","processing"]}
+  is_nullable: 0
+
+=head2 category
+
+  data_type: 'text'
+  is_nullable: 0
+
+=head2 component_id
+
+  data_type: 'text'
+  is_nullable: 1
+
+=head2 result_order
+
+  data_type: 'integer'
+  is_nullable: 0
+
+=head2 created
+
+  data_type: 'timestamp with time zone'
+  default_value: current_timestamp
+  is_nullable: 0
+  original: {default_value => \"now()"}
+
+=cut
+
+__PACKAGE__->add_columns(
+  "id",
+  {
+    data_type => "uuid",
+    default_value => \"uuid_generate_v4()",
+    is_nullable => 0,
+    size => 16,
+  },
+  "device_id",
+  { data_type => "text", is_foreign_key => 1, is_nullable => 0 },
+  "hardware_product_id",
+  { data_type => "uuid", is_foreign_key => 1, is_nullable => 0, size => 16 },
+  "validation_id",
+  { data_type => "uuid", is_foreign_key => 1, is_nullable => 0, size => 16 },
+  "message",
+  { data_type => "text", is_nullable => 0 },
+  "hint",
+  { data_type => "text", is_nullable => 1 },
+  "status",
+  {
+    data_type => "enum",
+    extra => {
+      custom_type_name => "validation_status_enum",
+      list => ["error", "pass", "fail", "processing"],
+    },
+    is_nullable => 0,
+  },
+  "category",
+  { data_type => "text", is_nullable => 0 },
+  "component_id",
+  { data_type => "text", is_nullable => 1 },
+  "result_order",
+  { data_type => "integer", is_nullable => 0 },
+  "created",
+  {
+    data_type     => "timestamp with time zone",
+    default_value => \"current_timestamp",
+    is_nullable   => 0,
+    original      => { default_value => \"now()" },
+  },
+);
+
+=head1 PRIMARY KEY
+
+=over 4
+
+=item * L</id>
+
+=back
+
+=cut
+
+__PACKAGE__->set_primary_key("id");
+
+=head1 RELATIONS
+
+=head2 device
+
+Type: belongs_to
+
+Related object: L<Conch::Legacy::Schema::Result::Device>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "device",
+  "Conch::Legacy::Schema::Result::Device",
+  { id => "device_id" },
+  { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
+);
+
+=head2 hardware_product
+
+Type: belongs_to
+
+Related object: L<Conch::Legacy::Schema::Result::HardwareProduct>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "hardware_product",
+  "Conch::Legacy::Schema::Result::HardwareProduct",
+  { id => "hardware_product_id" },
+  { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
+);
+
+=head2 validation
+
+Type: belongs_to
+
+Related object: L<Conch::Legacy::Schema::Result::Validation>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "validation",
+  "Conch::Legacy::Schema::Result::Validation",
+  { id => "validation_id" },
+  { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
+);
+
+=head2 validation_state_members
+
+Type: has_many
+
+Related object: L<Conch::Legacy::Schema::Result::ValidationStateMember>
+
+=cut
+
+__PACKAGE__->has_many(
+  "validation_state_members",
+  "Conch::Legacy::Schema::Result::ValidationStateMember",
+  { "foreign.validation_result_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
+=head2 validation_states
+
+Type: many_to_many
+
+Composing rels: L</validation_state_members> -> validation_state
+
+=cut
+
+__PACKAGE__->many_to_many(
+  "validation_states",
+  "validation_state_members",
+  "validation_state",
+);
+
+
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-06-22 17:47:09
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:zlpGnnl3sE1qkMfVbuzE0g
+
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+__PACKAGE__->meta->make_immutable;
+1;

--- a/Conch/lib/Conch/Legacy/Schema/Result/ValidationState.pm
+++ b/Conch/lib/Conch/Legacy/Schema/Result/ValidationState.pm
@@ -1,0 +1,197 @@
+use utf8;
+package Conch::Legacy::Schema::Result::ValidationState;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+=head1 NAME
+
+Conch::Legacy::Schema::Result::ValidationState
+
+=cut
+
+use strict;
+use warnings;
+
+use Moose;
+use MooseX::NonMoose;
+use MooseX::MarkAsMethods autoclean => 1;
+extends 'DBIx::Class::Core';
+
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<DBIx::Class::InflateColumn::DateTime>
+
+=item * L<DBIx::Class::TimeStamp>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("InflateColumn::DateTime", "TimeStamp");
+
+=head1 TABLE: C<validation_state>
+
+=cut
+
+__PACKAGE__->table("validation_state");
+
+=head1 ACCESSORS
+
+=head2 id
+
+  data_type: 'uuid'
+  default_value: uuid_generate_v4()
+  is_nullable: 0
+  size: 16
+
+=head2 device_id
+
+  data_type: 'text'
+  is_foreign_key: 1
+  is_nullable: 0
+
+=head2 validation_plan_id
+
+  data_type: 'uuid'
+  is_foreign_key: 1
+  is_nullable: 0
+  size: 16
+
+=head2 created
+
+  data_type: 'timestamp with time zone'
+  default_value: current_timestamp
+  is_nullable: 0
+  original: {default_value => \"now()"}
+
+=head2 status
+
+  data_type: 'enum'
+  default_value: 'processing'
+  extra: {custom_type_name => "validation_status_enum",list => ["error","pass","fail","processing"]}
+  is_nullable: 0
+
+=head2 completed
+
+  data_type: 'timestamp with time zone'
+  is_nullable: 1
+
+=cut
+
+__PACKAGE__->add_columns(
+  "id",
+  {
+    data_type => "uuid",
+    default_value => \"uuid_generate_v4()",
+    is_nullable => 0,
+    size => 16,
+  },
+  "device_id",
+  { data_type => "text", is_foreign_key => 1, is_nullable => 0 },
+  "validation_plan_id",
+  { data_type => "uuid", is_foreign_key => 1, is_nullable => 0, size => 16 },
+  "created",
+  {
+    data_type     => "timestamp with time zone",
+    default_value => \"current_timestamp",
+    is_nullable   => 0,
+    original      => { default_value => \"now()" },
+  },
+  "status",
+  {
+    data_type => "enum",
+    default_value => "processing",
+    extra => {
+      custom_type_name => "validation_status_enum",
+      list => ["error", "pass", "fail", "processing"],
+    },
+    is_nullable => 0,
+  },
+  "completed",
+  { data_type => "timestamp with time zone", is_nullable => 1 },
+);
+
+=head1 PRIMARY KEY
+
+=over 4
+
+=item * L</id>
+
+=back
+
+=cut
+
+__PACKAGE__->set_primary_key("id");
+
+=head1 RELATIONS
+
+=head2 device
+
+Type: belongs_to
+
+Related object: L<Conch::Legacy::Schema::Result::Device>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "device",
+  "Conch::Legacy::Schema::Result::Device",
+  { id => "device_id" },
+  { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
+);
+
+=head2 validation_plan
+
+Type: belongs_to
+
+Related object: L<Conch::Legacy::Schema::Result::ValidationPlan>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "validation_plan",
+  "Conch::Legacy::Schema::Result::ValidationPlan",
+  { id => "validation_plan_id" },
+  { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
+);
+
+=head2 validation_state_members
+
+Type: has_many
+
+Related object: L<Conch::Legacy::Schema::Result::ValidationStateMember>
+
+=cut
+
+__PACKAGE__->has_many(
+  "validation_state_members",
+  "Conch::Legacy::Schema::Result::ValidationStateMember",
+  { "foreign.validation_state_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
+=head2 validation_results
+
+Type: many_to_many
+
+Composing rels: L</validation_state_members> -> validation_result
+
+=cut
+
+__PACKAGE__->many_to_many(
+  "validation_results",
+  "validation_state_members",
+  "validation_result",
+);
+
+
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-06-22 17:47:09
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:btP1qV5Ppg7pqKflB85q4w
+
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+__PACKAGE__->meta->make_immutable;
+1;

--- a/Conch/lib/Conch/Legacy/Schema/Result/ValidationStateMember.pm
+++ b/Conch/lib/Conch/Legacy/Schema/Result/ValidationStateMember.pm
@@ -1,0 +1,119 @@
+use utf8;
+package Conch::Legacy::Schema::Result::ValidationStateMember;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+=head1 NAME
+
+Conch::Legacy::Schema::Result::ValidationStateMember
+
+=cut
+
+use strict;
+use warnings;
+
+use Moose;
+use MooseX::NonMoose;
+use MooseX::MarkAsMethods autoclean => 1;
+extends 'DBIx::Class::Core';
+
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<DBIx::Class::InflateColumn::DateTime>
+
+=item * L<DBIx::Class::TimeStamp>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("InflateColumn::DateTime", "TimeStamp");
+
+=head1 TABLE: C<validation_state_member>
+
+=cut
+
+__PACKAGE__->table("validation_state_member");
+
+=head1 ACCESSORS
+
+=head2 validation_state_id
+
+  data_type: 'uuid'
+  is_foreign_key: 1
+  is_nullable: 0
+  size: 16
+
+=head2 validation_result_id
+
+  data_type: 'uuid'
+  is_foreign_key: 1
+  is_nullable: 0
+  size: 16
+
+=cut
+
+__PACKAGE__->add_columns(
+  "validation_state_id",
+  { data_type => "uuid", is_foreign_key => 1, is_nullable => 0, size => 16 },
+  "validation_result_id",
+  { data_type => "uuid", is_foreign_key => 1, is_nullable => 0, size => 16 },
+);
+
+=head1 PRIMARY KEY
+
+=over 4
+
+=item * L</validation_state_id>
+
+=item * L</validation_result_id>
+
+=back
+
+=cut
+
+__PACKAGE__->set_primary_key("validation_state_id", "validation_result_id");
+
+=head1 RELATIONS
+
+=head2 validation_result
+
+Type: belongs_to
+
+Related object: L<Conch::Legacy::Schema::Result::ValidationResult>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "validation_result",
+  "Conch::Legacy::Schema::Result::ValidationResult",
+  { id => "validation_result_id" },
+  { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
+);
+
+=head2 validation_state
+
+Type: belongs_to
+
+Related object: L<Conch::Legacy::Schema::Result::ValidationState>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "validation_state",
+  "Conch::Legacy::Schema::Result::ValidationState",
+  { id => "validation_state_id" },
+  { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
+);
+
+
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-06-22 17:47:09
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:tMKlZwRXOypO3xCSLJ8wug
+
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+__PACKAGE__->meta->make_immutable;
+1;

--- a/Conch/lib/Conch/Model/DeviceLocation.pm
+++ b/Conch/lib/Conch/Model/DeviceLocation.pm
@@ -45,7 +45,12 @@ sub lookup ( $self, $device_id ) {
       hw_product.name   AS hw_product_name,
       hw_product.alias  AS hw_product_alias,
       hw_product.prefix AS hw_product_prefix,
-      hw_product.vendor AS hw_product_vendor
+      hw_product.vendor AS hw_product_vendor,
+
+      hw_product.specification       AS hw_product_specification,
+      hw_product.sku                 AS hw_sku,
+      hw_product.generation_name     AS hw_generation_name,
+      hw_product.legacy_product_name AS hw_legacy_product_name
 
     FROM device_location loc
     JOIN datacenter_rack rack
@@ -87,11 +92,15 @@ sub _build_device_location ($loc) {
 		vendor_name => $loc->{room_vendor_name},
 	);
 	my $hardware_product = HardwareProduct->new(
-		id     => $loc->{hw_product_id},
-		name   => $loc->{hw_product_name},
-		alias  => $loc->{hw_product_alias},
-		prefix => $loc->{hw_product_prefix},
-		vendor => $loc->{hw_product_vendor}
+		id                  => $loc->{hw_product_id},
+		name                => $loc->{hw_product_name},
+		alias               => $loc->{hw_product_alias},
+		prefix              => $loc->{hw_product_prefix},
+		vendor              => $loc->{hw_product_vendor},
+		specification       => $loc->{hw_product_specification},
+		sku                 => $loc->{hw_sku},
+		generation_name     => $loc->{hw_generation_name},
+		legacy_product_name => $loc->{legacy_product_name},
 	);
 	return DeviceLocation->new(
 		rack_unit               => $loc->{location_rack_unit},

--- a/Conch/lib/Conch/Model/HardwareProduct.pm
+++ b/Conch/lib/Conch/Model/HardwareProduct.pm
@@ -23,6 +23,10 @@ my $fields = q{
   hw_product.name AS hw_product_name,
   hw_product.alias AS hw_product_alias,
   hw_product.prefix AS hw_product_prefix,
+  hw_product.specification as hw_specification,
+  hw_product.sku as hw_sku,
+  hw_product.generation_name as hw_generation_name,
+  hw_product.legacy_product_name as hw_legacy_product_name,
   vendor.name AS hw_product_vendor,
 
   hw_profile.id AS hw_profile_id,
@@ -172,12 +176,16 @@ sub _build_hardware_product ($hw) {
 	);
 
 	return HardwareProduct->new(
-		id      => $hw->{hw_product_id},
-		name    => $hw->{hw_product_name},
-		alias   => $hw->{hw_product_alias},
-		prefix  => $hw->{hw_product_prefix},
-		vendor  => $hw->{hw_product_vendor},
-		profile => $hw_profile
+		id                  => $hw->{hw_product_id},
+		alias               => $hw->{hw_product_alias},
+		generation_name     => $hw->{hw_generation_name},
+		legacy_product_name => $hw->{hw_legacy_product_name},
+		name                => $hw->{hw_product_name},
+		prefix              => $hw->{hw_product_prefix},
+		sku                 => $hw->{hw_sku},
+		specification       => $hw->{hw_specification},
+		vendor              => $hw->{hw_product_vendor},
+		profile             => $hw_profile
 	);
 }
 

--- a/sql/migrations/0035-hw-prod-spec-sku.sql
+++ b/sql/migrations/0035-hw-prod-spec-sku.sql
@@ -1,0 +1,69 @@
+-- name: manta-storage-v3-512g-36-8tb (Conch specific)
+-- sku: 600-0025-001
+-- generation_name: Joyent-S10G4
+-- legacy_product_name: The old-style Product Name (JSP/JCP-XXXX), still needed
+-- for mapping purposes with the Dells.
+
+SELECT run_migration(35, $$
+	alter table hardware_product add column specification jsonb;
+
+	alter table hardware_product drop constraint hardware_product_alias_key;
+
+	alter table hardware_product add column sku text;
+	alter table hardware_product add unique(sku);
+
+	alter table hardware_product add column generation_name text;
+
+	alter table hardware_product add column legacy_product_name text;
+
+	update hardware_product set legacy_product_name = name;
+
+	-- Shrimp Mk III
+	update hardware_product set name = 'smci-storage-v3-512g-36-sata-8tb' where name = 'Joyent-Storage-Platform-7001';
+	update hardware_product set sku = '600-0025-001' where name = 'smci-storage-v3-512g-36-sata-8tb';
+	update hardware_product set generation_name = 'Joyent-S10G4' where name = 'smci-storage-v3-512g-36-sata-8tb';
+
+	-- Shrimp Mk III.5
+	update hardware_product set name = 'smci-storage-v3-256g-36-sata-12tb' where name = 'Joyent-Storage-Platform-4201';
+	update hardware_product set sku = 'Joyent-Storage-Platform-4201' where name = 'smci-storage-v3-256g-36-sata-12tb';
+	update hardware_product set generation_name = 'Joyent-S10G5' where name = 'smci-storage-v3-256g-36-sata-12tb';
+
+	-- CERES
+	-- We don't currently provide a SKU or generation for CERES systems.
+	update hardware_product set name = 'dell-2u-compute-v1-256g-10-12tb' where name = 'Joyent-Compute-Platform-3211';
+
+	-- HAr2
+	update hardware_product set name = 'smci-2u-compute-512g-16-sata-1tb' where name = 'Joyent-Compute-Platform-3101';
+	update hardware_product set sku = '600-0027-001' where name = 'smci-2u-compute-512g-16-sata-1tb';
+	update hardware_product set generation_name = 'Joyent-M12G4' where name = 'smci-2u-compute-512g-16-sata-1tb';
+
+	-- HA
+	update hardware_product set name = 'dell-2u-compute-512g-16-sata-1tb' where name = 'Joyent-Compute-Platform-3301';
+	update hardware_product set sku = '600-0023-001' where name = 'dell-2u-compute-512g-16-sata-1tb';
+	update hardware_product set generation_name = 'Joyent-M11G4' where name = 'dell-2u-compute-512g-16-sata-1tb';
+
+	-- HC
+	update hardware_product set name = 'dell-2u-compute-256g-16-ssd-1tb' where name = 'Joyent-Compute-Platform-3302';
+	update hardware_product set sku = '600-0024-001' where name = 'dell-2u-compute-256g-16-ssd-1tb';
+	update hardware_product set generation_name = 'Joyent-M11G4' where name = 'dell-2u-compute-256g-16-ssd-1tb';
+
+	-- HB
+	update hardware_product set name = 'smci-4u-storage-256g-36-sata-8tb' where name = 'Joyent-Storage-Platform-7201';
+	update hardware_product set sku = '600-0028-001' where name = 'smci-4u-storage-256g-36-sata-8tb';
+	update hardware_product set generation_name = 'Joyent-S10G4' where name = 'smci-4u-storage-256g-36-sata-8tb';
+
+	-- JA
+	update hardware_product set name = 'smci-2u-compute-512g-16-sas-1tb' where name = 'Joyent-Compute-Platform-4101';
+	update hardware_product set sku = '600-0032-001' where name = 'smci-2u-compute-512g-16-sas-1tb';
+	update hardware_product set generation_name = 'Joyent-M12G5' where name = 'smci-2u-compute-512g-16-sas-1tb';
+
+	-- JB
+	update hardware_product set name = 'smci-2u-storage-256g-12-sas-12tb' where name = 'Joyent-Compute-Platform-4201';
+	update hardware_product set sku = '600-0033-001' where name = 'smci-2u-storage-256g-12-sas-12tb';
+	update hardware_product set generation_name = 'Joyent-S12G5' where name = 'smci-2u-storage-256g-12-sas-12tb';
+
+	-- JC (12)
+	update hardware_product set name = 'smci-2u-compute-512g-12-ssd-2tb' where name = 'Joyent-Compute-Platform-4102';
+	update hardware_product set sku = '600-0034-001' where name = 'smci-2u-compute-512g-12-ssd-2tb';
+	update hardware_product set generation_name = 'Joyent-M12G5' where name = 'smci-2u-compute-512g-12-ssd-2tb';
+$$);


### PR DESCRIPTION
We are changing how we manage product names and SKUs internally.

We would also like a more expressive way of defining hardware product specifications (currently stored in the hardware_product_profile table.)

This migration adds a `sku` column, and changes the current `name` column to `product_name`. So we end up with:

* name: smci-4u-storage-v3-512g-36-sata-8tb (Conch specific)
* sku: 600-0025-001
* generation_name: Joyent-S10G4

An example of what we end up with:

```
conch=# select name,alias,sku,generation_name from hardware_product where sku is not null;
             name              |         alias         |     sku      | generation_name 
-------------------------------+-----------------------+--------------+--------------
 smci-4u-storage-v3-512g-36-sata-8tb  | Mantis Shrimp MkIII   | 600-0025-001 | Joyent-S10G4
 smci-4u-storage-v3-256g-36-sata-10tb | Mantis Shrimp MkIII   | 600-0025-002 | Joyent-S10G4
 smci-4u-storage-v3-256g-36-sata-12tb | Mantis Shrimp MkIII.5 | 600-0036-001 | Joyent-S10G5
(3 rows)
```

- [x] Update schema via migration (bdha)
- [x] Update contents via migration (bdha)
- [ ] Update code to reflect new columns (sungo)