### PR TITLE
do not automatically redirect to /user/me/password

### DIFF
--- a/lib/Conch/Controller/Login.pm
+++ b/lib/Conch/Controller/Login.pm
@@ -252,7 +252,7 @@ sub session_login ($c) {
 		$c->session(expires => time + 10 * 60);
 
 		# we logged the user in, but he must now change his password (within 10 minutes)
-		$c->res->code(303);
+		$c->res->code(200);
 		$c->res->headers->location($c->url_for('/user/me/password'));
 		my $payload = { jwt_token => $c->_create_jwt($user->id, 10 * 60) };
 		$c->respond_to(

--- a/t/integration/00_only_1_user_loaded.t
+++ b/t/integration/00_only_1_user_loaded.t
@@ -679,7 +679,7 @@ subtest 'modify another user' => sub {
 			user     => 'foo',
 			password => $insecure_password,
 		})
-		->status_is(303, 'user can log in with new password')
+		->status_is(200, 'user can log in with new password')
 		->location_is('/user/me/password');
 	$jwt_token = $t2->tx->res->json->{jwt_token};
 	$jwt_sig   = $t2->tx->res->cookie('jwt_sig')->value;


### PR DESCRIPTION
...we cannot specify that it needs to be a POST, and the user doesn't
know what the payload should be, either.