### PR TITLE
add_user_to_workspace takes an id, not an object

### DIFF
--- a/lib/Conch/Controller/WorkspaceUser.pm
+++ b/lib/Conch/Controller/WorkspaceUser.pm
@@ -96,7 +96,7 @@ sub invite ($c) {
 
 	Conch::Model::Workspace->new->add_user_to_workspace(
 		$user->id,
-		$c->stash('current_workspace'),
+		$c->stash('current_workspace')->id,
 		$maybe_role->id
 	);
 	$c->log->info("Add user ".$user->id." to workspace ".$c->stash('current_workspace')->id);


### PR DESCRIPTION
issue introduced in commit bb2c8e26c
fixes rollbar exception #43
This change is not relevant to master given PR#337.