### PR TITLE
fix: Update switchpeers validation to support Arista deployments

### DIFF
--- a/Conch/lib/Conch/Validation/SwitchPeers.pm
+++ b/Conch/lib/Conch/Validation/SwitchPeers.pm
@@ -87,24 +87,32 @@ sub validate {
 
 sub _calculate_switch_peer_ports {
 	my ( $self, $rack_unit, $rack_slots, $peer_vendor ) = @_;
-	my $rack_index =
-		first { $rack_slots->[$_] == $rack_unit } 0 .. $rack_slots->$#*;
+
+	my $rack_index = first { $rack_slots->[$_] == $rack_unit } 0 .. $rack_slots->$#*;
+
 	defined $rack_index
 		or $self->die('Device assigned to rack unit not in rack layout');
 
 	my $first_port = 1 + $rack_index;
 
-	if ($peer_vendor eq "Dell") {
-		# offset of 19 is standard for all Dell deployments, including 62U racks
+	if ($peer_vendor) {
+		if ($peer_vendor eq "Dell") {
+			# offset of 19 is standard for all Dell deployments, including 62U racks
+			my $second_port = $first_port + 19;
+			return ( "1/$first_port", "1/$second_port" );
+		}
+
+		if ($peer_vendor eq "Arista") {
+			# offset of 24 is standard for all Arista deployments, including 62U racks
+			my $second_port = $first_port + 24;
+			return ( "Ethernet$first_port", "Ethernet$second_port" );
+		}
+	} else {
+		# Handle legacy reports that lack peer vendor data
 		my $second_port = $first_port + 19;
 		return ( "1/$first_port", "1/$second_port" );
 	}
 
-	if ($peer_vendor eq "Arista") {
-		# offset of 24 is standard for all Arista deployments, including 62U racks
-		my $second_port = $first_port + 24;
-		return ( "Ethernet$first_port", "Ethernet$second_port" );
-	}
 }
 
 1;

--- a/Conch/lib/Conch/Validation/SwitchPeers.pm
+++ b/Conch/lib/Conch/Validation/SwitchPeers.pm
@@ -120,18 +120,16 @@ sub _calculate_switch_peer_ports {
 			# offset of 19 is standard for all Dell deployments, including 62U racks
 			my $second_port = $first_port + 19;
 			return ( "1/$first_port", "1/$second_port" );
-		}
-
-		if ($peer_vendor eq "Arista") {
+		} elsif ($peer_vendor eq "Arista") {
 			# offset of 24 is standard for all Arista deployments, including 62U racks
 			my $second_port = $first_port + 24;
 			return ( "Ethernet$first_port", "Ethernet$second_port" );
 		}
-	} else {
-		# Handle legacy reports that lack peer vendor data
-		my $second_port = $first_port + 19;
-		return ( "1/$first_port", "1/$second_port" );
 	}
+
+	# Handle reports that lack peer vendor data
+	my $second_port = $first_port + 19;
+	return ( "1/$first_port", "1/$second_port" );
 
 }
 

--- a/Conch/t/validations/switch_peers_v1.t
+++ b/Conch/t/validations/switch_peers_v1.t
@@ -161,4 +161,269 @@ test_validation(
 	]
 );
 
+my $descr = "Arista Networks EOS version 1.23.4A running on an Arista Networks DCS-1234-56AB7";
+
+test_validation(
+	'Conch::Validation::SwitchPeers',
+	hardware_product => {
+		name => 'Test Product',
+	},
+	device_location => {
+		rack_unit       => 2,
+		datacenter_rack => { slots => [ 1, 2, 3 ] }
+	},
+
+	cases => [
+		{
+			description => 'No Data',
+			data        => {},
+			dies        => 1
+		},
+		{
+			description =>
+				'Single failure with no eth interfaces (num of switch ports)',
+			data        => { interfaces => {} },
+			failure_num => 1
+		},
+		{
+			description => 'Correctly wired peers',
+			data        => {
+				interfaces => {
+					eth0 => {
+						peer_port => 'Ethernet2',
+						peer_mac  => 'de:ad:be:ef:00:00',
+						peer_descr => $descr,
+					},
+					eth1 => {
+						peer_port => 'Ethernet26',
+						peer_mac  => 'de:ad:be:ef:00:00',
+						peer_descr => $descr,
+					},
+					eth3 => {
+						peer_port => 'Ethernet2',
+						peer_mac  => 'co:ff:ee:b0:d1::35',
+						peer_descr => $descr,
+					},
+					eth4 => {
+						peer_port => 'Ethernet26',
+						peer_mac  => 'co:ff:ee:b0:d1::35',
+						peer_descr => $descr,
+					}
+				}
+			},
+			success_num => 7,
+			failure_num => 0
+		},
+		{
+			description => 'Only mis-wired peer ports',
+			data        => {
+				interfaces => {
+					eth0 => {
+						peer_port => 'Ethernet1',
+						peer_mac  => 'de:ad:be:ef:00:00',
+						peer_descr => $descr,
+					},
+					eth1 => {
+						peer_port => 'Ethernet25',
+						peer_mac  => 'de:ad:be:ef:00:00',
+						peer_descr => $descr,
+					},
+					eth3 => {
+						peer_port => 'Ethernet1',
+						peer_mac  => 'co:ff:ee:b0:d1::35',
+						peer_descr => $descr,
+					},
+					eth4 => {
+						peer_port => 'Ethernet25',
+						peer_mac  => 'co:ff:ee:b0:d1::35',
+						peer_descr => $descr,
+					}
+				}
+			},
+			success_num => 3,
+			failure_num => 4
+		},
+		{
+			description => 'Incorrect number of peer switches',
+			data        => {
+				interfaces => {
+					eth0 => {
+						peer_port => 'Ethernet2',
+						peer_mac  => 'de:ad:be:ef:00:00',
+						peer_descr => $descr,
+					},
+					eth1 => {
+						peer_port => 'Ethernet26',
+						peer_mac  => 'de:ad:be:ef:00:00',
+						peer_descr => $descr,
+					},
+				}
+			},
+			success_num => 3,
+			failure_num => 1
+		},
+		{
+			description => 'Incorrect number of ports per switch',
+			data        => {
+				interfaces => {
+					eth0 => {
+						peer_port => 'Ethernet2',
+						peer_mac  => 'de:ad:be:ef:00:00',
+						peer_descr => $descr,
+					},
+					eth1 => {
+						peer_port => 'Ethernet26',
+						peer_mac  => 'de:ad:be:ef:00:00',
+						peer_descr => $descr,
+					},
+					eth2 => {
+						peer_port => 'Ethernet27',
+						peer_mac  => 'de:ad:be:ef:00:00',
+						peer_descr => $descr,
+					},
+
+					eth3 => {
+						peer_port => 'Ethernet2',
+						peer_mac  => 'co:ff:ee:b0:d1::35',
+						peer_descr => $descr,
+					},
+					eth4 => {
+						peer_port => 'Ethernet26',
+						peer_mac  => 'co:ff:ee:b0:d1::35',
+						peer_descr => $descr,
+					}
+				}
+			},
+			success_num => 6,
+			failure_num => 2
+		},
+	]
+);
+
+test_validation(
+	'Conch::Validation::SwitchPeers',
+	hardware_product => {
+		name => 'Test Product',
+	},
+	device_location => {
+		rack_unit       => 2,
+		datacenter_rack => { slots => [ 1, 2, 3 ] }
+	},
+
+	cases => [
+		{
+			description => 'Correctly wired peers',
+			data        => {
+				interfaces => {
+					eth0 => {
+						peer_port => 'Ethernet2',
+						peer_mac  => 'de:ad:be:ef:00:00',
+						peer_vendor => 'Arista',
+					},
+					eth1 => {
+						peer_port => 'Ethernet26',
+						peer_mac  => 'de:ad:be:ef:00:00',
+						peer_vendor => 'Arista',
+					},
+					eth3 => {
+						peer_port => 'Ethernet2',
+						peer_mac  => 'co:ff:ee:b0:d1::35',
+						peer_vendor => 'Arista',
+					},
+					eth4 => {
+						peer_port => 'Ethernet26',
+						peer_mac  => 'co:ff:ee:b0:d1::35',
+						peer_vendor => 'Arista',
+					}
+				}
+			},
+			success_num => 7,
+			failure_num => 0
+		},
+		{
+			description => 'Only mis-wired peer ports',
+			data        => {
+				interfaces => {
+					eth0 => {
+						peer_port => 'Ethernet1',
+						peer_mac  => 'de:ad:be:ef:00:00',
+						peer_vendor => 'Arista',
+					},
+					eth1 => {
+						peer_port => 'Ethernet25',
+						peer_mac  => 'de:ad:be:ef:00:00',
+						peer_vendor => 'Arista',
+					},
+					eth3 => {
+						peer_port => 'Ethernet1',
+						peer_mac  => 'co:ff:ee:b0:d1::35',
+						peer_vendor => 'Arista',
+					},
+					eth4 => {
+						peer_port => 'Ethernet25',
+						peer_mac  => 'co:ff:ee:b0:d1::35',
+						peer_vendor => 'Arista',
+					}
+				}
+			},
+			success_num => 3,
+			failure_num => 4
+		},
+		{
+			description => 'Incorrect number of peer switches',
+			data        => {
+				interfaces => {
+					eth0 => {
+						peer_port => 'Ethernet2',
+						peer_mac  => 'de:ad:be:ef:00:00',
+						peer_vendor => 'Arista',
+					},
+					eth1 => {
+						peer_port => 'Ethernet26',
+						peer_mac  => 'de:ad:be:ef:00:00',
+						peer_vendor => 'Arista',
+					},
+				}
+			},
+			success_num => 3,
+			failure_num => 1
+		},
+		{
+			description => 'Incorrect number of ports per switch',
+			data        => {
+				interfaces => {
+					eth0 => {
+						peer_port => 'Ethernet2',
+						peer_mac  => 'de:ad:be:ef:00:00',
+						peer_vendor => 'Arista',
+					},
+					eth1 => {
+						peer_port => 'Ethernet26',
+						peer_mac  => 'de:ad:be:ef:00:00',
+						peer_vendor => 'Arista',
+					},
+					eth2 => {
+						peer_port => 'Ethernet27',
+						peer_mac  => 'de:ad:be:ef:00:00',
+						peer_vendor => 'Arista',
+					},
+
+					eth3 => {
+						peer_port => 'Ethernet2',
+						peer_mac  => 'co:ff:ee:b0:d1::35',
+						peer_vendor => 'Arista',
+					},
+					eth4 => {
+						peer_port => 'Ethernet26',
+						peer_mac  => 'co:ff:ee:b0:d1::35',
+						peer_vendor => 'Arista',
+					}
+				}
+			},
+			success_num => 6,
+			failure_num => 2
+		},
+	]
+);
+
 done_testing();


### PR DESCRIPTION
We need to detect the peer vendor so we can modify the peer text (Arista hands us "Ethernet"). We've also modified the map so data is ports 1 - 20 and admin is 24 - 44.