### PR TITLE
when handling an exception, use the exception that is always in the stash but not always in the args

### DIFF
--- a/Conch/lib/Conch.pm
+++ b/Conch/lib/Conch.pm
@@ -147,7 +147,7 @@ sub startup {
 			my ( $c, $args ) = @_;
 			return unless my $template = $args->{template};
 			if ( $template =~ /exception/ ) {
-				my $exception = $c->stash('exception');
+				my $exception = $c->stash('exception') // $args->{exception};
 				$exception->verbose(1);
 				$self->log->error($exception);
 

--- a/Conch/lib/Conch.pm
+++ b/Conch/lib/Conch.pm
@@ -147,7 +147,7 @@ sub startup {
 			my ( $c, $args ) = @_;
 			return unless my $template = $args->{template};
 			if ( $template =~ /exception/ ) {
-				my $exception = $args->{exception};
+				my $exception = $c->stash('exception');
 				$exception->verbose(1);
 				$self->log->error($exception);
 


### PR DESCRIPTION
This fixes the scenario where a request just times out if DBIC throws an exception