### PR TITLE
Fix hardware product lookups.

### DIFF
--- a/Conch/lib/Conch/Controller/DeviceReport.pm
+++ b/Conch/lib/Conch/Controller/DeviceReport.pm
@@ -26,8 +26,18 @@ sub process ($c) {
 	my $raw_report = $c->req->body;
 
 	my $hw_product_name = $device_report->{product_name};
-	my $maybe_hw =
-		Conch::Model::HardwareProduct->lookup_by_name($hw_product_name);
+	my $maybe_hw;
+
+	if ( $device_report->{device_type}
+		&& $device_report->{device_type} eq "switch" )
+	{
+		$maybe_hw =
+			Conch::Model::HardwareProduct->lookup_by_name($hw_product_name);
+	} else {
+		my $hw_sku = $device_report->{sku};
+		$maybe_hw = Conch::Model::HardwareProduct->lookup_by_sku($hw_sku);
+	}
+
 
 	unless ($maybe_hw) {
 		return $c->status(

--- a/Conch/lib/Conch/Controller/DeviceReport.pm
+++ b/Conch/lib/Conch/Controller/DeviceReport.pm
@@ -25,27 +25,27 @@ sub process ($c) {
 	my $device_report = $c->validate_input('DeviceReport') or return;
 	my $raw_report = $c->req->body;
 
-	my $hw_product_name = $device_report->{product_name};
 	my $maybe_hw;
 
 	if ( $device_report->{device_type}
 		&& $device_report->{device_type} eq "switch" )
 	{
-		$maybe_hw =
-			Conch::Model::HardwareProduct->lookup_by_name($hw_product_name);
-	} else {
-		my $hw_sku = $device_report->{sku};
-		$maybe_hw = Conch::Model::HardwareProduct->lookup_by_sku($hw_sku);
-	}
-
-
-	unless ($maybe_hw) {
-		return $c->status(
-			409,
-			{
-				error => "Hardware Product '$hw_product_name' does not exist."
-			}
+		$maybe_hw = Conch::Model::HardwareProduct->lookup_by_name(
+			$device_report->{product_name}
 		);
+		return $c->status(409, { 
+			error => "Hardware product name '".$device_report->{product_name}."' does not exist"
+		}) unless ($maybe_hw);
+
+	} else {
+		$maybe_hw = Conch::Model::HardwareProduct->lookup_by_sku(
+			$device_report->{sku}
+		);
+
+		return $c->status(409, { 
+			error => "Hardware product SKU '".$device_report->{sku}."' does not exist"
+		}) unless ($maybe_hw);
+
 	}
 
 	# Use the old device report recording and device validation code for now.

--- a/Conch/lib/Conch/Legacy/Control/DeviceReport.pm
+++ b/Conch/lib/Conch/Legacy/Control/DeviceReport.pm
@@ -45,12 +45,22 @@ Record device report and device details from the report
 =cut
 sub record_device_report {
 	my ( $schema, $dr, $raw_report ) = @_;
-	my $hw = $schema->resultset('HardwareProduct')->find(
+	if ($dr->{device_type} && $dr->{device_type} eq "switch")
+	{
+		$hw = $schema->resultset('HardwareProduct')->find(
 		{
 			name => $dr->{product_name}
 		}
-	);
-	$hw or die $log->critical("Product $dr->{product_name} not found");
+		);
+		$hw or die $log->critical("Product $dr->{product_name} not found");
+	} else {
+		$hw = $schema->resultset('HardwareProduct')->find(
+		{
+			sku => $dr->{sku}
+		}
+		);
+		$hw or die $log->critical("Product $dr->{sku} not found");
+	}
 
 	my $hw_profile = $hw->hardware_product_profile;
 	$hw_profile

--- a/Conch/lib/Conch/Legacy/Control/DeviceReport.pm
+++ b/Conch/lib/Conch/Legacy/Control/DeviceReport.pm
@@ -45,6 +45,9 @@ Record device report and device details from the report
 =cut
 sub record_device_report {
 	my ( $schema, $dr, $raw_report ) = @_;
+
+	my $hw;
+
 	if ($dr->{device_type} && $dr->{device_type} eq "switch")
 	{
 		$hw = $schema->resultset('HardwareProduct')->find(

--- a/Conch/lib/Conch/Model/HardwareProduct.pm
+++ b/Conch/lib/Conch/Model/HardwareProduct.pm
@@ -19,46 +19,46 @@ use Conch::Pg;
 # Query fields used to build HardwareProduct, which depends on
 # HardwareProductProfile and ZpoolProfile
 my $fields = q{
-  hw_product.id AS hw_product_id,
-  hw_product.name AS hw_product_name,
-  hw_product.alias AS hw_product_alias,
-  hw_product.prefix AS hw_product_prefix,
-  hw_product.specification as hw_specification,
-  hw_product.sku as hw_sku,
-  hw_product.generation_name as hw_generation_name,
-  hw_product.legacy_product_name as hw_legacy_product_name,
-  vendor.name AS hw_product_vendor,
+	  hw_product.id AS hw_product_id,
+	  hw_product.name AS hw_product_name,
+	  hw_product.alias AS hw_product_alias,
+	  hw_product.prefix AS hw_product_prefix,
+	  hw_product.specification as hw_specification,
+	  hw_product.sku as hw_sku,
+	  hw_product.generation_name as hw_generation_name,
+	  hw_product.legacy_product_name as hw_legacy_product_name,
+	  vendor.name AS hw_product_vendor,
 
-  hw_profile.id AS hw_profile_id,
-  hw_profile.bios_firmware AS hw_profile_bios_firmware,
-  hw_profile.cpu_num AS hw_profile_cpu_num,
-  hw_profile.cpu_type AS hw_profile_cpu_type,
-  hw_profile.dimms_num AS hw_profile_dimms_num,
-  hw_profile.hba_firmware AS hw_profile_hba_firmware,
-  hw_profile.nics_num AS hw_profile_nics_num,
-  hw_profile.psu_total AS hw_profile_psu_total,
-  hw_profile.purpose AS hw_profile_purpose,
-  hw_profile.rack_unit AS hw_profile_rack_unit,
-  hw_profile.ram_total AS hw_profile_ram_total,
-  hw_profile.sas_num AS hw_profile_sas_num,
-  hw_profile.sas_size AS hw_profile_sas_size,
-  hw_profile.sas_slots AS hw_profile_sas_slots,
-  hw_profile.sata_num AS hw_profile_sata_num,
-  hw_profile.sata_size AS hw_profile_sata_size,
-  hw_profile.sata_slots AS hw_profile_sata_slots,
-  hw_profile.ssd_num AS hw_profile_ssd_num,
-  hw_profile.ssd_size AS hw_profile_ssd_size,
-  hw_profile.ssd_slots AS hw_profile_ssd_slots,
-  hw_profile.usb_num AS hw_profile_usb_num,
+	  hw_profile.id AS hw_profile_id,
+	  hw_profile.bios_firmware AS hw_profile_bios_firmware,
+	  hw_profile.cpu_num AS hw_profile_cpu_num,
+	  hw_profile.cpu_type AS hw_profile_cpu_type,
+	  hw_profile.dimms_num AS hw_profile_dimms_num,
+	  hw_profile.hba_firmware AS hw_profile_hba_firmware,
+	  hw_profile.nics_num AS hw_profile_nics_num,
+	  hw_profile.psu_total AS hw_profile_psu_total,
+	  hw_profile.purpose AS hw_profile_purpose,
+	  hw_profile.rack_unit AS hw_profile_rack_unit,
+	  hw_profile.ram_total AS hw_profile_ram_total,
+	  hw_profile.sas_num AS hw_profile_sas_num,
+	  hw_profile.sas_size AS hw_profile_sas_size,
+	  hw_profile.sas_slots AS hw_profile_sas_slots,
+	  hw_profile.sata_num AS hw_profile_sata_num,
+	  hw_profile.sata_size AS hw_profile_sata_size,
+	  hw_profile.sata_slots AS hw_profile_sata_slots,
+	  hw_profile.ssd_num AS hw_profile_ssd_num,
+	  hw_profile.ssd_size AS hw_profile_ssd_size,
+	  hw_profile.ssd_slots AS hw_profile_ssd_slots,
+	  hw_profile.usb_num AS hw_profile_usb_num,
 
-  zpool.id AS zpool_id,
-  zpool.name AS zpool_name,
-  zpool.cache AS zpool_cache,
-  zpool.log AS zpool_log,
-  zpool.disk_per AS zpool_disk_per,
-  zpool.spare AS zpool_spare,
-  zpool.vdev_n AS zpool_vdev_n,
-  zpool.vdev_t AS zpool_vdev_t
+	  zpool.id AS zpool_id,
+	  zpool.name AS zpool_name,
+	  zpool.cache AS zpool_cache,
+	  zpool.log AS zpool_log,
+	  zpool.disk_per AS zpool_disk_per,
+	  zpool.spare AS zpool_spare,
+	  zpool.vdev_n AS zpool_vdev_n,
+	  zpool.vdev_t AS zpool_vdev_t
 };
 
 =head2 list
@@ -68,19 +68,17 @@ profiles.
 
 =cut
 sub list ($self) {
-	my $hw_product_hashes = Conch::Pg->new->db->query(
-		qq{
-      SELECT $fields
-      FROM hardware_product hw_product
-      JOIN hardware_product_profile hw_profile
-        ON hw_product.id = hw_profile.product_id
-      JOIN hardware_vendor vendor
-        ON hw_product.vendor = vendor.id
-      LEFT JOIN zpool_profile zpool
-        ON hw_profile.zpool_id = zpool.id
-      WHERE hw_product.deactivated IS NULL
-    }
-	)->hashes->to_array;
+	my $hw_product_hashes = Conch::Pg->new->db->query(qq{
+		  SELECT $fields
+		  FROM hardware_product hw_product
+		  JOIN hardware_product_profile hw_profile
+			ON hw_product.id = hw_profile.product_id
+		  JOIN hardware_vendor vendor
+			ON hw_product.vendor = vendor.id
+		  LEFT JOIN zpool_profile zpool
+			ON hw_profile.zpool_id = zpool.id
+		  WHERE hw_product.deactivated IS NULL
+	})->hashes->to_array;
 	return [ map { _build_hardware_product($_) } @$hw_product_hashes ];
 }
 
@@ -91,20 +89,18 @@ profile by ID.
 
 =cut
 sub lookup ( $self, $hw_id ) {
-	my $ret = Conch::Pg->new->db->query(
-		qq{
-        SELECT $fields
-        FROM hardware_product hw_product
-        JOIN hardware_product_profile hw_profile
-          ON hw_product.id = hw_profile.product_id
-        JOIN hardware_vendor vendor
-          ON hw_product.vendor = vendor.id
-        LEFT JOIN zpool_profile zpool
-          ON hw_profile.zpool_id = zpool.id
-        WHERE hw_product.deactivated IS NULL
-          AND hw_product.id = ?
-      }, $hw_id
-	)->hash;
+	my $ret = Conch::Pg->new->db->query(qq{
+		SELECT $fields
+		FROM hardware_product hw_product
+		JOIN hardware_product_profile hw_profile
+		  ON hw_product.id = hw_profile.product_id
+		JOIN hardware_vendor vendor
+		  ON hw_product.vendor = vendor.id
+		LEFT JOIN zpool_profile zpool
+		  ON hw_profile.zpool_id = zpool.id
+		WHERE hw_product.deactivated IS NULL
+		  AND hw_product.id = ?
+      }, $hw_id)->hash;
 	return undef unless $ret;
 	return _build_hardware_product($ret);
 }
@@ -116,20 +112,18 @@ profile by the hardware product name.
 
 =cut
 sub lookup_by_name ( $self, $name ) {
-	my $ret = Conch::Pg->new->db->query(
-		qq{
-        SELECT $fields
-        FROM hardware_product hw_product
-        JOIN hardware_product_profile hw_profile
-          ON hw_product.id = hw_profile.product_id
-        JOIN hardware_vendor vendor
-          ON hw_product.vendor = vendor.id
-        LEFT JOIN zpool_profile zpool
-          ON hw_profile.zpool_id = zpool.id
-        WHERE hw_product.deactivated IS NULL
-          AND hw_product.name = ?
-      }, $name
-	)->hash;
+	my $ret = Conch::Pg->new->db->query(qq{
+		SELECT $fields
+		FROM hardware_product hw_product
+		JOIN hardware_product_profile hw_profile
+		  ON hw_product.id = hw_profile.product_id
+		JOIN hardware_vendor vendor
+		  ON hw_product.vendor = vendor.id
+		LEFT JOIN zpool_profile zpool
+		  ON hw_profile.zpool_id = zpool.id
+		WHERE hw_product.deactivated IS NULL
+		  AND hw_product.name = ?
+	}, $name)->hash;
 	return undef unless $ret;
 
 	return _build_hardware_product($ret);
@@ -142,23 +136,21 @@ profile by the hardware SKU.
 
 =cut
 sub lookup_by_sku ( $self, $sku ) {
-	my $ret = Conch::Pg->new->db->query(
-		qq{
-        SELECT $fields
-        FROM hardware_product hw_product
-        JOIN hardware_product_profile hw_profile
-          ON hw_product.id = hw_profile.product_id
-        JOIN hardware_vendor vendor
-          ON hw_product.vendor = vendor.id
-        LEFT JOIN zpool_profile zpool
-          ON hw_profile.zpool_id = zpool.id
-        WHERE hw_product.deactivated IS NULL
-          AND hw_product.sku = ?
-      }, $sku
-	)->hash;
-return undef unless $ret;
+	my $ret = Conch::Pg->new->db->query(qq{
+		SELECT $fields
+		FROM hardware_product hw_product
+		JOIN hardware_product_profile hw_profile
+		  ON hw_product.id = hw_profile.product_id
+		JOIN hardware_vendor vendor
+		  ON hw_product.vendor = vendor.id
+		LEFT JOIN zpool_profile zpool
+		  ON hw_profile.zpool_id = zpool.id
+		WHERE hw_product.deactivated IS NULL
+		  AND hw_product.sku = ?
+      }, $sku)->hash;
+	return undef unless $ret;
 
-return _build_hardware_product($ret);
+	return _build_hardware_product($ret);
 }
 
 sub _build_hardware_product ($hw) {

--- a/Conch/lib/Conch/Model/HardwareProduct.pm
+++ b/Conch/lib/Conch/Model/HardwareProduct.pm
@@ -135,6 +135,32 @@ sub lookup_by_name ( $self, $name ) {
 	return _build_hardware_product($ret);
 }
 
+=head2 lookup_by_sku
+
+Look up a hardware product and associated hardware product
+profile by the hardware SKU.
+
+=cut
+sub lookup_by_sku ( $self, $sku ) {
+	my $ret = Conch::Pg->new->db->query(
+		qq{
+        SELECT $fields
+        FROM hardware_product hw_product
+        JOIN hardware_product_profile hw_profile
+          ON hw_product.id = hw_profile.product_id
+        JOIN hardware_vendor vendor
+          ON hw_product.vendor = vendor.id
+        LEFT JOIN zpool_profile zpool
+          ON hw_profile.zpool_id = zpool.id
+        WHERE hw_product.deactivated IS NULL
+          AND hw_product.sku = ?
+      }, $sku
+	)->hash;
+return undef unless $ret;
+
+return _build_hardware_product($ret);
+}
+
 sub _build_hardware_product ($hw) {
 
 	my $zpool_profile =

--- a/Conch/lib/Conch/Validation.pm
+++ b/Conch/lib/Conch/Validation.pm
@@ -342,6 +342,34 @@ sub hardware_product_name ($self) {
 	return $self->{_hardware_product}->name;
 }
 
+=head2 hardware_product_generation
+
+Get the expected hardware product generation for the device under validation.
+
+	if ($self->hardware_product_generation eq 'Joyent-123') {...}
+
+=cut
+
+sub hardware_product_name ($self) {
+	$self->die( "Validation must have an expected hardware product", level => 2 )
+		unless $self->{_hardware_product};
+	return $self->{_hardware_product}->generation_name;
+}
+
+=head2 hardware_product_sku
+
+Get the expected hardware product SKU for the device under validation.
+
+	if ($self->hardware_product_sku eq 'Joyent-123') {...}
+
+=cut
+
+sub hardware_product_name ($self) {
+	$self->die( "Validation must have an expected hardware product", level => 2 )
+		unless $self->{_hardware_product};
+	return $self->{_hardware_product}->sku;
+}
+
 =head2 hardware_product_vendor
 
 Get the expected hardware product vendor name for the device under validation.

--- a/Conch/lib/Conch/Validation.pm
+++ b/Conch/lib/Conch/Validation.pm
@@ -350,7 +350,7 @@ Get the expected hardware product generation for the device under validation.
 
 =cut
 
-sub hardware_product_name ($self) {
+sub hardware_product_generation ($self) {
 	$self->die( "Validation must have an expected hardware product", level => 2 )
 		unless $self->{_hardware_product};
 	return $self->{_hardware_product}->generation_name;
@@ -364,7 +364,7 @@ Get the expected hardware product SKU for the device under validation.
 
 =cut
 
-sub hardware_product_name ($self) {
+sub hardware_product_sku ($self) {
 	$self->die( "Validation must have an expected hardware product", level => 2 )
 		unless $self->{_hardware_product};
 	return $self->{_hardware_product}->sku;

--- a/Conch/t/integration/00_only_1_user_loaded.t
+++ b/Conch/t/integration/00_only_1_user_loaded.t
@@ -288,7 +288,7 @@ subtest 'Device Report' => sub {
 	my $report =
 		io->file('t/integration/resource/passing-device-report.json')->slurp;
 	$t->post_ok( '/device/TEST', { 'Content-Type' => 'application/json' }, $report )->status_is(409)
-		->json_like( '/error', qr/Hardware Product '.+' does not exist/ );
+		->json_like( '/error', qr/Hardware product SKU '.+' does not exist/ );
 
 	$t->post_ok( '/device/TEST', json => { serial_number => 'TEST' } )
 		->status_is(400)->json_like( '/error', qr/Missing property/ );

--- a/Conch/t/integration/01_hardware_products_loaded.t
+++ b/Conch/t/integration/01_hardware_products_loaded.t
@@ -71,7 +71,7 @@ subtest 'Device Report' => sub {
 	my $report =
 		io->file('t/integration/resource/passing-device-report.json')->slurp;
 	$t->post_ok( '/device/TEST', { 'Content-Type' => 'application/json' }, $report )->status_is(409)
-		->json_like( '/error', qr/Hardware Product '.+' does not exist/ );
+		->json_like( '/error', qr/Hardware product SKU '.+' does not exist/ );
 };
 
 subtest 'Hardware Product' => sub {

--- a/Conch/t/integration/02_hardware_product_profiles_loaded.t
+++ b/Conch/t/integration/02_hardware_product_profiles_loaded.t
@@ -90,7 +90,7 @@ subtest 'Hardware Product' => sub {
 	is_deeply(
 		\@hardware_product_names,
 		[
-			'Joyent-Compute-Platform', 'Joyent-Storage-Platform',
+			'2-ssds-1-cpu', '65-ssds-2-cpu',
 			'Switch'
 		]
 	);

--- a/Conch/t/integration/03_zpool_profiles_loaded.t
+++ b/Conch/t/integration/03_zpool_profiles_loaded.t
@@ -93,19 +93,19 @@ subtest 'Hardware Product' => sub {
 	is_deeply(
 		\@hardware_product_names,
 		[
-			'Joyent-Compute-Platform', 'Joyent-Storage-Platform',
+			'2-ssds-1-cpu', '65-ssds-2-cpu',
 			'Switch'
 		]
 	);
 	ok(
 		defined(
-			$hardware_product_hash{'Joyent-Compute-Platform'}->{profile}->{zpool}
+			$hardware_product_hash{'2-ssds-1-cpu'}->{profile}->{zpool}
 		),
 		'Compute has zpool profile'
 	);
 	ok(
 		defined(
-			$hardware_product_hash{'Joyent-Storage-Platform'}->{profile}->{zpool}
+			$hardware_product_hash{'65-ssds-2-cpu'}->{profile}->{zpool}
 		),
 		'Storage has zpool profile'
 	);

--- a/Conch/t/integration/resource/passing-device-report.json
+++ b/Conch/t/integration/resource/passing-device-report.json
@@ -324,7 +324,8 @@
   },
   "state": "ONLINE",
   "serial_number": "TEST",
-  "product_name": "Joyent-Compute-Platform",
+  "product_name": "65-ssds-2-cpu",
+  "sku": "550-552-003",
   "relay": { "serial": "deadbeef" },
   "system_uuid": "4C4C4544-0035-4D10-8032-B4C04F4E4432"
 }

--- a/sql/test/00-hardware.sql
+++ b/sql/test/00-hardware.sql
@@ -1,11 +1,11 @@
 INSERT INTO hardware_vendor (name) VALUES ('DellBell');
 INSERT INTO hardware_vendor (name) VALUES ('SuperDuperMicro');
 
-INSERT INTO hardware_product (name, alias, prefix, vendor)
-       VALUES ( 'Switch', 'Farce 10', 'F10', ( SELECT id FROM hardware_vendor WHERE name = 'DellBell' ) );
+INSERT INTO hardware_product (name, alias, prefix, vendor, legacy_product_name)
+       VALUES ( 'Switch', 'Farce 10', 'F10', ( SELECT id FROM hardware_vendor WHERE name = 'DellBell' ), 'FuerzaDiaz' );
 
-INSERT INTO hardware_product (name, alias, prefix, vendor)
-       VALUES ( 'Joyent-Compute-Platform', 'Test Compute', 'HA', ( SELECT id FROM hardware_vendor WHERE name = 'DellBell' ) );
+INSERT INTO hardware_product (name, alias, prefix, vendor, sku, generation_name, legacy_product_name)
+       VALUES ( '2-ssds-1-cpu', 'Test Compute', 'HA', ( SELECT id FROM hardware_vendor WHERE name = 'DellBell' ), '550-551-001', 'Joyent-G1', 'Joyent-Compute-Platform' );
 
-INSERT INTO hardware_product (name, alias, prefix, vendor)
-       VALUES ( 'Joyent-Storage-Platform', 'Test Storage', 'MS', ( SELECT id FROM hardware_vendor WHERE name = 'SuperDuperMicro' ) );
+INSERT INTO hardware_product (name, alias, prefix, vendor, sku, generation_name, legacy_product_name)
+       VALUES ( '65-ssds-2-cpu', 'Test Storage', 'MS', ( SELECT id FROM hardware_vendor WHERE name = 'SuperDuperMicro' ), '550-552-003', 'Joyent-S1', 'Joyent-Storage-Platform' );

--- a/sql/test/01-hardware-profiles.sql
+++ b/sql/test/01-hardware-profiles.sql
@@ -8,7 +8,7 @@ INSERT INTO hardware_product_profile ( product_id, purpose, bios_firmware, cpu_n
 INSERT INTO hardware_product_profile ( product_id, purpose, bios_firmware, cpu_num, cpu_type,
             dimms_num, ram_total, nics_num, sas_num, sas_size, ssd_num, ssd_size, ssd_slots, psu_total,
             rack_unit, usb_num)
-       VALUES (  ( SELECT id FROM hardware_product WHERE name = 'Joyent-Storage-Platform' ),
+       VALUES (  ( SELECT id FROM hardware_product WHERE name = '65-ssds-2-cpu' ),
             'Manta Object Store', 'American Megatrends Inc. 2.0a', 2, 'Intel(R) Xeon(R) CPU E5-2690 v4 @ 2.60GHz',
             16, 512, 7, 35, 7452.04, 1, 93.16, '0', 2, 4, 1
        );
@@ -16,7 +16,7 @@ INSERT INTO hardware_product_profile ( product_id, purpose, bios_firmware, cpu_n
 INSERT INTO hardware_product_profile ( product_id, purpose, bios_firmware, cpu_num, cpu_type,
             dimms_num, ram_total, nics_num, sas_num, sas_size, ssd_num, ssd_size, ssd_slots, psu_total,
             rack_unit, usb_num )
-      VALUES (  ( SELECT id FROM hardware_product WHERE name = 'Joyent-Compute-Platform' ),
+      VALUES (  ( SELECT id FROM hardware_product WHERE name = '2-ssds-1-cpu' ),
             'General Compute', 'Dell Inc. 2.2.5', 2, 'Intel(R) Xeon(R) CPU E5-2690 v4 @ 2.60GHz',
             16, 256, 7, 15, 1117.81, 1, 93.16, '0', 2, 2, 1
        );

--- a/sql/test/02-zpool-profiles.sql
+++ b/sql/test/02-zpool-profiles.sql
@@ -1,9 +1,9 @@
 
 INSERT INTO zpool_profile (name, vdev_t, vdev_n, disk_per, spare, log, cache)
-       VALUES ( 'Joyent-Compute-Platform', 'mirror', 7, 2, 1, 1, 0 );
+       VALUES ( '2-ssds-1-cpu', 'mirror', 7, 2, 1, 1, 0 );
 
 INSERT INTO zpool_profile (name, vdev_t, vdev_n, disk_per, spare, log, cache)
-       VALUES ( 'Joyent-Storage-Platform', 'raidz2', 3, 11, 2, 1, 0 );
+       VALUES ( '65-ssds-2-cpu', 'raidz2', 3, 11, 2, 1, 0 );
 
 UPDATE hardware_product_profile
     SET zpool_id =

--- a/sql/test/02-zpool-profiles.sql
+++ b/sql/test/02-zpool-profiles.sql
@@ -7,13 +7,13 @@ INSERT INTO zpool_profile (name, vdev_t, vdev_n, disk_per, spare, log, cache)
 
 UPDATE hardware_product_profile
     SET zpool_id =
-        ( SELECT id FROM zpool_profile WHERE name = 'Joyent-Compute-Platform' )
+        ( SELECT id FROM zpool_profile WHERE name = '2-ssds-1-cpu' )
     WHERE product_id =
-        ( SELECT id FROM hardware_product WHERE name = 'Joyent-Compute-Platform' );
+        ( SELECT id FROM hardware_product WHERE name = '2-ssds-1-cpu' );
 
 UPDATE hardware_product_profile
     SET zpool_id =
-        ( SELECT id FROM zpool_profile WHERE name = 'Joyent-Storage-Platform' )
+        ( SELECT id FROM zpool_profile WHERE name = '65-ssds-2-cpu' )
     WHERE product_id =
-        ( SELECT id FROM hardware_product WHERE name = 'Joyent-Storage-Platform' );
+        ( SELECT id FROM hardware_product WHERE name = '65-ssds-2-cpu' );
 

--- a/sql/test/03-test-datacenter.sql
+++ b/sql/test/03-test-datacenter.sql
@@ -16,13 +16,20 @@ INSERT INTO datacenter_rack (datacenter_room_id, name, role)
 INSERT INTO datacenter_rack_layout (rack_id, product_id, ru_start)
     VALUES (
         ( SELECT id FROM datacenter_rack WHERE name = 'Test Rack' ),
-        ( SELECT id FROM hardware_product WHERE name = 'Joyent-Compute-Platform'),
+        ( SELECT id FROM hardware_product WHERE name = '2-ssds-1-cpu'),
         1
     );
 
 INSERT INTO datacenter_rack_layout (rack_id, product_id, ru_start)
     VALUES (
         ( SELECT id FROM datacenter_rack WHERE name = 'Test Rack' ),
-        ( SELECT id FROM hardware_product WHERE name = 'Joyent-Compute-Platform'),
+        ( SELECT id FROM hardware_product WHERE name = '2-ssds-1-cpu'),
         3
+    );
+
+INSERT INTO datacenter_rack_layout (rack_id, product_id, ru_start)
+    VALUES (
+        ( SELECT id FROM datacenter_rack WHERE name = 'Test Rack' ),
+        ( SELECT id FROM hardware_product WHERE name = '65-ssds-2-cpu'),
+        7
     );


### PR DESCRIPTION
Due to the recent changes in hardware product naming, we need to modify how we do validations based on the device type.

If we're a switch, we continue on as we have been.
If we're a server, we need to use the SKU or the generation_name depending on what kind of data the reporter is sending up.
In the future, we'll want to further normalize this -- or add multiple validations for each field. This is a bit of a crunch hack, however.