### PR TITLE
do not build the doc target automatically

### DIFF
--- a/Conch/Makefile
+++ b/Conch/Makefile
@@ -6,7 +6,7 @@ run: build morbo ## Default. Build and run under morbo
 morbo: ## Run under morbo, listening on :5001
 	@carton exec -- morbo -v bin/conch -l http://\*:5001
 
-build: local doc ## Install deps and build docs
+build: local ## Install deps (TODO: and build docs)
 
 local: cpanfile.snapshot ## Install deps
 # '--deployment' installs the same dep versions that are in the lockfile


### PR DESCRIPTION
fixing this will include figuring out how to properly run yarn -- now
that ether is installing yarn under sudo npm (as per changes in
buildops-docs), yarn install has auth fails unless it is also run as
sudo.

Plus, we aren't even keeping the docs up to date, so rebuilding them is
useless until we fix that.