### PR TITLE
new test for multiple db connections in a test

### DIFF
--- a/lib/Test/Conch.pm
+++ b/lib/Test/Conch.pm
@@ -26,6 +26,9 @@ Override with your own Test::PostgreSQL object if you want to use a custom datab
 with extra settings or loaded with additional data.  Defaults to the basic database created by
 L<Test::ConchTmpDB/mk_tmp_db>.
 
+This is the attribute to copy if you want multiple Test::Conch objects to be able to talk to
+the same database.
+
 =cut
 
 has 'pg';   # this is generally a Test::PostgreSQL object

--- a/t/test-conch.t
+++ b/t/test-conch.t
@@ -1,0 +1,24 @@
+use strict;
+use warnings;
+use v5.26;
+
+use Test::More;
+use Test::Conch;
+
+subtest 'multiple Test::Conches talking to the same db' => sub {
+
+	my $t = Test::Conch->new;
+	my $new_user = $t->schema->resultset('UserAccount')->create({
+		name => 'foo',
+		email => 'foo@conch.joyent.us',
+		password => $t->app->random_string,
+	});
+
+	my $t2 = Test::Conch->new(pg => $t->pg);
+	my $new_user_copy = $t2->schema->resultset('UserAccount')->find({ name => 'foo' });
+	is($new_user->id, $new_user_copy->id, 'can obtain the user from the second test instance');
+
+};
+
+
+done_testing;


### PR DESCRIPTION
This shows that we can create multiple Test::Conches that all point to
the same db, each maintaining their own connection to it.