### PR TITLE
Attempt at doing legacy_product_name lookups as a fallback

### DIFF
--- a/lib/Conch/Controller/DeviceReport.pm
+++ b/lib/Conch/Controller/DeviceReport.pm
@@ -45,6 +45,14 @@ sub process ($c) {
 			$device_report->{sku}
 		);
 
+		unless ($maybe_hw) {
+			$c->log->debug("Could not find hardware product by SKU, falling back to legacy_product_name");
+			$maybe_hw =
+				Conch::Model::HardwareProduct->lookup_by_legacy_product_name(
+					$device_report->{product_name}
+				);
+		}
+
 		return $c->status(409, {
 			error => "Hardware product SKU '".$device_report->{sku}."' does not exist"
 		}) unless ($maybe_hw);
@@ -123,6 +131,15 @@ sub _record_device_report {
 			sku => $dr->{sku}
 		}
 		);
+
+		unless ($hw) {
+			$c->log->debug("Could not find hardware product by SKU, falling back to legacy_product_name");
+			#$hw = Conch::Model::HardwareProduct->lookup_by_legacy_product_name(
+		    $hw = $schema->resultset('HardwareProduct')->find(
+				legacy_product_name => $dr->{product_name}
+			);
+		}
+
 		$hw or die $log->critical("Product $dr->{sku} not found");
 	}
 

--- a/lib/Conch/Controller/DeviceReport.pm
+++ b/lib/Conch/Controller/DeviceReport.pm
@@ -134,16 +134,15 @@ sub _record_device_report {
 
 		unless ($hw) {
 			$c->log->debug("Could not find hardware product by SKU, falling back to legacy_product_name");
-			#$hw = Conch::Model::HardwareProduct->lookup_by_legacy_product_name(
-		    $hw = $schema->resultset('HardwareProduct')->find(
-				legacy_product_name => $dr->{product_name}
+			$hw = Conch::Model::HardwareProduct->lookup_by_legacy_product_name(
+				$dr->{product_name}
 			);
 		}
 
 		$hw or die $log->critical("Product $dr->{sku} not found");
 	}
 
-	my $hw_profile = $hw->hardware_product_profile;
+	my $hw_profile = $hw->profile;
 	$hw_profile
 		or die $log->criticalf(
 		"Hardware product '%s' exists but does not have a hardware profile",

--- a/lib/Conch/Model/HardwareProduct.pm
+++ b/lib/Conch/Model/HardwareProduct.pm
@@ -153,6 +153,30 @@ sub lookup_by_sku ( $self, $sku ) {
 	return _build_hardware_product($ret);
 }
 
+=head2 lookup_by_legacy_product_name
+
+Look up a hardware product and associated hardware product
+profile by the hardware legacy product name
+
+=cut
+sub lookup_by_legacy_product_name ( $self, $legacy_product_name ) {
+	my $ret = Conch::Pg->new->db->query(qq{
+		SELECT $fields
+		FROM hardware_product hw_product
+		JOIN hardware_product_profile hw_profile
+		  ON hw_product.id = hw_profile.product_id
+		JOIN hardware_vendor vendor
+		  ON hw_product.vendor = vendor.id
+		LEFT JOIN zpool_profile zpool
+		  ON hw_profile.zpool_id = zpool.id
+		WHERE hw_product.deactivated IS NULL
+		  AND hw_product.legacy_product_name = ?
+      }, $legacy_product_name)->hash;
+	return undef unless $ret;
+
+	return _build_hardware_product($ret);
+}
+
 sub _build_hardware_product ($hw) {
 
 	my $zpool_profile =


### PR DESCRIPTION
If product_name and sku lookups fail, attempt to find a profile by legacy_product_name. This is needed as in production we do not necessarily have the ability to change DMI information on all systems (it requires a reboot of the system, or for the Dells we can't do it without spending a lot of money.)