### PR TITLE
fix: Add check for switch product name in validation

### DIFF
--- a/lib/Conch/Validation/DeviceProductName.pm
+++ b/lib/Conch/Validation/DeviceProductName.pm
@@ -20,6 +20,20 @@ has schema => sub {
 
 sub validate {
 	my ( $self, $data ) = @_;
+
+	# We do not currently define a Conch or Joyent specific name for
+	# switches. This may change in the future, but currently we continue
+	# to use the vendor product ID.
+	if ($data->{device_type} && $data->{device_type} eq "switch") {
+		$self->register_result(
+			expected => $self->hardware_product_name,
+			got      => $data->{product_name},
+		);
+		return;
+	}
+
+	# Previous iterations of our hardware naming are still in the field
+	# and cannot be updated to the new style. Continue to support them.
 	if(
 		($data->{product_name} =~ /^Joyent-Compute/) or
 		($data->{product_name} =~ /^Joyent-Storage/)

--- a/t/validations/device_product_name_v1.t
+++ b/t/validations/device_product_name_v1.t
@@ -28,4 +28,29 @@ test_validation(
 	]
 );
 
+test_validation(
+	'Conch::Validation::DeviceProductName',
+	hardware_product => {
+		name => 'Test Product',
+	},
+	cases            => [
+		{
+			description => 'Correct product name',
+			data        => {
+				device_type  => 'switch',
+				product_name => 'Test Product'
+			},
+			success_num => 1
+		},
+		{
+			description => 'Incorrect product name',
+			data        => {
+				device_type  => 'switch',
+				product_name => 'Test Product2'
+			},
+			failure_num => 1
+		}
+	]
+);
+
 done_testing();


### PR DESCRIPTION
Tested by pushing Arista and SMCI reports into local API.

As noted in the comment, this occurs because we do not have internal names for switches (yet) and were keying product_name off the generation for servers. This adds an override for switches.