### PR TITLE
When resetting a user's password, force them to change it

### DIFF
--- a/lib/Conch/Controller/Login.pm
+++ b/lib/Conch/Controller/Login.pm
@@ -313,30 +313,11 @@ with their new password.
 
 sub reset_password ($c) {
 	my $body = $c->req->json;
+
 	return $c->status( 400, { error => '"email" required' } )
 		unless $body->{email};
 
-	# check for the user and sent the email non-blocking to prevent timing attacks
-	Mojo::IOLoop->subprocess(
-		sub {
-			my $user = $c->db_user_accounts->lookup_by_email($body->{email});
-
-			if ($user) {
-				my $pw = $c->random_string();
-				$user->update({ password => $pw });
-
-				$c->log->info('sending password reset mail to user ' . $user->name);
-				Conch::Mail::password_reset_email(
-					{
-						email    => $user->email,
-						password => $pw,
-					}
-				);
-			}
-		},
-		sub { }
-	);
-	return $c->status(204);
+	return $c->status(301, "/user/email=$body->{email}/password");
 }
 
 =head2 refresh_token

--- a/lib/Conch/Controller/Login.pm
+++ b/lib/Conch/Controller/Login.pm
@@ -162,16 +162,13 @@ sub authenticate ($c) {
 	# earlier (via /login)?
 	$user_id ||= $c->session('user');
 
-	unless ($user_id && is_uuid($user_id)) {
-		$c->status( 401, { error => 'unauthorized' } );
-		return 0;
-	}
-
-	$c->log->debug('looking up user by id ' . $user_id . '...');
-	if (my $user = $c->db_user_accounts->lookup_by_id($user_id)) {
-		$c->stash( user_id => $user_id );
-		$c->stash( user    => $user );
-		return 1;
+	if ($user_id and is_uuid($user_id)) {
+		$c->log->debug('looking up user by id ' . $user_id . '...');
+		if (my $user = $c->db_user_accounts->lookup_by_id($user_id)) {
+			$c->stash( user_id => $user_id );
+			$c->stash( user    => $user );
+			return 1;
+		}
 	}
 
 	$c->status( 401, { error => 'unauthorized' } );

--- a/lib/Conch/Controller/User.pm
+++ b/lib/Conch/Controller/User.pm
@@ -50,6 +50,7 @@ sub revoke_user_tokens ($c) {
 	return $c->status( 404, { error => "user $user_param not found" } )
 		unless $user;
 
+	$c->log->debug('revoking session tokens for user ' . $user->name . ', forcing them to /login again');
 	$user->delete_related('user_session_tokens');
 
 	$c->status(204);

--- a/lib/Conch/DB/Result/UserAccount.pm
+++ b/lib/Conch/DB/Result/UserAccount.pm
@@ -76,6 +76,18 @@ __PACKAGE__->table("user_account");
   data_type: 'timestamp with time zone'
   is_nullable: 1
 
+=head2 refuse_session_auth
+
+  data_type: 'boolean'
+  default_value: false
+  is_nullable: 0
+
+=head2 force_password_change
+
+  data_type: 'boolean'
+  default_value: false
+  is_nullable: 0
+
 =cut
 
 __PACKAGE__->add_columns(
@@ -103,6 +115,10 @@ __PACKAGE__->add_columns(
   { data_type => "text", is_nullable => 0 },
   "deactivated",
   { data_type => "timestamp with time zone", is_nullable => 1 },
+  "refuse_session_auth",
+  { data_type => "boolean", default_value => \"false", is_nullable => 0 },
+  "force_password_change",
+  { data_type => "boolean", default_value => \"false", is_nullable => 0 },
 );
 
 =head1 PRIMARY KEY
@@ -206,8 +222,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-01 14:34:45
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:+qcKfZJc/oa3IWDNp/Q08A
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-03 10:49:18
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:H1YZWElkgjg1bvGLKrka5w
 
 use Crypt::Eksblowfish::Bcrypt qw(bcrypt en_base64);
 

--- a/lib/Conch/Mail.pm
+++ b/lib/Conch/Mail.pm
@@ -17,13 +17,6 @@ use Mail::Sendmail;
 use Data::Printer;
 use Log::Any '$log';
 
-use Exporter 'import';
-our @EXPORT_OK = qw(
-	send_mail_with_template
-	new_user_invite
-	password_reset_email
-);
-
 =head2 send_mail_with_template
 
 Simple email sender.
@@ -32,6 +25,8 @@ Simple email sender.
 
 sub send_mail_with_template {
 	my ($content, $mail_args) = @_;
+
+	# TODO: we should use Mojo::IOLoop->subprocess to send these.
 
 	# TODO: make use of Mojo::Template for more sophisticated content munging.
 
@@ -81,42 +76,6 @@ sub new_user_invite {
 
 	send_mail_with_template($template, $headers)
 		&& $log->info("New user invite successfully sent to $email.");
-}
-
-=head2 password_reset_email
-
-Template for reseting a existing user's password
-
-=cut
-
-sub password_reset_email {
-	my ($args)   = @_;
-	my $email    = $args->{email};
-	my $password = $args->{password};
-
-	my $headers = {
-		To      => $email,
-		From    => 'noreply@conch.joyent.us',
-		Subject => "Conch Password Reset",
-	};
-
-	my $template = qq{Hello,
-
-    A request was received to reset your password.  A new password has been
-    randomly generated and your old password has been deactivated.
-
-    Please log into https://conch.joyent.us using the following credentials:
-
-    Username: $email
-    Password: $password
-
-
-    Thank you,
-    Joyent Build Ops Team
-    };
-
-	send_mail_with_template($template, $headers)
-		&& $log->info("Existing user invite successfully sent to $email.");
 }
 
 =head2 changed_user_password

--- a/lib/Conch/Mail.pm
+++ b/lib/Conch/Mail.pm
@@ -142,7 +142,10 @@ sub changed_user_password {
 	my $template = qq{Hello,
 
     Your password at Joyent Conch has been reset. You should now log
-    into https://conch.joyent.us using the credentials below:
+    into https://conch.joyent.us using the credentials below.
+
+	WARNING!!! You will only be able to use this password once, and
+	must select a new password within 10 minutes after logging in.
 
     Username: $name
     Email:    $email

--- a/lib/Conch/Route/User.pm
+++ b/lib/Conch/Route/User.pm
@@ -14,11 +14,9 @@ use Mojo::Base -strict;
 use Exporter 'import';
 our @EXPORT_OK = qw(user_routes);
 
-use DDP;
-
 =head2 user_routes
 
-Sets up routes for the /user namespace
+Sets up routes for /user:
 
     POST    /user/me/revoke
     GET     /user/me/settings
@@ -45,23 +43,30 @@ sub user_routes {
         # all these routes are under /user/
         my $user_me = $user->any('/me');
 
+        # POST /user/me/revoke
         $user_me->post('/revoke')->to('#revoke_own_tokens');
 
         {
             my $user_me_settings = $user_me->any('/settings');
 
+            # GET /user/me/settings
             $user_me_settings->get->to('#get_settings');
+            # POST /user/me/settings
             $user_me_settings->post->to('#set_settings');
 
             # 'key' is extracted into the stash
             my $user_me_settings_with_key = $user_me_settings->any('/#key');
 
+            # GET /user/me/settings/#key
             $user_me_settings_with_key->get->to('#get_setting');
+            # POST /user/me/settings/#key
             $user_me_settings_with_key->post->to('#set_setting');
+            # DELETE /user/me/settings/#key
             $user_me_settings_with_key->delete->to('#delete_setting');
         }
 
         # after changing password, (possibly) pass through to logging out too
+        # POST /user/me/password
         $user_me->post('/password')->to('#change_own_password')
             ->under->any->to('login#session_logout');
     }
@@ -71,10 +76,13 @@ sub user_routes {
         # target_user could be a user id or email
         my $user_with_target = $user->require_global_admin->any('/#target_user');
 
+        # POST /user/#target_user/revoke
         $user_with_target->post('/revoke')->to('#revoke_user_tokens');
+        # DELETE /user/#target_user/password
         $user_with_target->delete('/password')->to('#reset_user_password');
-
+        # POST /user
         $user->require_global_admin->post('/')->to('#create');
+        # DELETE /user/#target_user
         $user_with_target->delete('/')->to('#deactivate');
     }
 }

--- a/lib/Test/Conch.pm
+++ b/lib/Test/Conch.pm
@@ -90,6 +90,19 @@ sub new {
     return $self;
 }
 
+=head2 location_is
+
+Stolen from Test::Mojo's examples. I don't know why this isn't just part of the interface!
+
+=cut
+
+sub location_is {
+    my ($t, $value, $desc) = @_;
+    $desc ||= "Location: $value";
+    local $Test::Builder::Level = $Test::Builder::Level + 1;
+    return $t->success(Test::More->builder->is_eq($t->tx->res->headers->location, $value, $desc));
+}
+
 =head2 json_schema_is
 
 Adds a method 'json_schema_is` to validate the JSON response of

--- a/sql/migrations/0038-force-password-change.sql
+++ b/sql/migrations/0038-force-password-change.sql
@@ -1,0 +1,4 @@
+SELECT run_migration(38, $$
+	alter table user_account add column refuse_session_auth boolean default false not null;
+	alter table user_account add column force_password_change boolean default false not null;
+$$);

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -738,7 +738,9 @@ CREATE TABLE public.user_account (
     created timestamp with time zone DEFAULT now() NOT NULL,
     last_login timestamp with time zone,
     email text NOT NULL,
-    deactivated timestamp with time zone
+    deactivated timestamp with time zone,
+    refuse_session_auth boolean DEFAULT false NOT NULL,
+    force_password_change boolean DEFAULT false NOT NULL
 );
 
 

--- a/t/integration/00_only_1_user_loaded.t
+++ b/t/integration/00_only_1_user_loaded.t
@@ -35,6 +35,7 @@ my $conch_user = $t->schema->resultset('UserAccount')->find({ name => 'conch' })
 ok($conch_user->last_login >= $now, 'user last_login is updated')
 	or diag('last_login not updated: ' . $conch_user->last_login . ' is not updated to ' . $now);
 
+
 subtest 'User' => sub {
 	$t->get_ok("/me")->status_is(204)->content_is("");
 	$t->get_ok("/user/me/settings")->status_is(200)->json_is( '', {} );
@@ -541,7 +542,7 @@ subtest 'modify another user' => sub {
 		->json_is('/user/name' => 'foo', 'got user name')
 		->json_is('/user/deactivated' => undef, 'got user deactivated date');
 
-	my $t2 = Test::Conch->new;
+	my $t2 = Test::Conch->new(pg => $t->pg);
 	$t2->post_ok(
 		'/login' => json => {
 			user     => 'foo',
@@ -553,14 +554,13 @@ subtest 'modify another user' => sub {
 
 	$t2->get_ok('/me')->status_is(204);
 
-	my $t3 = Test::Conch->new;	# we will only use this $mojo for basic auth
+	my $t3 = Test::Conch->new(pg => $t->pg);	# we will only use this $mojo for basic auth
 	$t3->get_ok($t3->ua->server->url->userinfo('foo:123')->path('/me'))
 		->status_is(204, 'user can also use the app with basic auth');
 
 	$t->post_ok("/user/$new_user_id/revoke")
 		->status_is(204, 'revoked all tokens for the new user');
 
-	$t2->reset_session;
 	$t2->get_ok('/me')->status_is(401, 'new user cannot authenticate with persistent session after session is cleared')
 		->json_is({ error => 'unauthorized' });
 
@@ -587,10 +587,10 @@ subtest 'modify another user' => sub {
 	# in order to get the user's new password, we need to extract it from a method call before
 	# we forget it -- so we pull it out of the call to UserAccount->update.
 	my $orig_update = \&Conch::DB::Result::UserAccount::update;
-	my $new_password;
+	my $_new_password;
 	no warnings 'redefine';
 	local *Conch::DB::Result::UserAccount::update = sub {
-		$new_password = $_[1]->{password} if exists $_[1]->{password};
+		$_new_password = $_[1]->{password} if exists $_[1]->{password};
 		$orig_update->(@_);
 	};
 
@@ -606,8 +606,17 @@ subtest 'modify another user' => sub {
 	$t->delete_ok(
 		'/user/email=FOO@CONCH.JOYENT.US/password?send_password_reset_mail=0')
 		->status_is(204, 'reset the new user\'s password again, using (case insensitive) email lookup');
+	my $insecure_password = $_new_password;
 
-	$t2->reset_session;
+	$t2->get_ok('/me')
+		->status_is(401, 'user can no longer use his saved session after his password is changed')
+		->json_is({ error => 'unauthorized' });
+
+	$t2->reset_session;	# force JWT to be used to authenticate
+	$t2->get_ok('/me', { Authorization => "Bearer $jwt_token.$jwt_sig" })
+		->status_is(401, 'user cannot authenticate with JWT after his password is changed')
+		->json_is({ error => 'unauthorized' });
+
 	$t2->post_ok(
 		'/login' => json => {
 			user     => 'foo',
@@ -616,17 +625,71 @@ subtest 'modify another user' => sub {
 		->status_is(401, 'cannot log in with the old password')
 		->json_is({ 'error' => 'unauthorized' });
 
+	$t3->get_ok($t3->ua->server->url->userinfo('foo:' . $insecure_password)->path('/me'))
+		->status_is(401, 'user cannot use new password with basic auth')
+		->location_is('/user/me/password')
+		->json_is({ error => 'unauthorized' });
+
 	$t2->post_ok(
 		'/login' => json => {
 			user     => 'foo',
-			password => $new_password,
+			password => $insecure_password,
 		})
-		->status_is(200, 'user can log in with new password');
+		->status_is(303, 'user can log in with new password')
+		->location_is('/user/me/password');
+	$jwt_token = $t2->tx->res->json->{jwt_token};
+	$jwt_sig   = $t2->tx->res->cookie('jwt_sig')->value;
+	cmp_ok($t2->tx->res->cookie('jwt_sig')->expires, '<', time + 11 * 60, 'JWT expires in 10 minutes');
 
-	$t2->get_ok('/me')->status_is(204);
+	$t2->get_ok('/me')
+		->status_is(401, 'user can\'t use his session to do anything else')
+		->location_is('/user/me/password')
+		->json_is({ error => 'unauthorized' });
 
-	$t3->get_ok($t3->ua->server->url->userinfo('foo:' . $new_password)->path('/me'))
-		->status_is(204, 'user can also use the new password in basic auth');
+	$t2->reset_session;	# force JWT to be used to authenticate
+	$t2->get_ok('/me', { Authorization => "Bearer $jwt_token.$jwt_sig" })
+		->status_is(401, 'user can\'t use his JWT to do anything else')
+		->location_is('/user/me/password')
+		->json_is({ error => 'unauthorized' });
+
+	$t2->post_ok(
+		'/login' => json => {
+			user     => 'foo',
+			password => $insecure_password,
+		})
+		->status_is(401, 'user cannot log in with the same insecure password again')
+		->json_is({ error => 'unauthorized' });
+
+	$t2->post_ok(
+		'/user/me/password' => { Authorization => "Bearer $jwt_token.$jwt_sig" }
+			=> json => { password => 'a more secure password' })
+		->status_is(204, 'user finally acquiesced and changed his password');
+
+	my $secure_password = $_new_password;
+	is($secure_password, 'a more secure password', 'provided password was saved to the db');
+
+	$t2->post_ok(
+		'/login' => json => {
+			user     => 'foo',
+			password => $secure_password,
+		})
+		->status_is(200, 'user can log in with new password')
+		->json_has('/jwt_token')
+		->json_hasnt('/message');
+	$jwt_token = $t2->tx->res->json->{jwt_token};
+	$jwt_sig   = $t2->tx->res->cookie('jwt_sig')->value;
+
+	$t2->get_ok('/me')
+		->status_is(204, 'user can use his saved session again after changing his password');
+	is($t2->tx->res->body, '', '...with no extra response messages');
+
+	$t2->reset_session;	# force JWT to be used to authenticate
+	$t2->get_ok('/me', { Authorization => "Bearer $jwt_token.$jwt_sig" })
+		->status_is(204, 'user authenticate with JWT again after his password is changed');
+	is($t2->tx->res->body, '', '...with no extra response messages');
+
+	$t3->get_ok($t3->ua->server->url->userinfo('foo:' . $secure_password)->path('/me'))
+		->status_is(204, 'after user fixes his password, he can use basic auth again');
 
 
 	$t->delete_ok("/user/foobar")
@@ -641,11 +704,11 @@ subtest 'modify another user' => sub {
 		->status_is(401, 'user cannot log in with saved browser session')
 		->json_is({ 'error' => 'unauthorized' });
 
-	$t2->reset_session;
+	$t2->reset_session;	# force JWT to be used to authenticate
 	$t2->post_ok(
 		'/login' => json => {
 			user     => 'foo',
-			password => $new_password,
+			password => $secure_password,
 		})
 		->status_is(401, 'user can no longer log in with credentials')
 		->json_is({ 'error' => 'unauthorized' });


### PR DESCRIPTION
- the user can no longer use any endpoint without logging in with the
  new password which is insecure, since it was in an email in plaintext)

- the user still cannot use any endpoint before changing his password,
  and existing session tokens (from the insecure login) will only work for
  10 minutes to allow him to do this.
