### PR TITLE
fix: treat email addresses as if they were case insensitive for lookups

### DIFF
--- a/lib/Conch/Command/create_user.pm
+++ b/lib/Conch/Command/create_user.pm
@@ -41,8 +41,13 @@ sub run {
         [ 'help',           'print usage message and exit', { shortcircuit => 1 } ],
     );
 
-    if ($self->app->db_user_accounts->search([ name => $opt->name, email => $opt->email ])->count) {
-        $self->app->log->warn('cannot create user: name ' . $opt->name . ' and/or email ' . $opt->email . ' already exists');
+    if ($self->app->db_user_accounts->search({
+			-or => [
+				{ name => $opt->name },
+				\[ 'lower(email) = lower(?)', $opt->email ],
+			]
+		})->count) {
+        say 'cannot create user: name ' . $opt->name . ' and/or email ' . $opt->email . ' already exists';
         return;
     }
 

--- a/lib/Conch/Controller/User.pm
+++ b/lib/Conch/Controller/User.pm
@@ -279,7 +279,10 @@ sub create ($c) {
 
 	# we don't use lookup_by_* because they only search active users.
 	if (my $user = $c->db_user_accounts->search({
-			-or => { name => $name, email => $email }
+			-or => [
+				{ name => $name },
+				\[ 'lower(email) = lower(?)', $email ],
+			]
 		})->first)
 	{
 		return $c->status(409, {

--- a/lib/Conch/DB/ResultSet/UserAccount.pm
+++ b/lib/Conch/DB/ResultSet/UserAccount.pm
@@ -48,11 +48,20 @@ sub lookup_by_id {
 
 =head2 lookup_by_email
 
+Returns the user with the (case-insensitively) matching email.
+
+If more than one is found, we return the one created most recently, and a warning will be
+logged (via DBIx::Class::ResultSet::single).
+
 =cut
 
 sub lookup_by_email {
     my ($self, $email) = @_;
-    $self->active->find({ email => $email });
+
+    $self->active->search(
+        [ \[ 'lower(email) = lower(?)', $email ] ],
+        { order_by => { -desc => 'created' } },
+    )->single;
 }
 
 =head2 lookup_by_name

--- a/sql/migrations/0037-user-account-email-citext.sql
+++ b/sql/migrations/0037-user-account-email-citext.sql
@@ -1,0 +1,9 @@
+SELECT run_migration(37, $$
+	create table user_account_bak_v2_15 as table user_account;
+
+	-- to see the duplicates, do:
+	-- select u1.* from user_account u1 inner join user_account u2 ON lower(u1.email) = lower(u2.email) and u1.created < u2.created;
+
+	delete from user_account where id in ( select distinct u1.id from user_account u1 inner join user_account u2 ON lower(u1.email) = lower(u2.email) and u1.created < u2.created );
+$$);
+


### PR DESCRIPTION
this closes issue #141.

This can also be achieved by changing user_account.email from type
'text' to type 'citext', and adding this to the schema (but it requires
superuser privileges to execute, so migrating might be awkward):

    CREATE EXTENSION IF NOT EXISTS citext;