### PR TITLE
fix bad resultset replacement

### DIFF
--- a/lib/Conch/Controller/WorkspaceUser.pm
+++ b/lib/Conch/Controller/WorkspaceUser.pm
@@ -33,7 +33,10 @@ sub list ($c) {
 				(map { $_ => $uwr->user_account->$_ } qw(name email)),
 				role => $uwr->role,
 			}
-		} $c->stash('user_workspace_role_rs')->all
+		} $c->db_user_workspace_roles->search(
+			{ workspace_id => $c->stash('workspace_id') },
+			{ prefetch => 'user_account' },
+		)->all
 	];
 
 	$c->log->debug("Found ".scalar($users->@*)." users");

--- a/t/integration/04_test_datacenter_loaded.t
+++ b/t/integration/04_test_datacenter_loaded.t
@@ -533,6 +533,22 @@ subtest 'Permissions' => sub {
 		subtest "Can't get a relay list" => sub {
 			$t->get_ok("/relay")->status_is(403);
 		};
+
+		$t->get_ok("/workspace/$id/user")
+			->status_is(200, 'get list of users for this workspace')
+			->json_is([
+				{
+					name => 'conch',
+					email => 'conch@conch.joyent.us',
+					role => 'admin',
+				},
+				{
+					name => $ro_name,
+					email => $ro_email,
+					role => 'ro',
+				},
+			]);
+
 		$t->post_ok("/logout")->status_is(204);
 	};
 
@@ -582,8 +598,27 @@ subtest 'Permissions' => sub {
 			$t->get_ok("/relay")->status_is(403);
 		};
 
-		$t->post_ok("/logout")->status_is(204);
+		$t->get_ok("/workspace/$id/user")
+			->status_is(200, 'get list of users for this workspace')
+			->json_is([
+				{
+					name => 'conch',
+					email => 'conch@conch.joyent.us',
+					role => 'admin',
+				},
+				{
+					name => $ro_name,
+					email => $ro_email,
+					role => 'ro',
+				},
+				{
+					name => $name,
+					email => $email,
+					role => 'rw',
+				},
+			]);
 
+		$t->post_ok("/logout")->status_is(204);
 	};
 
 };


### PR DESCRIPTION
We want to search for workspaces across *all* users, not just the current user.
(this problem was just introduced in the last PR, commit 93ada4a06.)