### PR TITLE
fix: update the DeviceProductName validation to handle the new naming scheme

### DIFF
--- a/Conch/lib/Conch/Validation.pm
+++ b/Conch/lib/Conch/Validation.pm
@@ -342,6 +342,21 @@ sub hardware_product_name ($self) {
 	return $self->{_hardware_product}->name;
 }
 
+=head2 hardware_legacy_product_name
+
+Get the expected hardware legacy product name for the device under validation.
+
+	if ($self->hardware_legacy_product_name eq 'Joyent-123') {...}
+
+=cut
+
+sub hardware_legacy_product_name ($self) {
+	$self->die( "Validation must have an expected hardware product", level => 2 )
+		unless $self->{_hardware_product};
+	return $self->{_hardware_product}->legacy_product_name;
+}
+
+
 =head2 hardware_product_generation
 
 Get the expected hardware product generation for the device under validation.
@@ -349,7 +364,6 @@ Get the expected hardware product generation for the device under validation.
 	if ($self->hardware_product_generation eq 'Joyent-123') {...}
 
 =cut
-
 sub hardware_product_generation ($self) {
 	$self->die( "Validation must have an expected hardware product", level => 2 )
 		unless $self->{_hardware_product};

--- a/Conch/lib/Conch/Validation.pm
+++ b/Conch/lib/Conch/Validation.pm
@@ -177,6 +177,7 @@ sub run ( $self, $data ) {
 		);
 		push $self->validation_results->@*, $validation_error;
 	};
+	return $self;
 }
 
 =head2 run_unsafe

--- a/Conch/lib/Conch/Validation/DeviceProductName.pm
+++ b/Conch/lib/Conch/Validation/DeviceProductName.pm
@@ -20,11 +20,20 @@ has schema => sub {
 
 sub validate {
 	my ( $self, $data ) = @_;
-
-	$self->register_result(
-		expected => $self->hardware_product_name,
-		got      => $data->{product_name},
-	);
+	if(
+		($data->{product_name} =~ /^Joyent-Compute/) or
+		($data->{product_name} =~ /^Joyent-Storage/)
+	) {
+		$self->register_result(
+			expected => $self->hardware_legacy_product_name,
+			got      => $data->{product_name},
+		);
+	} else {
+		$self->register_result(
+			expected => $self->hardware_product_generation,
+			got      => $data->{product_name},
+		);
+	}
 }
 
 1;

--- a/Conch/t/integration/resource/passing-device-report.json
+++ b/Conch/t/integration/resource/passing-device-report.json
@@ -324,7 +324,7 @@
   },
   "state": "ONLINE",
   "serial_number": "TEST",
-  "product_name": "65-ssds-2-cpu",
+  "product_name": "Joyent-S1",
   "sku": "550-552-003",
   "relay": { "serial": "deadbeef" },
   "system_uuid": "4C4C4544-0035-4D10-8032-B4C04F4E4432"

--- a/Conch/t/model/Validation.t
+++ b/Conch/t/model/Validation.t
@@ -30,7 +30,8 @@ my $hardware_product_id = $pg->db->insert(
 	{
 		name   => 'test hw product',
 		alias  => 'alias',
-		vendor => $hardware_vendor_id
+		vendor => $hardware_vendor_id,
+		generation_name => 'Joyent-G1',
 	},
 	{ returning => ['id'] }
 )->hash->{id};
@@ -164,8 +165,8 @@ subtest "build_device_validation" => sub {
 	};
 
 	isa_ok( $device_validation, 'Conch::Validation' );
-	my $results = $device_validation->run( { product_name => 'test hw product' } )
-		->validation_results;
+	my $results = $device_validation->run( { product_name => 'Joyent-G1' } )
+			->validation_results;
 	is( scalar @$results, 1 );
 
 	# 'run_validation_for_device' is a convenience function for building and
@@ -174,7 +175,7 @@ subtest "build_device_validation" => sub {
 		my $run_results;
 		lives_ok {
 			$run_results = $real_validation->run_validation_for_device( $device,
-				{ product_name => 'test hw product' } );
+				{ product_name => 'Joyent-G1' } );
 		};
 		is_deeply( $run_results, $results, 'Results should be the same' );
 	};

--- a/Conch/t/model/ValidationState.t
+++ b/Conch/t/model/ValidationState.t
@@ -39,7 +39,8 @@ my $hardware_product_id = $pg->db->insert(
 	{
 		name   => 'test hw product',
 		alias  => 'alias',
-		vendor => $hardware_vendor_id
+		vendor => $hardware_vendor_id,
+		generation_name => 'Joyent-G1',
 	},
 	{ returning => ['id'] }
 )->hash->{id};
@@ -199,7 +200,7 @@ subtest "run validation plan" => sub {
 
 	my $pass_state =
 		Conch::Model::ValidationState->run_validation_plan( $device->id,
-		$validation_plan->id, { product_name => 'test hw product' } );
+		$validation_plan->id, { product_name => 'Joyent-G1' } );
 	is( scalar $pass_state->validation_results->@*, 1 );
 	is( $pass_state->status, 'pass',
 		'Validation state should be pass because all results passed' );

--- a/Conch/t/validations/device_product_name_v1.t
+++ b/Conch/t/validations/device_product_name_v1.t
@@ -3,7 +3,10 @@ use Test::Conch::Validation;
 
 test_validation(
 	'Conch::Validation::DeviceProductName',
-	hardware_product => { name => 'Test Product' },
+	hardware_product => { 
+		name => 'Test Product',
+		generation_name => 'Joyent-G1',
+	},
 	cases            => [
 		{
 			description => 'No data dies',
@@ -12,7 +15,7 @@ test_validation(
 		},
 		{
 			description => 'Correct product name',
-			data        => { 'product_name' => 'Test Product' },
+			data        => { 'product_name' => 'Joyent-G1' },
 			success_num => 1
 		},
 		{


### PR DESCRIPTION
Includes support for legacy devices predating the standard