### PR TITLE
fix: Return 204 instead of 409/conflict if a device is already marked validated

### DIFF
--- a/lib/Conch/Controller/Device.pm
+++ b/lib/Conch/Controller/Device.pm
@@ -195,9 +195,7 @@ Sets the C<validated> field on a device unless that field has already been set
 sub set_validated($c) {
 	my $device    = $c->stash('current_device');
 	my $device_id = $device->id;
-	return $c->status( 204,
-		{ error => "Device $device_id has already marked validated" } )
-		if defined( $device->validated );
+	return $c->status(204) if defined( $device->validated );
 
 	$device->set_validated();
 

--- a/lib/Conch/Controller/Device.pm
+++ b/lib/Conch/Controller/Device.pm
@@ -195,7 +195,7 @@ Sets the C<validated> field on a device unless that field has already been set
 sub set_validated($c) {
 	my $device    = $c->stash('current_device');
 	my $device_id = $device->id;
-	return $c->status( 409,
+	return $c->status( 204,
 		{ error => "Device $device_id has already marked validated" } )
 		if defined( $device->validated );
 

--- a/t/integration/04_test_datacenter_loaded.t
+++ b/t/integration/04_test_datacenter_loaded.t
@@ -170,7 +170,7 @@ subtest 'Single device' => sub {
 
 		$t->post_ok('/device/TEST/validated')->status_is(303)
 			->header_like( Location => qr!/device/TEST$! );
-		$t->post_ok('/device/TEST/validated')->status_is(409)
+		$t->post_ok('/device/TEST/validated')->status_is(204)
 			->json_like( '/error', qr/already marked validated/ );
 	};
 

--- a/t/integration/04_test_datacenter_loaded.t
+++ b/t/integration/04_test_datacenter_loaded.t
@@ -171,7 +171,7 @@ subtest 'Single device' => sub {
 		$t->post_ok('/device/TEST/validated')->status_is(303)
 			->header_like( Location => qr!/device/TEST$! );
 		$t->post_ok('/device/TEST/validated')->status_is(204)
-			->json_like( '/error', qr/already marked validated/ );
+			->content_is('');
 	};
 
 	subtest 'Device settings' => sub {


### PR DESCRIPTION
There's no conflict; this API endpoint should be considered idempotent. (I'd go so far as to say we should just return 200, but there may be instances where knowing it was already validated might be helpful.)