### PR TITLE
Remove variant overrides for Shrimps

### DIFF
--- a/lib/Conch/Validation/DimmCount.pm
+++ b/lib/Conch/Validation/DimmCount.pm
@@ -27,12 +27,6 @@ sub validate {
 	my $dimms_num  = $data->{memory}->{count};
 	my $dimms_want = $hw_profile->dimms_num;
 
-	# Shrimps can have 256GB or 512GB RAM, with 8 or 16 DIMMs.
-	if ( $self->hardware_product_name eq 'Joyent-Storage-Platform-7001' ) {
-		if ( $dimms_num <= 8 ) { $dimms_want = 8; }
-		if ( $dimms_num > 8 )  { $dimms_want = 16; }
-	}
-
 	$self->register_result(
 		expected => $dimms_want,
 		got      => $dimms_num,

--- a/lib/Conch/Validation/RamTotal.pm
+++ b/lib/Conch/Validation/RamTotal.pm
@@ -29,12 +29,6 @@ sub validate {
 	my $ram_total = $data->{memory}->{total};
 	my $ram_want  = $hw_profile->ram_total;
 
-	# Shrimps can have 256GB or 512GB RAM, with 8 or 16 DIMMs.
-	if ( $self->hardware_product_name eq "Joyent-Storage-Platform-7001" ) {
-		if ( $ram_total <= 256 ) { $ram_want = 256; }
-		if ( $ram_total > 256 )  { $ram_want = 512; }
-	}
-
 	$self->register_result(
 		expected => $ram_want,
 		got      => $ram_total,

--- a/t/validations/dimm_count_v1.t
+++ b/t/validations/dimm_count_v1.t
@@ -28,34 +28,4 @@ test_validation(
 	]
 );
 
-test_validation(
-	'Conch::Validation::DimmCount',
-	hardware_product => {
-		name    => 'Joyent-Storage-Platform-7001',
-		profile => {}
-	},
-	cases => [
-		{
-			description => 'Incorrect DIMM count for Joyent Storage 7001',
-			data        => { 'memory' => { count => 7 } },
-			failure_num => 1
-		},
-		{
-			description => '1 of 2 correct DIMM count for Joyent Storage 7001',
-			data        => { 'memory' => { count => 8 } },
-			success_num => 1
-		},
-		{
-			description => '>8 incorrect DIMM count for Joyent Storage 7001',
-			data        => { 'memory' => { count => 15 } },
-			failure_num => 1
-		},
-		{
-			description => '2 of 2 correct DIMM count for Joyent Storage 7001',
-			data        => { 'memory' => { count => 16 } },
-			success_num => 1
-		},
-	]
-);
-
 done_testing();

--- a/t/validations/ram_total_v1.t
+++ b/t/validations/ram_total_v1.t
@@ -33,35 +33,4 @@ test_validation(
 	]
 );
 
-# Special case for Joyent-Storage-Platform-7001. Needs either 256 or 512
-test_validation(
-	'Conch::Validation::RamTotal',
-	hardware_product => {
-		name => 'Joyent-Storage-Platform-7001',
-		profile => { ram_total => 128 } # doesn't matter
-	},
-	cases => [
-		{
-			description => 'Wrong memory total fails',
-			data        => { memory => { total => 128 } },
-			failure_num => 1
-		},
-		{
-			description => '256 is computed correct memory total',
-			data        => { memory => { total => 256 } },
-			success_num => 1
-		},
-		{
-			description => '512 is computed correct memory total',
-			data        => { memory => { total => 512 } },
-			success_num => 1
-		},
-		{
-			description => '384 is wrong memory total',
-			data        => { memory => { total => 384 } },
-			failure_num => 1
-		},
-	]
-);
-
 done_testing();


### PR DESCRIPTION
These overrides are no longer needed now that we've moved to the new hardware product naming schema. They are accounted for in the hardware_product and rack layout tables.

We cannot remove the Dell overrides, unfortunately, as the SMBIOS Product Name on those systems will not be updated in the field.