### PR TITLE
New logging framework and lots more log lines

### DIFF
--- a/conch.conf.dist
+++ b/conch.conf.dist
@@ -32,10 +32,6 @@
 		stop_conch_cookie_issue => 0,
 	},
 
-	audit => {
-		log_path => "log/audit.log",
-		payloads => 0,
-	},
 
 	# See all settings at https://metacpan.org/pod/Mojo::Server::Hypnotoad#SETTINGS
 	hypnotoad => {

--- a/lib/Conch/Controller/DatacenterRoom.pm
+++ b/lib/Conch/Controller/DatacenterRoom.pm
@@ -1,8 +1,11 @@
 package Conch::Controller::DatacenterRoom;
 
+use Role::Tiny::With;
 use Mojo::Base 'Mojolicious::Controller', -signatures;
 
 use Conch::Models;
+
+with 'Conch::Role::MojoLog';
 
 
 =head2 under
@@ -20,16 +23,20 @@ sub under ($c) {
 	my $s;
 
 	if($c->param('id') =~ /^(.+?)\=(.+)$/) {
+		$c->log->warn("Unsupported identifier '$1'");
 		$c->status(501);
 		return undef;
 	} else {
+		$c->log->debug("Looking up datacenter room ".$c->param('id'));
 		$s = Conch::Model::DatacenterRoom->from_id($c->param('id'));
 	}
 
 	if ($s) {
+		$c->log->debug("Found datacenter room");
 		$c->stash('datacenter_room' => $s);
 		return 1;
 	} else {
+		$c->log->debug("Could not find datacenter room");
 		$c->status(404 => { error => "Not found" });
 		return undef;
 	}
@@ -45,7 +52,11 @@ Get all datacenter rooms
 
 sub get_all ($c) {
 	return $c->status(403) unless $c->is_global_admin;
-	return $c->status(200, Conch::Model::DatacenterRoom->all());
+
+	my $r = Conch::Model::DatacenterRoom->all();
+	$c->log->debug("Found ".scalar($r->@*)." datacenter rooms");
+
+	return $c->status(200 => $r);
 }
 
 
@@ -69,9 +80,13 @@ Create a new datacenter room
 sub create ($c) {
 	return $c->status(403) unless $c->is_global_admin;
 	my $i = $c->validate_input('DatacenterRoomCreate');
-	return if not $i;
+	if(not $i) {
+		$c->log->warn("Input failed validation");
+		return;
+	}
 
 	my $r = Conch::Model::DatacenterRoom->new($i->%*)->save;
+	$c->log->debug("Created datacenter room ".$r->id);
 	$c->status(303 => "/room/".$r->id);
 }
 
@@ -85,9 +100,13 @@ Update an existing room
 sub update ($c) {
 	return $c->status(403) unless $c->is_global_admin;
 	my $i = $c->validate_input('DatacenterRoomUpdate');
-	return if not $i;
+	if(not $i) {
+		$c->log->warn("Input failed validation");
+		return;
+	}
 
 	$c->stash('datacenter_room')->update($i->%*)->save();
+	$c->log->debug("Updated datacenter room ".$c->stash('datacenter_room')->id);
 	$c->status(303 => "/room/".$c->stash('datacenter_room')->id);
 }
 
@@ -101,6 +120,7 @@ Permanently delete a datacenter room
 sub delete ($c) {
 	return $c->status(403) unless $c->is_global_admin;
 	$c->stash('datacenter_room')->burn;
+	$c->log->debug("Deleted datacenter room ".$c->stash('datacenter_room')->id);
 	return $c->status(204);
 }
 
@@ -112,11 +132,14 @@ sub delete ($c) {
 sub racks ($c) {
 	return $c->status(403) unless $c->is_global_admin;
 
-	return $c->status(
-		200 => Conch::Model::DatacenterRack->from_datacenter_room(
-			$c->stash('datacenter_room')->id
-		)
+	my $r = Conch::Model::DatacenterRack->from_datacenter_room(
+		$c->stash('datacenter_room')->id
 	);
+	$c->log->debug(
+		"Found ".scalar($r->@*).
+		" racks for datacenter room ".$c->stash('datacenter_room')->id
+	);
+	return $c->status(200 => $r);
 
 }
 

--- a/lib/Conch/Controller/DeviceLocation.pm
+++ b/lib/Conch/Controller/DeviceLocation.pm
@@ -10,10 +10,13 @@ Conch::Controller::DeviceLocation
 
 package Conch::Controller::DeviceLocation;
 
+use Role::Tiny::With;
 use Mojo::Base 'Mojolicious::Controller', -signatures;
 use Conch::UUID 'is_uuid';
 
 use Conch::Models;
+
+with 'Conch::Role::MojoLog';
 
 =head2 get
 

--- a/lib/Conch/Controller/DeviceReport.pm
+++ b/lib/Conch/Controller/DeviceReport.pm
@@ -10,10 +10,13 @@ Conch::Controller::DeviceReport
 
 package Conch::Controller::DeviceReport;
 
+use Role::Tiny::With;
 use Mojo::Base 'Mojolicious::Controller', -signatures;
 
 use Conch::Models;
 use Conch::Legacy::Control::DeviceReport 'record_device_report';
+
+with 'Conch::Role::MojoLog';
 
 =head2 process
 

--- a/lib/Conch/Controller/DeviceSettings.pm
+++ b/lib/Conch/Controller/DeviceSettings.pm
@@ -10,9 +10,11 @@ Conch::Controller::DeviceSettings
 
 package Conch::Controller::DeviceSettings;
 
+use Role::Tiny::With;
 use Mojo::Base 'Mojolicious::Controller', -signatures;
 use Conch::Models;
 
+with 'Conch::Role::MojoLog';
 
 =head2 set_all
 

--- a/lib/Conch/Controller/HardwareProduct.pm
+++ b/lib/Conch/Controller/HardwareProduct.pm
@@ -10,10 +10,12 @@ Conch::Controller::HardwareProduct
 
 package Conch::Controller::HardwareProduct;
 
+use Role::Tiny::With;
 use Mojo::Base 'Mojolicious::Controller', -signatures;
 use Conch::UUID 'is_uuid';
 
 use Conch::Models;
+with 'Conch::Role::MojoLog';
 
 =head2 list
 

--- a/lib/Conch/Controller/Relay.pm
+++ b/lib/Conch/Controller/Relay.pm
@@ -10,10 +10,12 @@ Conch::Controller::Relay
 
 package Conch::Controller::Relay;
 
+use Role::Tiny::With;
 use Mojo::Base 'Mojolicious::Controller', -signatures;
 use Conch::UUID 'is_uuid';
 
 use Conch::Models;
+with 'Conch::Role::MojoLog';
 
 =head2 register
 

--- a/lib/Conch/Controller/User.pm
+++ b/lib/Conch/Controller/User.pm
@@ -10,12 +10,15 @@ Conch::Controller::User
 
 package Conch::Controller::User;
 
+use Role::Tiny::With;
 use Mojo::Base 'Mojolicious::Controller', -signatures;
 use Mojo::Exception;
 
 use Conch::UUID qw( is_uuid );
 use List::Util 'pairmap';
 use Mojo::JSON qw(to_json from_json);
+
+with 'Conch::Role::MojoLog';
 
 =head2 revoke_own_tokens
 
@@ -25,7 +28,7 @@ B<NOTE>: This will cause the next request to fail authentication.
 =cut
 
 sub revoke_own_tokens ($c) {
-	$c->app->log->debug('revoking user token for user ' . $c->stash('user')->name . ' at their request');
+	$c->log->debug('revoking user token for user ' . $c->stash('user')->name . ' at their request');
 	$c->stash('user')->delete_related('user_session_tokens');
 	$c->status(204);
 }
@@ -205,7 +208,7 @@ sub change_password ($c) {
 		unless $user;
 
 	$user->update({ password => $new_password });
-	$c->app->log->debug('updated password for user ' . $user->name . ' at their request');
+	$c->log->debug('updated password for user ' . $user->name . ' at their request');
 
 	return $c->status(204)
 		unless $c->req->query_params->param('clear_tokens') // 1;

--- a/lib/Conch/Controller/Validation.pm
+++ b/lib/Conch/Controller/Validation.pm
@@ -12,8 +12,10 @@ Controller for managing Validations, B<NOT> executing them.
 
 package Conch::Controller::Validation;
 
+use Role::Tiny::With;
 use Mojo::Base 'Mojolicious::Controller', -signatures;
 use Conch::Models;
+with 'Conch::Role::MojoLog';
 
 =head2 list
 

--- a/lib/Conch/Controller/Workspace.pm
+++ b/lib/Conch/Controller/Workspace.pm
@@ -10,10 +10,12 @@ Conch::Controller::Workspace
 
 package Conch::Controller::Workspace;
 
+use Role::Tiny::With;
 use Mojo::Base 'Mojolicious::Controller', -signatures;
 use Conch::UUID 'is_uuid';
 
 use Conch::Models;
+with 'Conch::Role::MojoLog';
 
 =head2 under
 

--- a/lib/Conch/Controller/WorkspaceDevice.pm
+++ b/lib/Conch/Controller/WorkspaceDevice.pm
@@ -10,9 +10,11 @@ Conch::Controller::WorkspaceDevice
 
 package Conch::Controller::WorkspaceDevice;
 
+use Role::Tiny::With;
 use Mojo::Base 'Mojolicious::Controller', -signatures;
 
 use Conch::Models;
+with 'Conch::Role::MojoLog';
 
 =head2 list
 

--- a/lib/Conch/Controller/WorkspaceProblem.pm
+++ b/lib/Conch/Controller/WorkspaceProblem.pm
@@ -10,10 +10,13 @@ Conch::Controller::WorkspaceProblem
 
 package Conch::Controller::WorkspaceProblem;
 
+use Role::Tiny::With;
 use Mojo::Base 'Mojolicious::Controller', -signatures;
 
 use Conch::Models;
 use Conch::Legacy::Control::Problem 'get_problems';
+
+with 'Conch::Role::MojoLog';
 
 
 =head2 list

--- a/lib/Conch/Controller/WorkspaceRelay.pm
+++ b/lib/Conch/Controller/WorkspaceRelay.pm
@@ -10,9 +10,11 @@ Conch::Controller::WorkspaceRelay
 
 package Conch::Controller::WorkspaceRelay;
 
+use Role::Tiny::With;
 use Mojo::Base 'Mojolicious::Controller', -signatures;
 
 use Conch::Models;
+with 'Conch::Role::MojoLog';
 
 =head2 list
 
@@ -25,6 +27,11 @@ sub list ($c) {
 		$c->stash('current_workspace')->id,
 		$c->param('active') ? 2 : undef,
 		$c->param('no_devices') ? undef : 1,
+	);
+
+	$c->log->debug(
+		"Found ".scalar($relays->@*).
+		" relays in workspace ".$c->stash('current_workspace')->id
 	);
 	$c->status( 200, $relays );
 }

--- a/lib/Conch/Log.pm
+++ b/lib/Conch/Log.pm
@@ -1,0 +1,111 @@
+=head1 Conch::Log
+
+Enhanced Mojo logger that logs with file path, and caller data using the Bunyan
+log format
+
+See also: Mojo::Log, Mojo::Log::More, and node-bunyan
+
+=head1 SYNOPSIS
+
+	$app->log(Conch::Log->new)
+
+=head1 METHODS
+
+=head2 debug
+
+=head2 info
+
+=head2 warn
+
+=head2 error
+
+=head2 fatal
+
+=head2 raw
+
+See L<Conch::Plugin::Logger> for a use case of C<raw>
+
+=cut
+
+package Conch::Log;
+
+use Mojo::Base 'Mojo::Log';
+use Mojo::JSON;
+use File::Spec;
+use Sys::Hostname;
+use Conch::Time;
+
+sub new {
+	my $class = shift;
+	my $self = $class->SUPER::new(@_);
+
+	$self->unsubscribe('message');
+	$self->on(message => '_message');
+	return $self;
+}
+
+has 'request_id';
+has 'payload';
+
+has 'name' => 'conch-api';
+ 
+
+sub _message {
+	my $self = shift;
+	my ($level, $msg) = @_;
+
+	return unless $self->is_level($level);
+
+	if($self->payload) {
+		$self->append(Mojo::JSON::to_json($self->payload)."\n");
+		return;
+	}
+
+	my @caller = caller(3);
+
+	my ($package, $filepath, $line, $filename);
+
+	if (scalar @caller) {
+		($package, $filepath, $line) = ($caller[0], $caller[1], $caller[2]);
+		$filename = (File::Spec->splitpath($filepath))[2];
+	} else {
+		($package, $line, $filename) = ("unknown", 0, 'unknown');
+	}
+
+
+	my $log = {
+		v        => 1,
+		pid      => $$,
+		hostname => hostname,
+		time     => Conch::Time->now->iso8601,
+		level    => $level,
+		msg      => $msg,
+		name     => $self->name,
+		req_id   => $self->request_id,
+		src      => {
+			func => $package,
+			file => $filename,
+			line => $line,
+		},
+	};
+
+	$self->append(Mojo::JSON::to_json($log)."\n");
+}
+ 
+ 
+1;
+__END__
+
+=pod
+
+=head1 LICENSING
+
+Based on Mojo::Log::More : https://metacpan.org/pod/Mojo::Log::More
+
+Copyright Joyent, Inc.
+
+This Source Code Form is subject to the terms of the Mozilla Public License,
+v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+one at http://mozilla.org/MPL/2.0/.
+
+=cut

--- a/lib/Conch/Plugin/JsonValidator.pm
+++ b/lib/Conch/Plugin/JsonValidator.pm
@@ -93,9 +93,11 @@ sub register ( $self, $app, $conf ) {
 			$s,
 		);
 		if (@errors) {
+			$c->app->log->error("FAILED data validation for schema $schema: ".join(" // ", @errors));
 			$c->status(400 => { error => join("\n",@errors) });
 			return undef;
 		} else {
+			$c->app->log->debug("Passed data validation for schema $schema");
 			return $j;
 		}
 	});

--- a/lib/Conch/Plugin/Logging.pm
+++ b/lib/Conch/Plugin/Logging.pm
@@ -1,0 +1,150 @@
+=head1 NAME
+
+Conch::Plugin::Logging - Sets up logging for the application
+
+=head1 METHODS
+
+=cut
+
+package Conch::Plugin::Logging;
+
+use Mojo::Base 'Mojolicious::Plugin', -signatures;
+use Mojo::Log;
+use Conch::Log;
+
+use Mojo::JSON;
+use Sys::Hostname;
+
+=head2 register
+=cut
+
+sub register ($self, $app, $conf) {
+
+	my %features = $app->config('features') ?
+		$app->config('features')->%* : () ;
+
+	my $home = $app->home;
+	my $mode = $app->mode;
+	my $log_dir = $home->child('log');
+
+	if(-d $log_dir) {
+		unless(-w $log_dir) {
+			return Mojo::Exception->throw("Cannot write to $log_dir");
+		}
+	} else {
+		if(-w $home->path) {
+			$app->log->info("Creating log dir $log_dir");
+			$home->make_path($log_dir);
+		} else { 
+			return Mojo::Exception->throw("Cannot create $log_dir");
+		}
+	}
+	my $log_path = $home->child('log', "$mode.log");
+
+	$app->log(Conch::Log->new(
+		path       => $log_path,
+		level      => 'debug',
+    ));
+
+	if($features{rollbar}) {
+		$app->hook(
+			before_render => sub {
+				my ( $c, $args ) = @_;
+				my $template = $args->{template};
+				return if not $template;
+				if ( $template =~ /exception/ ) {
+					my $exception = $c->stash('exception') // $args->{exception};
+					$exception->verbose(1);
+
+					$app->send_exception_to_rollbar($exception);
+				}
+			}
+		);
+	}
+
+	$app->hook(after_dispatch => sub {
+		my $c = shift;
+
+		my $u_str = $c->stash('user') ?
+			$c->stash('user')->email . " (".$c->stash('user')->id.")" :
+			'NOT AUTHED';
+
+		my $req_headers = $c->tx->req->headers->to_hash;
+		for (qw(Authorization Cookie jwt_token jwt_sig)) {
+			delete $req_headers->{$_};
+		}
+
+		my $log = {
+			v        => 1,
+			pid      => $$,
+			hostname => hostname,
+			time     => Conch::Time->now->iso8601,
+			level    => 'info',
+			msg      => 'dispatch',
+			name     => 'conch-api',
+			req_id   => $c->req->request_id,
+			src      => {
+				func => __PACKAGE__,
+			},
+			req => {
+				user         => $u_str,
+				method       => $c->req->method,
+				url          => $c->req->url,
+				remoteAdress => $c->tx->original_remote_address,
+				remotePort   => $c->tx->remote_port,
+				headers      => $req_headers,
+				params       => $c->req->params->to_hash,
+			},
+		};
+
+
+		my $res_headers = $c->tx->res->headers->to_hash;
+		for (qw(Set-Cookie)) {
+			delete $res_headers->{$_};
+		}
+
+		$log->{res} = {
+			headers => $res_headers,
+		};
+
+		if($c->tx->res->code) {
+			$log->{res}->{statusCode} = $c->tx->res->code;
+
+			if($c->tx->res->code >= 400) {
+				$log->{res}->{body} = $c->res->body;
+			}
+		}
+
+		if ($features{'audit'}) {
+			$log->{req}->{body} = $c->req->body;
+			unless ($c->req->url =~ /login/) {
+				$log->{res}->{body} = $c->res->body;
+			}
+		}
+
+		my $l = Conch::Log->new(
+			path  => $log_path,
+			level => 'debug',
+		);
+
+		$l->request_id($c->req->request_id);
+		$l->payload($log);
+		$l->info();
+	});
+}
+
+
+1;
+__END__
+
+=pod
+
+=head1 LICENSING
+
+Copyright Joyent, Inc.
+
+This Source Code Form is subject to the terms of the Mozilla Public License,
+v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+one at http://mozilla.org/MPL/2.0/.
+
+=cut

--- a/lib/Conch/Role/MojoLog.pm
+++ b/lib/Conch/Role/MojoLog.pm
@@ -1,0 +1,58 @@
+=head1 NAME
+
+Conch::Role::MojoLog - Provide logging to a Mojo controllers
+
+=head1 DESCRIPTION
+
+This role provides a log method for a Mojo controller that adds additional
+context to the logs
+
+=head1 SYNOPSIS
+
+	use Role::Tiny;
+	with 'Conch::Role::MojoLog';
+
+	sub wat ($c) {
+		$c->log->debug('message');
+	}
+
+=head1 METHODS
+
+=cut
+
+package Conch::Role::MojoLog;
+use Mojo::Base -role;
+use Role::Tiny;
+
+=head2 log
+
+The logger itself. The usual levels are available, like debug, warn, etc.
+
+=cut
+	
+has log => sub {
+    my $c = shift;
+	my $home = $c->app->home;
+	my $mode = $c->app->mode;
+
+    return Conch::Log->new(
+        request_id => $c->req->request_id,
+		path       => $home->child('log', "$mode.log"),
+		level      => 'debug',
+    );
+};
+
+1;
+__END__
+
+=pod
+
+=head1 LICENSING
+
+Copyright Joyent, Inc.
+
+This Source Code Form is subject to the terms of the Mozilla Public License,
+v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+one at http://mozilla.org/MPL/2.0/.
+
+=cut

--- a/lib/Conch/Time.pm
+++ b/lib/Conch/Time.pm
@@ -147,6 +147,17 @@ sub timestamptz {
 	return shift->moment->strftime("%Y-%m-%d %H:%M:%S%f%z");
 }
 
+
+=head3 iso8601
+
+Render the timestamp as an ISO8601 extended format, in UTC
+
+=cut
+
+sub iso8601 {
+	return shift->moment->at_utc->strftime("%Y-%m-%dT%H:%M:%S%f%Z");
+}
+
 1;
 __END__
 

--- a/lib/Test/Conch/Datacenter.pm
+++ b/lib/Test/Conch/Datacenter.pm
@@ -20,6 +20,8 @@ use Mojo::Base 'Test::Conch';
 use Test::ConchTmpDB;
 use Conch::Models;
 
+use Conch::Log;
+
 
 =head2 new
 
@@ -37,8 +39,8 @@ sub new {
 		pg => Test::ConchTmpDB->make_full_db,
 	);
 
-	Conch::ValidationSystem->load_validation_plans([
-		{
+	Conch::ValidationSystem->load_validation_plans(
+		[{
 			name        => 'Conch v1 Legacy Plan: Server',
 			description => 'Test Plan',
 			validations => [ { name => 'product_name', version => 1 } ]

--- a/lib/Test/Conch/Datacenter.pm
+++ b/lib/Test/Conch/Datacenter.pm
@@ -42,8 +42,9 @@ sub new {
 			name        => 'Conch v1 Legacy Plan: Server',
 			description => 'Test Plan',
 			validations => [ { name => 'product_name', version => 1 } ]
-		}
-	]);
+		}],
+		Conch::Log->new(level => 'fatal'),
+	);
 
 	bless($self, $class);
 	return $self;

--- a/t/integration/02_hardware_product_profiles_loaded.t
+++ b/t/integration/02_hardware_product_profiles_loaded.t
@@ -10,13 +10,14 @@ my $uuid = Data::UUID->new;
 
 my $t = Test::Conch->new;
 
-Conch::ValidationSystem->load_validation_plans([
-	{
+Conch::ValidationSystem->load_validation_plans(
+	[{
 		name        => 'Conch v1 Legacy Plan: Server',
 		description => 'Test Plan',
 		validations => [ { name => 'product_name', version => 1 } ]
-	}
-]);
+	}],
+	Conch::Log->new(level => 'debug'),
+);
 
 $t->schema->storage->dbh_do(sub {
 	my ($storage, $dbh, @args) = @_;

--- a/t/integration/02_hardware_product_profiles_loaded.t
+++ b/t/integration/02_hardware_product_profiles_loaded.t
@@ -16,7 +16,7 @@ Conch::ValidationSystem->load_validation_plans(
 		description => 'Test Plan',
 		validations => [ { name => 'product_name', version => 1 } ]
 	}],
-	Conch::Log->new(level => 'debug'),
+	$t->app->log,
 );
 
 $t->schema->storage->dbh_do(sub {

--- a/t/integration/03_zpool_profiles_loaded.t
+++ b/t/integration/03_zpool_profiles_loaded.t
@@ -10,13 +10,14 @@ my $uuid = Data::UUID->new;
 
 my $t = Test::Conch->new;
 
-Conch::ValidationSystem->load_validation_plans([
-	{
+Conch::ValidationSystem->load_validation_plans(
+	[{
 		name        => 'Conch v1 Legacy Plan: Server',
 		description => 'Test Plan',
 		validations => [ { name => 'product_name', version => 1 } ]
-	}
-]);
+	}],
+	Conch::Log->new(level => 'debug'),
+);
 
 $t->schema->storage->dbh_do(sub {
 	my ($storage, $dbh, @args) = @_;

--- a/t/integration/03_zpool_profiles_loaded.t
+++ b/t/integration/03_zpool_profiles_loaded.t
@@ -16,7 +16,7 @@ Conch::ValidationSystem->load_validation_plans(
 		description => 'Test Plan',
 		validations => [ { name => 'product_name', version => 1 } ]
 	}],
-	Conch::Log->new(level => 'debug'),
+	$t->app->log,
 );
 
 $t->schema->storage->dbh_do(sub {

--- a/t/validation-system/01-load-validations.t
+++ b/t/validation-system/01-load-validations.t
@@ -16,9 +16,11 @@ my $pgtmp = mk_tmp_db();
 $pgtmp or die;
 my $pg    = Conch::Pg->new( $pgtmp->uri );
 
+use Conch::Log;
+my $logger = Conch::Log->new(level => 'warn');
+
 my $num_validations_loaded =
-	Conch::ValidationSystem->load_validations(
-	Mojo::Log->new( level => 'warn' ) );
+	Conch::ValidationSystem->load_validations($logger);
 
 my $loaded_validations = Conch::Model::Validation->list;
 
@@ -29,8 +31,7 @@ is(
 );
 
 my $num_validations_reloaded =
-	Conch::ValidationSystem->load_validations(
-	Mojo::Log->new( level => 'warn' ) );
+	Conch::ValidationSystem->load_validations($logger);
 
 is( $num_validations_reloaded, 0, 'No new validations loaded' );
 

--- a/t/validation-system/02-load-validation-plans.t
+++ b/t/validation-system/02-load-validation-plans.t
@@ -16,7 +16,9 @@ my $pgtmp = mk_tmp_db();
 $pgtmp or die;
 my $pg    = Conch::Pg->new( $pgtmp->uri );
 
-my $logger = Mojo::Log->new( level => 'warn' );
+
+use Conch::Log;
+my $logger = Conch::Log->new( level => 'warn' );
 
 Conch::ValidationSystem->load_validations($logger);
 


### PR DESCRIPTION
This also alters the functionality of audit logging. All the data formally only available when auditing is now available in the regular logs. The exception is request bodies and non-error response bodies. The audit feature flag controls the inclusion of that data.