### PR TITLE
features: new /user interfaces for adding, deleting users and resetting password

### DIFF
--- a/json-schema/input.yaml
+++ b/json-schema/input.yaml
@@ -273,3 +273,15 @@ definitions:
     properties:
       password:
         type: string
+  NewUser:
+    type: object
+    additionalProperties: false
+    required:
+      - email
+    properties:
+      name:
+        type: string
+      email:
+        type: string
+      password:
+        type: string

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -1320,4 +1320,40 @@ definitions:
           - type: string
           - type: null
 
+  User:
+    type: object
+    additionalProperties: false
+    required:
+      - id
+      - email
+      - name
+    properties:
+      id:
+        type: string
+        format: uuid
+      email:
+        type: string
+      name:
+        type: string
+      created:
+        type: string
+        format: date-time
+      deactivated:
+        anyOf:
+          -
+            type: string
+            format: date-time
+          -
+            type: null
 
+  UserError:
+    type: object
+    additionalProperties: false
+    required:
+      - error
+      - user
+    properties:
+      error:
+        type: string
+      user:
+        $ref: /definitions/User

--- a/lib/Conch/Command/create_user.pm
+++ b/lib/Conch/Command/create_user.pm
@@ -57,7 +57,7 @@ sub run {
 
     if ($opt->send_email) {
         say 'sending email to ', $opt->email, '...';
-        Conch::Mail::new_user_invite({ email => $opt->email, password => $opt->password });
+        Conch::Mail::new_user_invite({ map { $_ => $opt->$_ } qw(name email password) });
     }
 }
 

--- a/lib/Conch/Controller/Login.pm
+++ b/lib/Conch/Controller/Login.pm
@@ -191,8 +191,14 @@ sub session_login ($c) {
 		|| $c->db_user_accounts->lookup_by_name($body->{user})
 		|| $c->db_user_accounts->lookup_by_email($body->{user});
 
+	if (not $user) {
+		$c->log->debug("user lookup for $body->{user} failed");
+		return $c->status(401, { error => 'unauthorized' });
+	}
+
 	if (not $user->validate_password($body->{password})) {
-		return $c->status(401, { error => 'Invalid login' });
+		$c->log->debug("password validation for $body->{user} failed");
+		return $c->status(401, { error => 'unauthorized' });
 	}
 
 	$c->stash(user_id => $user->id);

--- a/lib/Conch/Controller/User.pm
+++ b/lib/Conch/Controller/User.pm
@@ -40,9 +40,6 @@ Revoke a specified user's session tokens. Global admin only.
 =cut
 
 sub revoke_user_tokens ($c) {
-	return $c->status( 403, { error => 'Must be global admin' } )
-		unless $c->is_global_admin;
-
 	my $user_param = $c->stash('target_user');
 	my $user =
 		is_uuid($user_param) ? $c->db_user_accounts->lookup_by_id($user_param)

--- a/lib/Conch/Controller/User.pm
+++ b/lib/Conch/Controller/User.pm
@@ -43,7 +43,7 @@ sub revoke_user_tokens ($c) {
 	return $c->status( 403, { error => 'Must be global admin' } )
 		unless $c->is_global_admin;
 
-	my $user_param = $c->param('id');
+	my $user_param = $c->stash('target_user');
 	my $user =
 		is_uuid($user_param) ? $c->db_user_accounts->lookup_by_id($user_param)
 	  : $user_param =~ s/^email\=// ? $c->db_user_accounts->lookup_by_email($user_param)
@@ -91,7 +91,7 @@ FIXME: the key name is repeated in the URL and the payload :(
 
 sub set_setting ($c) {
 	my $body  = $c->req->json;
-	my $key   = $c->param('key');
+	my $key   = $c->stash('key');
 	my $value = $body->{$key};
 	return $c->status(
 		400,
@@ -150,7 +150,7 @@ Get the individual key/value pair for a setting for the User
 =cut
 
 sub get_setting ($c) {
-	my $key = $c->param('key');
+	my $key = $c->stash('key');
 
 	my $user = $c->stash('user');
 	Mojo::Exception->throw('Could not find previously stashed user')
@@ -174,7 +174,7 @@ Delete a single setting for a user, provided it was set previously
 =cut
 
 sub delete_setting ($c) {
-	my $key = $c->param('key');
+	my $key = $c->stash('key');
 
 	my $user = $c->stash('user');
 	Mojo::Exception->throw('Could not find previously stashed user')

--- a/lib/Conch/Controller/WorkspaceUser.pm
+++ b/lib/Conch/Controller/WorkspaceUser.pm
@@ -84,8 +84,9 @@ sub invite ($c) {
 
 		$c->log->info("User '".$body->{user}."' was created with ID ".$user->id);
 		$c->mail->send_new_user_invite({
-			email    => $user->email,
-			password => $password
+			name	=> $user->name,
+			email	=> $user->email,
+			password => $password,
 		});
 
 		# TODO update this complain when we stop sending plaintext passwords

--- a/lib/Conch/DB/Result/UserAccount.pm
+++ b/lib/Conch/DB/Result/UserAccount.pm
@@ -73,6 +73,11 @@ __PACKAGE__->table("user_account");
   data_type: 'text'
   is_nullable: 0
 
+=head2 deactivated
+
+  data_type: 'timestamp with time zone'
+  is_nullable: 1
+
 =cut
 
 __PACKAGE__->add_columns(
@@ -98,6 +103,8 @@ __PACKAGE__->add_columns(
   { data_type => "timestamp with time zone", is_nullable => 1 },
   "email",
   { data_type => "text", is_nullable => 0 },
+  "deactivated",
+  { data_type => "timestamp with time zone", is_nullable => 1 },
 );
 
 =head1 PRIMARY KEY
@@ -201,8 +208,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-07-20 14:29:05
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:/ob4MGQbDk0L0sqGUZ2EpA
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-01 09:20:44
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:Hm6V/LYtoz14U9T8434bkw
 
 use Crypt::Eksblowfish::Bcrypt qw(bcrypt en_base64);
 

--- a/lib/Conch/DB/ResultSet/UserAccount.pm
+++ b/lib/Conch/DB/ResultSet/UserAccount.pm
@@ -23,6 +23,19 @@ allowing us to receive the 'password' key, which we hash into 'password_hash'.
 
 =cut
 
+=head2 update
+
+This method is built in to all resultsets.  In Conch::DB::Result::UserAccount we have overrides
+allowing us to receive the 'password' key, which we hash into 'password_hash'.
+
+    $c->schema->resultset('UserAccount') or $c->db_user_accounts
+    ->update({
+        password => ...,
+        ... possibly other things
+    });
+
+=cut
+
 =head2 lookup_by_id
 
 =cut
@@ -30,7 +43,7 @@ allowing us to receive the 'password' key, which we hash into 'password_hash'.
 sub lookup_by_id {
     my ($self, $user_id) = @_;
     return if not is_uuid($user_id);    # avoid pg exception "invalid input syntax for uuid"
-    $self->find({ id => $user_id });
+    $self->active->find({ id => $user_id });
 }
 
 =head2 lookup_by_email
@@ -39,7 +52,7 @@ sub lookup_by_id {
 
 sub lookup_by_email {
     my ($self, $email) = @_;
-    $self->find({ email => $email });
+    $self->active->find({ email => $email });
 }
 
 =head2 lookup_by_name
@@ -48,7 +61,33 @@ sub lookup_by_email {
 
 sub lookup_by_name {
     my ($self, $name) = @_;
-    $self->find({ name => $name });
+    $self->active->find({ name => $name });
+}
+
+=head2 active
+
+Chainable resultset to limit results to those that aren't deactivated.
+TODO: move to a role 'Deactivatable'
+
+=cut
+
+sub active {
+    my $self = shift;
+
+    $self->search({ deactivated => undef });
+}
+
+=head2 deactivate
+
+Update all matching rows by setting deactivated = NOW().
+TODO: move to a role 'Deactivatable'
+
+=cut
+
+sub deactivate {
+    my $self = shift;
+
+    $self->update({ deactivated => \'NOW()' });
 }
 
 1;

--- a/lib/Conch/Mail.pm
+++ b/lib/Conch/Mail.pm
@@ -119,6 +119,82 @@ sub password_reset_email {
 		&& $log->info("Existing user invite successfully sent to $email.");
 }
 
+=head2 changed_user_password
+
+Send mail when resetting an existing user's password
+
+=cut
+
+sub changed_user_password {
+	my ($args)   = @_;
+	my $name     = $args->{name};
+	my $email    = $args->{email};
+	my $password = $args->{password};
+
+	my $to = $email;
+	$to = "$name <$to>" if $name ne $email;
+
+	my $headers = {
+		To      => $to,
+		From    => 'noreply@conch.joyent.us',
+		Subject => "Your Conch password has changed.",
+	};
+	my $template = qq{Hello,
+
+    Your password at Joyent Conch has been reset. You should now log
+    into https://conch.joyent.us using the credentials below:
+
+    Username: $name
+    Email:    $email
+    Password: $password
+
+    Thank you,
+    Joyent Build Ops Team
+    };
+
+	send_mail_with_template($template, $headers)
+		&& $log->info("Password reset email sent to $email.");
+}
+
+=head2 welcome_new_user
+
+Template for the email when a new user has been created
+
+=cut
+
+sub welcome_new_user {
+	my ($args)   = @_;
+	my $name     = $args->{name};
+	my $email    = $args->{email};
+	my $password = $args->{password};
+
+	my $to = $email;
+	$to = "$name <$to>" if $name ne $email;
+
+	my $headers = {
+		To      => $to,
+		From    => 'noreply@conch.joyent.us',
+		Subject => "Welcome to Conch!",
+	};
+
+	my $template = qq{Hello,
+
+    You have been invited to join Joyent Conch. An account has been created for
+    you. Please log into https://conch.joyent.us using the credentials
+    below:
+
+    Username: $name
+    Email:    $email
+    Password: $password
+
+    Thank you,
+    Joyent Build Ops Team
+    };
+
+	send_mail_with_template($template, $headers)
+		&& $log->info("New user invite successfully sent to $email.");
+}
+
 1;
 __END__
 

--- a/lib/Conch/Mail.pm
+++ b/lib/Conch/Mail.pm
@@ -52,11 +52,15 @@ Template for the email for inviting a new user
 
 sub new_user_invite {
 	my ($args)   = @_;
+	my $name     = $args->{name};
 	my $email    = $args->{email};
 	my $password = $args->{password};
 
+	my $to = $email;
+	$to = "$name <$to>" if $name ne $email;
+
 	my $headers = {
-		To      => $email,
+		To      => $to,
 		From    => 'noreply@conch.joyent.us',
 		Subject => "Welcome to Conch!",
 	};
@@ -67,7 +71,8 @@ sub new_user_invite {
     you. Please log into https://conch.joyent.us using the credentials
     below:
 
-    Username: $email
+    Username: $name
+    Email:    $email
     Password: $password
 
     Thank you,

--- a/lib/Conch/Plugin/Mail.pm
+++ b/lib/Conch/Plugin/Mail.pm
@@ -27,7 +27,6 @@ sub register ( $self, $app, $conf ) {
 	$app->helper( mail => sub { $self } );
 }
 
-
 =head2 send_password_reset_email
 
 Alias for Conch::Mail::password_reset_email
@@ -40,7 +39,6 @@ sub send_password_reset_email {
 	Conch::Mail::password_reset_email(@_);
 }
 
-
 =head2 send_new_user_invite
 
 Alias for Conch::Mail::new_user_invite
@@ -51,6 +49,30 @@ sub send_new_user_invite {
 	my $self = shift;	# probably app or controller
 	$self->log->debug('sending new user invite mail');
 	Conch::Mail::new_user_invite(@_);
+}
+
+=head2 send_changed_user_password
+
+Alias for Conch::Mail::changed_user_password
+
+=cut
+
+sub send_changed_user_password {
+	my $self = shift;	# probably app or controller
+	$self->log->debug('sending "password was changed" mail');
+	Conch::Mail::changed_user_password(@_);
+}
+
+=head2 send_welcome_new_user
+
+Alias for Conch::Mail::welcome_new_user
+
+=cut
+
+sub send_welcome_new_user {
+	my $self = shift;	# probably app or controller
+	$self->log->debug('sending "welcome new user" mail');
+	Conch::Mail::welcome_new_user(@_);
 }
 
 1;

--- a/lib/Conch/Plugin/Mail.pm
+++ b/lib/Conch/Plugin/Mail.pm
@@ -35,7 +35,8 @@ Alias for Conch::Mail::password_reset_email
 =cut
 
 sub send_password_reset_email {
-	shift;
+	my $self = shift;	# probably app or controller
+	$self->log->debug('sending password reset mail');
 	Conch::Mail::password_reset_email(@_);
 }
 
@@ -47,7 +48,8 @@ Alias for Conch::Mail::new_user_invite
 =cut
 
 sub send_new_user_invite {
-	shift;
+	my $self = shift;	# probably app or controller
+	$self->log->debug('sending new user invite mail');
 	Conch::Mail::new_user_invite(@_);
 }
 

--- a/lib/Conch/Route.pm
+++ b/lib/Conch/Route.pm
@@ -37,34 +37,34 @@ Set up the full route structure
 =cut
 
 sub all_routes {
-	my $unsecured = shift;	# this is the base routing object
+	my $root = shift;	# this is the base routing object
 	my $features = shift || {};
 
 	# CORS preflight check
-	$unsecured->options('*', sub{ shift->status(204) });
+	$root->options('*', sub{ shift->status(204) });
 
-	$unsecured->get( '/doc',
+	$root->get( '/doc',
 		sub { shift->reply->static('public/doc/index.html') } );
 
-	$unsecured->get(
+	$root->get(
 		'/ping',
 		sub { shift->status( 200, { status => 'ok' } ) },
 	);
 
-	$unsecured->get(
+	$root->get(
 		'/version' => sub {
 			my $c = shift;
 			$c->status( 200, { version => $c->version_tag } );
 		}
 	);
 
-	$unsecured->post('/login')->to('login#session_login');
-	$unsecured->post('/logout')->to('login#session_logout');
-	$unsecured->post('/reset_password')->to('login#reset_password');
+	$root->post('/login')->to('login#session_login');
+	$root->post('/logout')->to('login#session_logout');
+	$root->post('/reset_password')->to('login#reset_password');
 
 	# all routes after this point require authentication
 
-	my $secured = $unsecured->to('login#authenticate')->under;
+	my $secured = $root->to('login#authenticate')->under;
 
 	$secured->get( '/login', sub { shift->status(204) } );
 	$secured->get( '/me',    sub { shift->status(204) } );

--- a/lib/Conch/Route/User.pm
+++ b/lib/Conch/Route/User.pm
@@ -28,6 +28,9 @@ Sets up routes for the /user namespace
     DELETE  /user/me/settings/#key
     POST    /user/me/password
     POST    /user/#target_user/revoke
+    DELETE  /user/#target_user/password
+    POST    /user
+    DELETE  /user/#target_user
 
 =cut
 
@@ -59,7 +62,7 @@ sub user_routes {
         }
 
         # after changing password, (possibly) pass through to logging out too
-        $user_me->post('/password')->to('#change_password')
+        $user_me->post('/password')->to('#change_own_password')
             ->under->any->to('login#session_logout');
     }
 
@@ -69,6 +72,10 @@ sub user_routes {
         my $user_with_target = $user->require_global_admin->any('/#target_user');
 
         $user_with_target->post('/revoke')->to('#revoke_user_tokens');
+        $user_with_target->delete('/password')->to('#reset_user_password');
+
+        $user->require_global_admin->post('/')->to('#create');
+        $user_with_target->delete('/')->to('#deactivate');
     }
 }
 

--- a/lib/Conch/Route/User.pm
+++ b/lib/Conch/Route/User.pm
@@ -63,10 +63,10 @@ sub user_routes {
             ->under->any->to('login#session_logout');
     }
 
-    # interfaces for updating a different user's account...
+    # administrator interfaces for updating a different user's account...
     {
         # target_user could be a user id or email
-        my $user_with_target = $user->any('/#target_user');
+        my $user_with_target = $user->require_global_admin->any('/#target_user');
 
         $user_with_target->post('/revoke')->to('#revoke_user_tokens');
     }

--- a/lib/Test/Conch.pm
+++ b/lib/Test/Conch.pm
@@ -124,6 +124,7 @@ sub json_schema_is {
                     . " Error(s) occurred when validating $req with schema "
                     . "$schema':\n\t"
                     . join( "\n\t", @errors ) );
+            0;
         }
     );
 }

--- a/sql/migrations/0036-user_account-deactivate.sql
+++ b/sql/migrations/0036-user_account-deactivate.sql
@@ -1,0 +1,4 @@
+-- add 'deactivated' column to user_account
+SELECT run_migration(36, $$
+	alter table user_account add column deactivated timestamptz DEFAULT NULL;
+$$);

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -737,7 +737,8 @@ CREATE TABLE public.user_account (
     password_hash text NOT NULL,
     created timestamp with time zone DEFAULT now() NOT NULL,
     last_login timestamp with time zone,
-    email text NOT NULL
+    email text NOT NULL,
+    deactivated timestamp with time zone
 );
 
 


### PR DESCRIPTION
features: new /user interfaces for adding, deleting users and resetting password
    
        DELETE  /user/<id>/password
        POST    /user          json payload: { name: ..., email: ..., password: <optional> }
        DELETE  /user/<id>
    
    This change includes a database migration.

    fulfills
        - LP-46272834 (forced password reset)
        - LP-46519267 (deactivate users rather than deleting them)
