### PR TITLE
fix db column and relationship names

### DIFF
--- a/lib/Conch/Controller/DB/HardwareProduct.pm
+++ b/lib/Conch/Controller/DB/HardwareProduct.pm
@@ -110,6 +110,8 @@ sub create ($c) {
 		}
 	}
 
+	$i->{hardware_vendor_id} = delete $i->{vendor} if exists $i->{vendor};
+
 	my $r = $c->schema->resultset("HardwareProduct")->create($i);
 
 	$c->log->debug("Created hardware product ".$r->id);

--- a/lib/Conch/Controller/DeviceReport.pm
+++ b/lib/Conch/Controller/DeviceReport.pm
@@ -191,7 +191,7 @@ sub _record_device_report {
 			my $device_specs = $schema->resultset('DeviceSpec')->update_or_create(
 				{
 					device_id     => $device_id,
-					product_id    => $hw_profile->id,
+					hardware_product_id    => $hw_profile->id,
 					bios_firmware => $dr->{bios_version},
 					cpu_num       => $dr->{processor}->{count},
 					cpu_type      => $dr->{processor}->{type},

--- a/lib/Conch/DB/Result/Datacenter.pm
+++ b/lib/Conch/DB/Result/Datacenter.pm
@@ -137,13 +137,13 @@ Related object: L<Conch::DB::Result::DatacenterRoom>
 __PACKAGE__->has_many(
   "datacenter_rooms",
   "Conch::DB::Result::DatacenterRoom",
-  { "foreign.datacenter" => "self.id" },
+  { "foreign.datacenter_id" => "self.id" },
   { cascade_copy => 0, cascade_delete => 0 },
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-15 16:00:18
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:8kXYfZMTsNZewkrJpW0Uew
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-23 12:46:05
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:nDozaA7v0DmvQEu/mxrVYw
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/DB/Result/DatacenterRackLayout.pm
+++ b/lib/Conch/DB/Result/DatacenterRackLayout.pm
@@ -51,7 +51,7 @@ __PACKAGE__->table("datacenter_rack_layout");
   is_nullable: 0
   size: 16
 
-=head2 product_id
+=head2 hardware_product_id
 
   data_type: 'uuid'
   is_foreign_key: 1
@@ -89,7 +89,7 @@ __PACKAGE__->add_columns(
   },
   "rack_id",
   { data_type => "uuid", is_foreign_key => 1, is_nullable => 0, size => 16 },
-  "product_id",
+  "hardware_product_id",
   { data_type => "uuid", is_foreign_key => 1, is_nullable => 0, size => 16 },
   "ru_start",
   { data_type => "integer", is_nullable => 0 },
@@ -142,7 +142,7 @@ __PACKAGE__->add_unique_constraint(
 
 =head1 RELATIONS
 
-=head2 product
+=head2 hardware_product
 
 Type: belongs_to
 
@@ -151,9 +151,9 @@ Related object: L<Conch::DB::Result::HardwareProduct>
 =cut
 
 __PACKAGE__->belongs_to(
-  "product",
+  "hardware_product",
   "Conch::DB::Result::HardwareProduct",
-  { id => "product_id" },
+  { id => "hardware_product_id" },
   { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
 );
 
@@ -173,8 +173,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-15 16:00:18
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:0wfW2xI8dfglh7Qoo/QMtw
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-22 17:47:15
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:uo/aiCKpReIr67au4jKFQw
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/DB/Result/DatacenterRoom.pm
+++ b/lib/Conch/DB/Result/DatacenterRoom.pm
@@ -44,7 +44,7 @@ __PACKAGE__->table("datacenter_room");
   is_nullable: 0
   size: 16
 
-=head2 datacenter
+=head2 datacenter_id
 
   data_type: 'uuid'
   is_foreign_key: 1
@@ -90,7 +90,7 @@ __PACKAGE__->add_columns(
     is_nullable => 0,
     size => 16,
   },
-  "datacenter",
+  "datacenter_id",
   { data_type => "uuid", is_foreign_key => 1, is_nullable => 0, size => 16 },
   "az",
   { data_type => "text", is_nullable => 0 },
@@ -139,7 +139,7 @@ Related object: L<Conch::DB::Result::Datacenter>
 __PACKAGE__->belongs_to(
   "datacenter",
   "Conch::DB::Result::Datacenter",
-  { id => "datacenter" },
+  { id => "datacenter_id" },
   { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
 );
 
@@ -174,8 +174,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-15 16:00:18
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:iYm/vF7M0e5trKHQMdfWTQ
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-23 12:46:05
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:WMR+xeS8FDHZv5ZKXOj+Eg
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/DB/Result/DeviceNeighbor.pm
+++ b/lib/Conch/DB/Result/DeviceNeighbor.pm
@@ -134,7 +134,7 @@ __PACKAGE__->set_primary_key("mac");
 
 =head1 RELATIONS
 
-=head2 mac
+=head2 device_nic
 
 Type: belongs_to
 
@@ -143,15 +143,15 @@ Related object: L<Conch::DB::Result::DeviceNic>
 =cut
 
 __PACKAGE__->belongs_to(
-  "mac",
+  "device_nic",
   "Conch::DB::Result::DeviceNic",
   { mac => "mac" },
   { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-15 16:00:18
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:dC7iBZWvTeTdhwiP5uVX0Q
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-23 14:03:46
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:iUlmXpxPIKB6gjKVJYSvGQ
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/DB/Result/DeviceRole.pm
+++ b/lib/Conch/DB/Result/DeviceRole.pm
@@ -132,7 +132,7 @@ Related object: L<Conch::DB::Result::DeviceRoleService>
 __PACKAGE__->has_many(
   "device_role_services",
   "Conch::DB::Result::DeviceRoleService",
-  { "foreign.role_id" => "self.id" },
+  { "foreign.device_role_id" => "self.id" },
   { cascade_copy => 0, cascade_delete => 0 },
 );
 
@@ -167,8 +167,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-15 16:08:57
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:zDBGhJGoJcUpbNmilnAwpA
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-21 11:42:45
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:H6x1GbpcsSZIN6KMY9MMCA
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/DB/Result/DeviceRoleService.pm
+++ b/lib/Conch/DB/Result/DeviceRoleService.pm
@@ -29,22 +29,22 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
 
-=head1 TABLE: C<device_role_services>
+=head1 TABLE: C<device_role_service>
 
 =cut
 
-__PACKAGE__->table("device_role_services");
+__PACKAGE__->table("device_role_service");
 
 =head1 ACCESSORS
 
-=head2 role_id
+=head2 device_role_id
 
   data_type: 'uuid'
   is_foreign_key: 1
   is_nullable: 0
   size: 16
 
-=head2 service_id
+=head2 device_role_service_id
 
   data_type: 'uuid'
   is_foreign_key: 1
@@ -54,9 +54,9 @@ __PACKAGE__->table("device_role_services");
 =cut
 
 __PACKAGE__->add_columns(
-  "role_id",
+  "device_role_id",
   { data_type => "uuid", is_foreign_key => 1, is_nullable => 0, size => 16 },
-  "service_id",
+  "device_role_service_id",
   { data_type => "uuid", is_foreign_key => 1, is_nullable => 0, size => 16 },
 );
 
@@ -66,9 +66,9 @@ __PACKAGE__->add_columns(
 
 =over 4
 
-=item * L</role_id>
+=item * L</device_role_id>
 
-=item * L</service_id>
+=item * L</device_role_service_id>
 
 =back
 
@@ -76,12 +76,12 @@ __PACKAGE__->add_columns(
 
 __PACKAGE__->add_unique_constraint(
   "device_role_services_role_id_service_id_key",
-  ["role_id", "service_id"],
+  ["device_role_id", "device_role_service_id"],
 );
 
 =head1 RELATIONS
 
-=head2 role
+=head2 device_role
 
 Type: belongs_to
 
@@ -90,13 +90,13 @@ Related object: L<Conch::DB::Result::DeviceRole>
 =cut
 
 __PACKAGE__->belongs_to(
-  "role",
+  "device_role",
   "Conch::DB::Result::DeviceRole",
-  { id => "role_id" },
+  { id => "device_role_id" },
   { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
 );
 
-=head2 service
+=head2 device_role_service
 
 Type: belongs_to
 
@@ -105,15 +105,15 @@ Related object: L<Conch::DB::Result::DeviceService>
 =cut
 
 __PACKAGE__->belongs_to(
-  "service",
+  "device_role_service",
   "Conch::DB::Result::DeviceService",
-  { id => "service_id" },
+  { id => "device_role_service_id" },
   { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-15 16:00:18
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:FTKJ414/weWalT1zdnEraQ
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-21 11:42:45
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:ted6wfW0VdeKGaPPPFs/lA
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/DB/Result/DeviceService.pm
+++ b/lib/Conch/DB/Result/DeviceService.pm
@@ -130,13 +130,13 @@ Related object: L<Conch::DB::Result::DeviceRoleService>
 __PACKAGE__->has_many(
   "device_role_services",
   "Conch::DB::Result::DeviceRoleService",
-  { "foreign.service_id" => "self.id" },
+  { "foreign.device_role_service_id" => "self.id" },
   { cascade_copy => 0, cascade_delete => 0 },
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-15 16:00:18
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:/QRfl+aK6Gz1wCkN4cbtfA
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-21 11:42:45
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:Fj0k2LAWus3Lltpzye0iBQ
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/DB/Result/DeviceSpec.pm
+++ b/lib/Conch/DB/Result/DeviceSpec.pm
@@ -29,11 +29,11 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
 
-=head1 TABLE: C<device_specs>
+=head1 TABLE: C<device_spec>
 
 =cut
 
-__PACKAGE__->table("device_specs");
+__PACKAGE__->table("device_spec");
 
 =head1 ACCESSORS
 
@@ -43,7 +43,7 @@ __PACKAGE__->table("device_specs");
   is_foreign_key: 1
   is_nullable: 0
 
-=head2 product_id
+=head2 hardware_product_id
 
   data_type: 'uuid'
   is_foreign_key: 1
@@ -90,7 +90,7 @@ __PACKAGE__->table("device_specs");
 __PACKAGE__->add_columns(
   "device_id",
   { data_type => "text", is_foreign_key => 1, is_nullable => 0 },
-  "product_id",
+  "hardware_product_id",
   { data_type => "uuid", is_foreign_key => 1, is_nullable => 0, size => 16 },
   "bios_firmware",
   { data_type => "text", is_nullable => 0 },
@@ -137,7 +137,7 @@ __PACKAGE__->belongs_to(
   { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
 );
 
-=head2 product
+=head2 hardware_product
 
 Type: belongs_to
 
@@ -146,15 +146,15 @@ Related object: L<Conch::DB::Result::HardwareProductProfile>
 =cut
 
 __PACKAGE__->belongs_to(
-  "product",
+  "hardware_product",
   "Conch::DB::Result::HardwareProductProfile",
-  { id => "product_id" },
+  { id => "hardware_product_id" },
   { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-15 16:00:18
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:hSKb7WpokPvU9QvjIHiZwg
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-22 17:58:22
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:oxznkSR0H2zemYTYFYvg9w
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/DB/Result/DeviceValidateCriteria.pm
+++ b/lib/Conch/DB/Result/DeviceValidateCriteria.pm
@@ -44,7 +44,7 @@ __PACKAGE__->table("device_validate_criteria");
   is_nullable: 0
   size: 16
 
-=head2 product_id
+=head2 hardware_product_id
 
   data_type: 'uuid'
   is_foreign_key: 1
@@ -101,7 +101,7 @@ __PACKAGE__->add_columns(
     is_nullable => 0,
     size => 16,
   },
-  "product_id",
+  "hardware_product_id",
   { data_type => "uuid", is_foreign_key => 1, is_nullable => 1, size => 16 },
   "component",
   { data_type => "text", is_nullable => 0 },
@@ -135,7 +135,7 @@ __PACKAGE__->set_primary_key("id");
 
 =head1 RELATIONS
 
-=head2 product
+=head2 hardware_product
 
 Type: belongs_to
 
@@ -144,9 +144,9 @@ Related object: L<Conch::DB::Result::HardwareProductProfile>
 =cut
 
 __PACKAGE__->belongs_to(
-  "product",
+  "hardware_product",
   "Conch::DB::Result::HardwareProductProfile",
-  { id => "product_id" },
+  { id => "hardware_product_id" },
   {
     is_deferrable => 0,
     join_type     => "LEFT",
@@ -156,8 +156,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-15 16:00:18
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:ESh8Tf+GrIeMMdvRj6tmIw
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-22 17:58:22
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:sgCqo+vjQqnjz9ckJy14WQ
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/DB/Result/HardwareProduct.pm
+++ b/lib/Conch/DB/Result/HardwareProduct.pm
@@ -59,7 +59,7 @@ __PACKAGE__->table("hardware_product");
   data_type: 'text'
   is_nullable: 1
 
-=head2 vendor
+=head2 hardware_vendor_id
 
   data_type: 'uuid'
   is_foreign_key: 1
@@ -121,7 +121,7 @@ __PACKAGE__->add_columns(
   { data_type => "text", is_nullable => 0 },
   "prefix",
   { data_type => "text", is_nullable => 1 },
-  "vendor",
+  "hardware_vendor_id",
   { data_type => "uuid", is_foreign_key => 1, is_nullable => 0, size => 16 },
   "deactivated",
   { data_type => "timestamp with time zone", is_nullable => 1 },
@@ -200,7 +200,7 @@ Related object: L<Conch::DB::Result::DatacenterRackLayout>
 __PACKAGE__->has_many(
   "datacenter_rack_layouts",
   "Conch::DB::Result::DatacenterRackLayout",
-  { "foreign.product_id" => "self.id" },
+  { "foreign.hardware_product_id" => "self.id" },
   { cascade_copy => 0, cascade_delete => 0 },
 );
 
@@ -245,8 +245,23 @@ Related object: L<Conch::DB::Result::HardwareProductProfile>
 __PACKAGE__->might_have(
   "hardware_product_profile",
   "Conch::DB::Result::HardwareProductProfile",
-  { "foreign.product_id" => "self.id" },
+  { "foreign.hardware_product_id" => "self.id" },
   { cascade_copy => 0, cascade_delete => 0 },
+);
+
+=head2 hardware_vendor
+
+Type: belongs_to
+
+Related object: L<Conch::DB::Result::HardwareVendor>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "hardware_vendor",
+  "Conch::DB::Result::HardwareVendor",
+  { id => "hardware_vendor_id" },
+  { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
 );
 
 =head2 validation_results
@@ -264,49 +279,24 @@ __PACKAGE__->has_many(
   { cascade_copy => 0, cascade_delete => 0 },
 );
 
-=head2 vendor
 
-Type: belongs_to
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-23 13:47:19
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:+Rhf4M0PfVMINqK55tNrbQ
 
-Related object: L<Conch::DB::Result::HardwareVendor>
+use Class::Method::Modifiers;
 
-=cut
+around TO_JSON => sub {
+    my $orig = shift;
+    my $self = shift;
 
-__PACKAGE__->belongs_to(
-  "vendor",
-  "Conch::DB::Result::HardwareVendor",
-  { id => "vendor" },
-  { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
+    my $data = $self->$orig(@_);
+    $data->{vendor} = delete $data->{hardware_vendor_id};
+    return $data;
+};
+
+__PACKAGE__->add_columns(
+    '+deactivated' => { is_serializable => 0 },
 );
-
-
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-15 16:08:57
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:sCsFRfbsWv0tJzzdFZggCw
-
-
-# You can replace this text with custom code or comments, and it will be preserved on regeneration
-
-
-my %s;
-foreach (qw[
-	id
-	name
-	alias
-	prefix
-	vendor
-	created
-	updated
-	specification
-	sku
-	generation_name
-	legacy_product_name
-]) {
-	$s{"+$_"} = { is_serializable => 1 }
-}
-
-$s{"+deactivated"} = { is_serializable => 0 };
-
-__PACKAGE__->add_columns(%s);
 
 1;
 __END__
@@ -322,3 +312,4 @@ v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
 one at http://mozilla.org/MPL/2.0/.
 
 =cut
+# vim: set ts=4 sts=4 sw=4 et :

--- a/lib/Conch/DB/Result/HardwareProductProfile.pm
+++ b/lib/Conch/DB/Result/HardwareProductProfile.pm
@@ -295,7 +295,7 @@ __PACKAGE__->has_many(
   { cascade_copy => 0, cascade_delete => 0 },
 );
 
-=head2 device_validate_criterias
+=head2 device_validate_criteria
 
 Type: has_many
 
@@ -304,7 +304,7 @@ Related object: L<Conch::DB::Result::DeviceValidateCriteria>
 =cut
 
 __PACKAGE__->has_many(
-  "device_validate_criterias",
+  "device_validate_criteria",
   "Conch::DB::Result::DeviceValidateCriteria",
   { "foreign.hardware_product_id" => "self.id" },
   { cascade_copy => 0, cascade_delete => 0 },
@@ -361,8 +361,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-23 14:04:56
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:89+BBiaTeiAf9hqD55Gofw
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-23 14:06:26
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:aJNvEedlKdVa2F9Nn3VXRg
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/DB/Result/HardwareProductProfile.pm
+++ b/lib/Conch/DB/Result/HardwareProductProfile.pm
@@ -44,7 +44,7 @@ __PACKAGE__->table("hardware_product_profile");
   is_nullable: 0
   size: 16
 
-=head2 product_id
+=head2 hardware_product_id
 
   data_type: 'uuid'
   is_foreign_key: 1
@@ -187,7 +187,7 @@ __PACKAGE__->add_columns(
     is_nullable => 0,
     size => 16,
   },
-  "product_id",
+  "hardware_product_id",
   { data_type => "uuid", is_foreign_key => 1, is_nullable => 0, size => 16 },
   "zpool_id",
   { data_type => "uuid", is_foreign_key => 1, is_nullable => 1, size => 16 },
@@ -267,13 +267,16 @@ __PACKAGE__->set_primary_key("id");
 
 =over 4
 
-=item * L</product_id>
+=item * L</hardware_product_id>
 
 =back
 
 =cut
 
-__PACKAGE__->add_unique_constraint("hardware_product_profile_product_id_key", ["product_id"]);
+__PACKAGE__->add_unique_constraint(
+  "hardware_product_profile_product_id_key",
+  ["hardware_product_id"],
+);
 
 =head1 RELATIONS
 
@@ -288,7 +291,7 @@ Related object: L<Conch::DB::Result::DeviceSpec>
 __PACKAGE__->has_many(
   "device_specs",
   "Conch::DB::Result::DeviceSpec",
-  { "foreign.product_id" => "self.id" },
+  { "foreign.hardware_product_id" => "self.id" },
   { cascade_copy => 0, cascade_delete => 0 },
 );
 
@@ -303,8 +306,23 @@ Related object: L<Conch::DB::Result::DeviceValidateCriteria>
 __PACKAGE__->has_many(
   "device_validate_criterias",
   "Conch::DB::Result::DeviceValidateCriteria",
-  { "foreign.product_id" => "self.id" },
+  { "foreign.hardware_product_id" => "self.id" },
   { cascade_copy => 0, cascade_delete => 0 },
+);
+
+=head2 hardware_product
+
+Type: belongs_to
+
+Related object: L<Conch::DB::Result::HardwareProduct>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "hardware_product",
+  "Conch::DB::Result::HardwareProduct",
+  { id => "hardware_product_id" },
+  { is_deferrable => 0, on_delete => "CASCADE", on_update => "NO ACTION" },
 );
 
 =head2 hardware_profile_settings
@@ -318,23 +336,8 @@ Related object: L<Conch::DB::Result::HardwareProfileSetting>
 __PACKAGE__->has_many(
   "hardware_profile_settings",
   "Conch::DB::Result::HardwareProfileSetting",
-  { "foreign.profile_id" => "self.id" },
+  { "foreign.hardware_product_profile_id" => "self.id" },
   { cascade_copy => 0, cascade_delete => 0 },
-);
-
-=head2 product
-
-Type: belongs_to
-
-Related object: L<Conch::DB::Result::HardwareProduct>
-
-=cut
-
-__PACKAGE__->belongs_to(
-  "product",
-  "Conch::DB::Result::HardwareProduct",
-  { id => "product_id" },
-  { is_deferrable => 0, on_delete => "CASCADE", on_update => "NO ACTION" },
 );
 
 =head2 zpool
@@ -358,8 +361,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-15 16:00:18
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:iLQSC3Ev1VuTO2ztZyLBWQ
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-23 14:04:56
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:89+BBiaTeiAf9hqD55Gofw
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/DB/Result/HardwareProfileSetting.pm
+++ b/lib/Conch/DB/Result/HardwareProfileSetting.pm
@@ -29,11 +29,11 @@ use base 'DBIx::Class::Core';
 
 __PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
 
-=head1 TABLE: C<hardware_profile_settings>
+=head1 TABLE: C<hardware_profile_setting>
 
 =cut
 
-__PACKAGE__->table("hardware_profile_settings");
+__PACKAGE__->table("hardware_profile_setting");
 
 =head1 ACCESSORS
 
@@ -44,7 +44,7 @@ __PACKAGE__->table("hardware_profile_settings");
   is_nullable: 0
   size: 16
 
-=head2 profile_id
+=head2 hardware_product_profile_id
 
   data_type: 'uuid'
   is_foreign_key: 1
@@ -95,7 +95,7 @@ __PACKAGE__->add_columns(
     is_nullable => 0,
     size => 16,
   },
-  "profile_id",
+  "hardware_product_profile_id",
   { data_type => "uuid", is_foreign_key => 1, is_nullable => 0, size => 16 },
   "resource",
   { data_type => "text", is_nullable => 0 },
@@ -135,7 +135,7 @@ __PACKAGE__->set_primary_key("id");
 
 =head1 RELATIONS
 
-=head2 profile
+=head2 hardware_product_profile
 
 Type: belongs_to
 
@@ -144,15 +144,15 @@ Related object: L<Conch::DB::Result::HardwareProductProfile>
 =cut
 
 __PACKAGE__->belongs_to(
-  "profile",
+  "hardware_product_profile",
   "Conch::DB::Result::HardwareProductProfile",
-  { id => "profile_id" },
+  { id => "hardware_product_profile_id" },
   { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-15 16:00:18
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:YrJxqsK3q5yoKuVFKRKZ1g
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-23 13:52:47
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:0Q3VBDR1HzZE9FHUXUXwHw
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/DB/Result/HardwareVendor.pm
+++ b/lib/Conch/DB/Result/HardwareVendor.pm
@@ -137,13 +137,13 @@ Related object: L<Conch::DB::Result::HardwareProduct>
 __PACKAGE__->has_many(
   "hardware_products",
   "Conch::DB::Result::HardwareProduct",
-  { "foreign.vendor" => "self.id" },
+  { "foreign.hardware_vendor_id" => "self.id" },
   { cascade_copy => 0, cascade_delete => 0 },
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-15 16:00:18
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:P/pjqLcfDKLCiLiBWT75mw
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-23 13:47:19
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:Q7NGUqyibscbrXzM7V3Stg
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/Model/DatacenterRackLayout.pm
+++ b/lib/Conch/Model/DatacenterRackLayout.pm
@@ -94,6 +94,15 @@ sub _build_serializable_attributes {[qw[
 
 =head1 METHODS
 
+=cut
+
+around BUILDARGS => sub {
+	my ($orig, $class, %args) = @_;
+
+	$args{product_id} = delete $args{hardware_product_id} if exists $args{hardware_product_id};
+    return $class->$orig(%args);
+};
+
 =head2 from_id
 
 	my $o = Conch::Model::DatacenterRackLayout->from_id($uuid);
@@ -196,6 +205,8 @@ sub save ($self) {
 	}
 
 	$fields{updated} = 'NOW()';
+
+	$fields{hardware_product_id} = delete $fields{product_id};
 
 	my $ret;
 	try {

--- a/lib/Conch/Model/DatacenterRoom.pm
+++ b/lib/Conch/Model/DatacenterRoom.pm
@@ -107,6 +107,15 @@ sub _build_serializable_attributes {[qw[
 
 =head1 METHODS
 
+=cut
+
+around BUILDARGS => sub {
+	my ($orig, $class, %args) = @_;
+
+	$args{datacenter} = delete $args{datacenter_id} if exists $args{datacenter_id};
+    return $class->$orig(%args);
+};
+
 =head2 from_id
 
 	my $r = Conch::Model::DatacenterRoom->from_id($uuid);
@@ -173,7 +182,7 @@ sub from_datacenter ($class, $id) {
 			'datacenter_room',
 			undef,
 			{
-				datacenter => $id,
+				datacenter_id => $id,
 			}
 		)->hashes->map(sub {
 			$class->new(_fixup_timestamptzs($_)->%*);
@@ -209,6 +218,8 @@ sub save ($self) {
 	}
 
 	$fields{updated} = 'NOW()';
+
+	$fields{datacenter_id} = delete $fields{datacenter};
 
 	my $ret;
 	try {

--- a/lib/Conch/Model/DeviceLocation.pm
+++ b/lib/Conch/Model/DeviceLocation.pm
@@ -44,7 +44,7 @@ sub lookup ( $self, $device_id ) {
       hw_product.name   AS hw_product_name,
       hw_product.alias  AS hw_product_alias,
       hw_product.prefix AS hw_product_prefix,
-      hw_product.vendor AS hw_product_vendor,
+      hw_product.hardware_vendor_id AS hw_product_vendor,
 
       hw_product.specification       AS hw_product_specification,
       hw_product.sku                 AS hw_sku,
@@ -65,10 +65,10 @@ sub lookup ( $self, $device_id ) {
       ON layout.rack_id = rack.id AND layout.ru_start = loc.rack_unit
 
     JOIN hardware_product hw_product
-      ON layout.product_id = hw_product.id
+      ON layout.hardware_product_id = hw_product.id
 
     JOIN hardware_vendor vendor
-      ON hw_product.vendor = vendor.id
+      ON hw_product.hardware_vendor_id = vendor.id
 
     WHERE loc.device_id = ?
   }, $device_id
@@ -123,7 +123,7 @@ sub assign ( $self, $device_id, $rack_id, $rack_unit ) {
 
 	my $maybe_slot = $db->select(
 		'datacenter_rack_layout',
-		[ 'id', 'product_id' ],
+		[ 'id', 'hardware_product_id' ],
 		{ rack_id => $rack_id, ru_start => $rack_unit }
 	)->hash;
 

--- a/lib/Conch/Model/DeviceRole.pm
+++ b/lib/Conch/Model/DeviceRole.pm
@@ -119,10 +119,10 @@ sub from_id ($class, $id) {
 	try {
 		$ret = Conch::Pg->new->db->query(q|
 			select r.*, array(
-				select drs.service_id
-				from device_role_services drs
-				where drs.role_id = r.id
-				order by drs.service_id
+				select drs.device_role_service_id
+				from device_role_service drs
+				where drs.device_role_id = r.id
+				order by drs.device_role_service_id
 			) as services
 			from device_role r
 			where r.id = ?
@@ -151,10 +151,10 @@ sub all ($class) {
 	try {
 		$ret = Conch::Pg->new->db->query(q|
 			select r.*, array(
-				select drs.service_id
-				from device_role_services drs
-				where drs.role_id = r.id
-				order by drs.service_id
+				select drs.device_role_service_id
+				from device_role_service drs
+				where drs.device_role_id = r.id
+				order by drs.device_role_service_id
 			) as services
 			from device_role r
 			where r.deactivated is null
@@ -192,7 +192,7 @@ sub add_service ($self, $service_uuid) {
 	my $ret;
 	try {
 		$ret = Conch::Pg->new->db->query(q|
-			insert into device_role_services(role_id, service_id)
+			insert into device_role_service(device_role_id, device_role_service_id)
 			values( ?, ?)
 			on conflict do nothing
 		|, $self->id, $service_uuid);
@@ -226,8 +226,8 @@ sub remove_service ($self, $service_uuid) {
 	my $ret;
 	try {
 		$ret = Conch::Pg->new->db->query(q|
-			delete from device_role_services
-			where role_id = ? and service_id = ?
+			delete from device_role_service
+			where device_role_id = ? and device_role_service_id = ?
 		|, $self->id, $service_uuid);
 	} catch {
 		Mojo::Exception->throw(__PACKAGE__."->remove_service: $_");

--- a/lib/Conch/Model/HardwareProduct.pm
+++ b/lib/Conch/Model/HardwareProduct.pm
@@ -72,9 +72,9 @@ sub list ($self) {
 		  SELECT $fields
 		  FROM hardware_product hw_product
 		  JOIN hardware_product_profile hw_profile
-			ON hw_product.id = hw_profile.product_id
+			ON hw_product.id = hw_profile.hardware_product_id
 		  JOIN hardware_vendor vendor
-			ON hw_product.vendor = vendor.id
+			ON hw_product.hardware_vendor_id = vendor.id
 		  LEFT JOIN zpool_profile zpool
 			ON hw_profile.zpool_id = zpool.id
 		  WHERE hw_product.deactivated IS NULL
@@ -93,9 +93,9 @@ sub lookup ( $self, $hw_id ) {
 		SELECT $fields
 		FROM hardware_product hw_product
 		JOIN hardware_product_profile hw_profile
-		  ON hw_product.id = hw_profile.product_id
+		  ON hw_product.id = hw_profile.hardware_product_id
 		JOIN hardware_vendor vendor
-		  ON hw_product.vendor = vendor.id
+		  ON hw_product.hardware_vendor_id = vendor.id
 		LEFT JOIN zpool_profile zpool
 		  ON hw_profile.zpool_id = zpool.id
 		WHERE hw_product.deactivated IS NULL
@@ -116,9 +116,9 @@ sub lookup_by_name ( $self, $name ) {
 		SELECT $fields
 		FROM hardware_product hw_product
 		JOIN hardware_product_profile hw_profile
-		  ON hw_product.id = hw_profile.product_id
+		  ON hw_product.id = hw_profile.hardware_product_id
 		JOIN hardware_vendor vendor
-		  ON hw_product.vendor = vendor.id
+		  ON hw_product.hardware_vendor_id = vendor.id
 		LEFT JOIN zpool_profile zpool
 		  ON hw_profile.zpool_id = zpool.id
 		WHERE hw_product.deactivated IS NULL
@@ -140,9 +140,9 @@ sub lookup_by_sku ( $self, $sku ) {
 		SELECT $fields
 		FROM hardware_product hw_product
 		JOIN hardware_product_profile hw_profile
-		  ON hw_product.id = hw_profile.product_id
+		  ON hw_product.id = hw_profile.hardware_product_id
 		JOIN hardware_vendor vendor
-		  ON hw_product.vendor = vendor.id
+		  ON hw_product.hardware_vendor_id = vendor.id
 		LEFT JOIN zpool_profile zpool
 		  ON hw_profile.zpool_id = zpool.id
 		WHERE hw_product.deactivated IS NULL

--- a/lib/Conch/Model/WorkspaceRack.pm
+++ b/lib/Conch/Model/WorkspaceRack.pm
@@ -75,9 +75,9 @@ sub rack_layout ( $self, $rack ) {
       SELECT hw.*, vendor.name AS vendor, profile.rack_unit as size
       FROM hardware_product hw
       JOIN hardware_vendor vendor
-        ON hw.vendor = vendor.id
+        ON hw.hardware_vendor_id = vendor.id
       JOIN hardware_product_profile profile
-        ON hw.id = profile.product_id
+        ON hw.id = profile.hardware_product_id
       WHERE hw.id = ?
       }, $slot->{product_id}
 		)->hash;

--- a/schema-loader.yaml
+++ b/schema-loader.yaml
@@ -14,3 +14,6 @@ loader_options:
 
   rel_name_map:
     user: user_account
+    device_validate_criterias: device_validate_criteria
+    DeviceNeighbor:
+      mac: device_nic

--- a/sql/migrations/0041-rename-devicerole-columns.sql
+++ b/sql/migrations/0041-rename-devicerole-columns.sql
@@ -1,0 +1,19 @@
+SELECT run_migration(41, $$
+
+    alter table device_role_services rename to device_role_service;
+    alter table device_role_service rename column role_id to device_role_id;
+    alter table device_role_service rename column service_id to device_role_service_id;
+
+    alter table device_specs rename to device_spec;
+    alter table hardware_profile_settings rename to hardware_profile_setting;
+
+    alter table hardware_product rename column vendor to hardware_vendor_id;
+    alter table hardware_profile_setting rename column profile_id to hardware_product_profile_id;
+    alter table hardware_product_profile rename column product_id to hardware_product_id;
+    alter table datacenter_rack_layout rename column product_id to hardware_product_id;
+    alter table device_spec rename column product_id to hardware_product_id;
+    alter table device_validate_criteria rename column product_id to hardware_product_id;
+
+    alter table datacenter_room rename column datacenter to datacenter_id;
+
+$$);

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -168,7 +168,7 @@ ALTER TABLE public.datacenter_rack OWNER TO conch;
 CREATE TABLE public.datacenter_rack_layout (
     id uuid DEFAULT public.gen_random_uuid() NOT NULL,
     rack_id uuid NOT NULL,
-    product_id uuid NOT NULL,
+    hardware_product_id uuid NOT NULL,
     ru_start integer NOT NULL,
     created timestamp with time zone DEFAULT now() NOT NULL,
     updated timestamp with time zone DEFAULT now() NOT NULL
@@ -198,7 +198,7 @@ ALTER TABLE public.datacenter_rack_role OWNER TO conch;
 
 CREATE TABLE public.datacenter_room (
     id uuid DEFAULT public.gen_random_uuid() NOT NULL,
-    datacenter uuid NOT NULL,
+    datacenter_id uuid NOT NULL,
     az text NOT NULL,
     alias text,
     vendor_name text,
@@ -433,16 +433,16 @@ CREATE TABLE public.device_role (
 ALTER TABLE public.device_role OWNER TO conch;
 
 --
--- Name: device_role_services; Type: TABLE; Schema: public; Owner: conch
+-- Name: device_role_service; Type: TABLE; Schema: public; Owner: conch
 --
 
-CREATE TABLE public.device_role_services (
-    role_id uuid NOT NULL,
-    service_id uuid NOT NULL
+CREATE TABLE public.device_role_service (
+    device_role_id uuid NOT NULL,
+    device_role_service_id uuid NOT NULL
 );
 
 
-ALTER TABLE public.device_role_services OWNER TO conch;
+ALTER TABLE public.device_role_service OWNER TO conch;
 
 --
 -- Name: device_service; Type: TABLE; Schema: public; Owner: conch
@@ -476,12 +476,12 @@ CREATE TABLE public.device_settings (
 ALTER TABLE public.device_settings OWNER TO conch;
 
 --
--- Name: device_specs; Type: TABLE; Schema: public; Owner: conch
+-- Name: device_spec; Type: TABLE; Schema: public; Owner: conch
 --
 
-CREATE TABLE public.device_specs (
+CREATE TABLE public.device_spec (
     device_id text NOT NULL,
-    product_id uuid NOT NULL,
+    hardware_product_id uuid NOT NULL,
     bios_firmware text NOT NULL,
     hba_firmware text,
     cpu_num integer NOT NULL,
@@ -492,7 +492,7 @@ CREATE TABLE public.device_specs (
 );
 
 
-ALTER TABLE public.device_specs OWNER TO conch;
+ALTER TABLE public.device_spec OWNER TO conch;
 
 --
 -- Name: device_validate; Type: TABLE; Schema: public; Owner: conch
@@ -515,7 +515,7 @@ ALTER TABLE public.device_validate OWNER TO conch;
 
 CREATE TABLE public.device_validate_criteria (
     id uuid DEFAULT public.gen_random_uuid() NOT NULL,
-    product_id uuid,
+    hardware_product_id uuid,
     component text NOT NULL,
     condition text NOT NULL,
     vendor text,
@@ -538,7 +538,7 @@ CREATE TABLE public.hardware_product (
     name text NOT NULL,
     alias text NOT NULL,
     prefix text,
-    vendor uuid NOT NULL,
+    hardware_vendor_id uuid NOT NULL,
     deactivated timestamp with time zone,
     created timestamp with time zone DEFAULT now() NOT NULL,
     updated timestamp with time zone DEFAULT now() NOT NULL,
@@ -557,7 +557,7 @@ ALTER TABLE public.hardware_product OWNER TO conch;
 
 CREATE TABLE public.hardware_product_profile (
     id uuid DEFAULT public.gen_random_uuid() NOT NULL,
-    product_id uuid NOT NULL,
+    hardware_product_id uuid NOT NULL,
     zpool_id uuid,
     rack_unit integer NOT NULL,
     purpose text NOT NULL,
@@ -588,12 +588,12 @@ CREATE TABLE public.hardware_product_profile (
 ALTER TABLE public.hardware_product_profile OWNER TO conch;
 
 --
--- Name: hardware_profile_settings; Type: TABLE; Schema: public; Owner: conch
+-- Name: hardware_profile_setting; Type: TABLE; Schema: public; Owner: conch
 --
 
-CREATE TABLE public.hardware_profile_settings (
+CREATE TABLE public.hardware_profile_setting (
     id uuid DEFAULT public.gen_random_uuid() NOT NULL,
-    profile_id uuid NOT NULL,
+    hardware_product_profile_id uuid NOT NULL,
     resource text NOT NULL,
     name text NOT NULL,
     value text NOT NULL,
@@ -603,7 +603,7 @@ CREATE TABLE public.hardware_profile_settings (
 );
 
 
-ALTER TABLE public.hardware_profile_settings OWNER TO conch;
+ALTER TABLE public.hardware_profile_setting OWNER TO conch;
 
 --
 -- Name: hardware_vendor; Type: TABLE; Schema: public; Owner: conch
@@ -1091,11 +1091,11 @@ ALTER TABLE ONLY public.device_role
 
 
 --
--- Name: device_role_services device_role_services_role_id_service_id_key; Type: CONSTRAINT; Schema: public; Owner: conch
+-- Name: device_role_service device_role_services_role_id_service_id_key; Type: CONSTRAINT; Schema: public; Owner: conch
 --
 
-ALTER TABLE ONLY public.device_role_services
-    ADD CONSTRAINT device_role_services_role_id_service_id_key UNIQUE (role_id, service_id);
+ALTER TABLE ONLY public.device_role_service
+    ADD CONSTRAINT device_role_services_role_id_service_id_key UNIQUE (device_role_id, device_role_service_id);
 
 
 --
@@ -1123,10 +1123,10 @@ ALTER TABLE ONLY public.device_settings
 
 
 --
--- Name: device_specs device_specs_pkey; Type: CONSTRAINT; Schema: public; Owner: conch
+-- Name: device_spec device_specs_pkey; Type: CONSTRAINT; Schema: public; Owner: conch
 --
 
-ALTER TABLE ONLY public.device_specs
+ALTER TABLE ONLY public.device_spec
     ADD CONSTRAINT device_specs_pkey PRIMARY KEY (device_id);
 
 
@@ -1183,7 +1183,7 @@ ALTER TABLE ONLY public.hardware_product_profile
 --
 
 ALTER TABLE ONLY public.hardware_product_profile
-    ADD CONSTRAINT hardware_product_profile_product_id_key UNIQUE (product_id);
+    ADD CONSTRAINT hardware_product_profile_product_id_key UNIQUE (hardware_product_id);
 
 
 --
@@ -1195,10 +1195,10 @@ ALTER TABLE ONLY public.hardware_product
 
 
 --
--- Name: hardware_profile_settings hardware_profile_settings_pkey; Type: CONSTRAINT; Schema: public; Owner: conch
+-- Name: hardware_profile_setting hardware_profile_settings_pkey; Type: CONSTRAINT; Schema: public; Owner: conch
 --
 
-ALTER TABLE ONLY public.hardware_profile_settings
+ALTER TABLE ONLY public.hardware_profile_setting
     ADD CONSTRAINT hardware_profile_settings_pkey PRIMARY KEY (id);
 
 
@@ -1476,7 +1476,7 @@ ALTER TABLE ONLY public.datacenter_rack
 --
 
 ALTER TABLE ONLY public.datacenter_rack_layout
-    ADD CONSTRAINT datacenter_rack_layout_product_id_fkey FOREIGN KEY (product_id) REFERENCES public.hardware_product(id);
+    ADD CONSTRAINT datacenter_rack_layout_product_id_fkey FOREIGN KEY (hardware_product_id) REFERENCES public.hardware_product(id);
 
 
 --
@@ -1500,7 +1500,7 @@ ALTER TABLE ONLY public.datacenter_rack
 --
 
 ALTER TABLE ONLY public.datacenter_room
-    ADD CONSTRAINT datacenter_room_datacenter_fkey FOREIGN KEY (datacenter) REFERENCES public.datacenter(id);
+    ADD CONSTRAINT datacenter_room_datacenter_fkey FOREIGN KEY (datacenter_id) REFERENCES public.datacenter(id);
 
 
 --
@@ -1624,19 +1624,19 @@ ALTER TABLE ONLY public.device_role
 
 
 --
--- Name: device_role_services device_role_services_role_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: conch
+-- Name: device_role_service device_role_services_role_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: conch
 --
 
-ALTER TABLE ONLY public.device_role_services
-    ADD CONSTRAINT device_role_services_role_id_fkey FOREIGN KEY (role_id) REFERENCES public.device_role(id);
+ALTER TABLE ONLY public.device_role_service
+    ADD CONSTRAINT device_role_services_role_id_fkey FOREIGN KEY (device_role_id) REFERENCES public.device_role(id);
 
 
 --
--- Name: device_role_services device_role_services_service_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: conch
+-- Name: device_role_service device_role_services_service_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: conch
 --
 
-ALTER TABLE ONLY public.device_role_services
-    ADD CONSTRAINT device_role_services_service_id_fkey FOREIGN KEY (service_id) REFERENCES public.device_service(id);
+ALTER TABLE ONLY public.device_role_service
+    ADD CONSTRAINT device_role_services_service_id_fkey FOREIGN KEY (device_role_service_id) REFERENCES public.device_service(id);
 
 
 --
@@ -1648,19 +1648,19 @@ ALTER TABLE ONLY public.device_settings
 
 
 --
--- Name: device_specs device_specs_device_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: conch
+-- Name: device_spec device_specs_device_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: conch
 --
 
-ALTER TABLE ONLY public.device_specs
+ALTER TABLE ONLY public.device_spec
     ADD CONSTRAINT device_specs_device_id_fkey FOREIGN KEY (device_id) REFERENCES public.device(id);
 
 
 --
--- Name: device_specs device_specs_product_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: conch
+-- Name: device_spec device_specs_product_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: conch
 --
 
-ALTER TABLE ONLY public.device_specs
-    ADD CONSTRAINT device_specs_product_id_fkey FOREIGN KEY (product_id) REFERENCES public.hardware_product_profile(id);
+ALTER TABLE ONLY public.device_spec
+    ADD CONSTRAINT device_specs_product_id_fkey FOREIGN KEY (hardware_product_id) REFERENCES public.hardware_product_profile(id);
 
 
 --
@@ -1668,7 +1668,7 @@ ALTER TABLE ONLY public.device_specs
 --
 
 ALTER TABLE ONLY public.device_validate_criteria
-    ADD CONSTRAINT device_validate_criteria_product_id_fkey FOREIGN KEY (product_id) REFERENCES public.hardware_product_profile(id);
+    ADD CONSTRAINT device_validate_criteria_product_id_fkey FOREIGN KEY (hardware_product_id) REFERENCES public.hardware_product_profile(id);
 
 
 --
@@ -1692,7 +1692,7 @@ ALTER TABLE ONLY public.device_validate
 --
 
 ALTER TABLE ONLY public.hardware_product_profile
-    ADD CONSTRAINT hardware_product_profile_product_id_fkey FOREIGN KEY (product_id) REFERENCES public.hardware_product(id) ON DELETE CASCADE;
+    ADD CONSTRAINT hardware_product_profile_product_id_fkey FOREIGN KEY (hardware_product_id) REFERENCES public.hardware_product(id) ON DELETE CASCADE;
 
 
 --
@@ -1708,15 +1708,15 @@ ALTER TABLE ONLY public.hardware_product_profile
 --
 
 ALTER TABLE ONLY public.hardware_product
-    ADD CONSTRAINT hardware_product_vendor_fkey FOREIGN KEY (vendor) REFERENCES public.hardware_vendor(id);
+    ADD CONSTRAINT hardware_product_vendor_fkey FOREIGN KEY (hardware_vendor_id) REFERENCES public.hardware_vendor(id);
 
 
 --
--- Name: hardware_profile_settings hardware_profile_settings_profile_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: conch
+-- Name: hardware_profile_setting hardware_profile_settings_profile_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: conch
 --
 
-ALTER TABLE ONLY public.hardware_profile_settings
-    ADD CONSTRAINT hardware_profile_settings_profile_id_fkey FOREIGN KEY (profile_id) REFERENCES public.hardware_product_profile(id);
+ALTER TABLE ONLY public.hardware_profile_setting
+    ADD CONSTRAINT hardware_profile_settings_profile_id_fkey FOREIGN KEY (hardware_product_profile_id) REFERENCES public.hardware_product_profile(id);
 
 
 --

--- a/sql/test/00-hardware.sql
+++ b/sql/test/00-hardware.sql
@@ -1,11 +1,11 @@
 INSERT INTO hardware_vendor (name) VALUES ('DellBell');
 INSERT INTO hardware_vendor (name) VALUES ('SuperDuperMicro');
 
-INSERT INTO hardware_product (name, alias, prefix, vendor, legacy_product_name)
+INSERT INTO hardware_product (name, alias, prefix, hardware_vendor_id, legacy_product_name)
        VALUES ( 'Switch', 'Farce 10', 'F10', ( SELECT id FROM hardware_vendor WHERE name = 'DellBell' ), 'FuerzaDiaz' );
 
-INSERT INTO hardware_product (name, alias, prefix, vendor, sku, generation_name, legacy_product_name)
+INSERT INTO hardware_product (name, alias, prefix, hardware_vendor_id, sku, generation_name, legacy_product_name)
        VALUES ( '2-ssds-1-cpu', 'Test Compute', 'HA', ( SELECT id FROM hardware_vendor WHERE name = 'DellBell' ), '550-551-001', 'Joyent-G1', 'Joyent-Compute-Platform' );
 
-INSERT INTO hardware_product (name, alias, prefix, vendor, sku, generation_name, legacy_product_name)
+INSERT INTO hardware_product (name, alias, prefix, hardware_vendor_id, sku, generation_name, legacy_product_name)
        VALUES ( '65-ssds-2-cpu', 'Test Storage', 'MS', ( SELECT id FROM hardware_vendor WHERE name = 'SuperDuperMicro' ), '550-552-003', 'Joyent-S1', 'Joyent-Storage-Platform' );

--- a/sql/test/01-hardware-profiles.sql
+++ b/sql/test/01-hardware-profiles.sql
@@ -1,11 +1,11 @@
-INSERT INTO hardware_product_profile ( product_id, purpose, bios_firmware, cpu_num, cpu_type, 
+INSERT INTO hardware_product_profile ( hardware_product_id, purpose, bios_firmware, cpu_num, cpu_type, 
             dimms_num, ram_total, nics_num, psu_total, rack_unit, usb_num )
        VALUES ( ( SELECT id FROM hardware_product WHERE name = 'Switch' ),
             'TOR switch', '9.10', 1, 'Intel Rangeley',
             1, 3, 48, 2, 1, 0
        );
 
-INSERT INTO hardware_product_profile ( product_id, purpose, bios_firmware, cpu_num, cpu_type,
+INSERT INTO hardware_product_profile ( hardware_product_id, purpose, bios_firmware, cpu_num, cpu_type,
             dimms_num, ram_total, nics_num, sas_num, sas_size, ssd_num, ssd_size, ssd_slots, psu_total,
             rack_unit, usb_num)
        VALUES (  ( SELECT id FROM hardware_product WHERE name = '65-ssds-2-cpu' ),
@@ -13,7 +13,7 @@ INSERT INTO hardware_product_profile ( product_id, purpose, bios_firmware, cpu_n
             16, 512, 7, 35, 7452.04, 1, 93.16, '0', 2, 4, 1
        );
 
-INSERT INTO hardware_product_profile ( product_id, purpose, bios_firmware, cpu_num, cpu_type,
+INSERT INTO hardware_product_profile ( hardware_product_id, purpose, bios_firmware, cpu_num, cpu_type,
             dimms_num, ram_total, nics_num, sas_num, sas_size, ssd_num, ssd_size, ssd_slots, psu_total,
             rack_unit, usb_num )
       VALUES (  ( SELECT id FROM hardware_product WHERE name = '2-ssds-1-cpu' ),

--- a/sql/test/02-zpool-profiles.sql
+++ b/sql/test/02-zpool-profiles.sql
@@ -8,12 +8,12 @@ INSERT INTO zpool_profile (name, vdev_t, vdev_n, disk_per, spare, log, cache)
 UPDATE hardware_product_profile
     SET zpool_id =
         ( SELECT id FROM zpool_profile WHERE name = '2-ssds-1-cpu' )
-    WHERE product_id =
+    WHERE hardware_product_id =
         ( SELECT id FROM hardware_product WHERE name = '2-ssds-1-cpu' );
 
 UPDATE hardware_product_profile
     SET zpool_id =
         ( SELECT id FROM zpool_profile WHERE name = '65-ssds-2-cpu' )
-    WHERE product_id =
+    WHERE hardware_product_id =
         ( SELECT id FROM hardware_product WHERE name = '65-ssds-2-cpu' );
 

--- a/sql/test/03-test-datacenter.sql
+++ b/sql/test/03-test-datacenter.sql
@@ -3,7 +3,7 @@ INSERT INTO datacenter_rack_role ( name, rack_size ) VALUES ( 'TEST_RACK_ROLE', 
 INSERT INTO datacenter (vendor, vendor_name, region, location )
     VALUES ( 'Test Vendor', 'Test Name', 'test-region-1', 'Testlandia, Testopolis');
 
-INSERT INTO datacenter_room (datacenter, az, alias, vendor_name)
+INSERT INTO datacenter_room (datacenter_id, az, alias, vendor_name)
     VALUES ( ( SELECT id FROM datacenter WHERE region = 'test-region-1' ), 'test-region-1a', 'TT1', 'TEST1.1');
 
 INSERT INTO datacenter_rack (datacenter_room_id, name, datacenter_rack_role_id)
@@ -13,21 +13,21 @@ INSERT INTO datacenter_rack (datacenter_room_id, name, datacenter_rack_role_id)
         ( SELECT id FROM datacenter_rack_role WHERE name =  'TEST_RACK_ROLE' )
     );
 
-INSERT INTO datacenter_rack_layout (rack_id, product_id, ru_start)
+INSERT INTO datacenter_rack_layout (rack_id, hardware_product_id, ru_start)
     VALUES (
         ( SELECT id FROM datacenter_rack WHERE name = 'Test Rack' ),
         ( SELECT id FROM hardware_product WHERE name = '2-ssds-1-cpu'),
         1
     );
 
-INSERT INTO datacenter_rack_layout (rack_id, product_id, ru_start)
+INSERT INTO datacenter_rack_layout (rack_id, hardware_product_id, ru_start)
     VALUES (
         ( SELECT id FROM datacenter_rack WHERE name = 'Test Rack' ),
         ( SELECT id FROM hardware_product WHERE name = '2-ssds-1-cpu'),
         3
     );
 
-INSERT INTO datacenter_rack_layout (rack_id, product_id, ru_start)
+INSERT INTO datacenter_rack_layout (rack_id, hardware_product_id, ru_start)
     VALUES (
         ( SELECT id FROM datacenter_rack WHERE name = 'Test Rack' ),
         ( SELECT id FROM hardware_product WHERE name = '65-ssds-2-cpu'),

--- a/t/model/DatacenterRack.t
+++ b/t/model/DatacenterRack.t
@@ -29,7 +29,7 @@ my $dc_id = $pg->db->insert(
 
 my $dc_room_id = $pg->db->insert(
 	'datacenter_room',
-	{ az => 'sungo', datacenter => $dc_id },
+	{ az => 'sungo', datacenter_id => $dc_id },
 	{ returning => ['id'] },
 )->hash->{id};
 

--- a/t/model/DatacenterRackLayout.t
+++ b/t/model/DatacenterRackLayout.t
@@ -43,7 +43,7 @@ my $hardware_product_id = $pg->db->insert(
 	{
 		name   => 'test hw product',
 		alias  => 'alias',
-		vendor => $hardware_vendor_id
+		hardware_vendor_id => $hardware_vendor_id
 	},
 	{ returning => ['id'] }
 )->hash->{id};

--- a/t/model/Device.t
+++ b/t/model/Device.t
@@ -33,7 +33,7 @@ try {
 		{
 			name   => 'test hw product',
 			alias  => 'alias',
-			vendor => $hw_vendor_id
+			hardware_vendor_id => $hw_vendor_id
 		},
 		{ returning => ['id'] }
 	)->hash->{id};

--- a/t/model/DeviceReport.t
+++ b/t/model/DeviceReport.t
@@ -22,7 +22,7 @@ my $hardware_product_id = $pg->db->insert(
 	{
 		name   => 'test hw product',
 		alias  => 'alias',
-		vendor => $hardware_vendor_id
+		hardware_vendor_id => $hardware_vendor_id
 	},
 	{ returning => ['id'] }
 )->hash->{id};

--- a/t/model/DeviceRole.t
+++ b/t/model/DeviceRole.t
@@ -23,7 +23,7 @@ my $hw_product_id = $pg->db->insert(
 	{
 		name   => 'test hw product',
 		alias  => 'alias',
-		vendor => $vendor_id
+		hardware_vendor_id => $vendor_id
 	},
 	{ returning => ['id'] }
 )->hash->{id};

--- a/t/model/DeviceSettings.t
+++ b/t/model/DeviceSettings.t
@@ -22,7 +22,7 @@ my $hardware_product_id = $pg->db->insert(
 	{
 		name   => 'test hw product',
 		alias  => 'alias',
-		vendor => $hardware_vendor_id
+		hardware_vendor_id => $hardware_vendor_id
 	},
 	{ returning => ['id'] }
 )->hash->{id};

--- a/t/model/HardwareProduct.t
+++ b/t/model/HardwareProduct.t
@@ -20,7 +20,7 @@ my $hardware_product_id = $pg->db->insert(
 	{
 		name   => 'test hw product',
 		alias  => 'alias',
-		vendor => $hardware_vendor_id
+		hardware_vendor_id => $hardware_vendor_id
 	},
 	{ returning => ['id'] }
 )->hash->{id};
@@ -46,7 +46,7 @@ my %hw_profile_values = (
 my $hardware_profile_id = $pg->db->insert(
 	'hardware_product_profile',
 	{
-		product_id => $hardware_product_id,
+		hardware_product_id => $hardware_product_id,
 		zpool_id   => $zpool_profile_id,
 		%hw_profile_values
 	},

--- a/t/model/Relay.t
+++ b/t/model/Relay.t
@@ -25,7 +25,7 @@ my $hardware_product_id = $pg->db->insert(
 	{
 		name   => 'test hw product',
 		alias  => 'alias',
-		vendor => $hardware_vendor_id
+		hardware_vendor_id => $hardware_vendor_id
 	},
 	{ returning => ['id'] }
 )->hash->{id};

--- a/t/model/Validation.t
+++ b/t/model/Validation.t
@@ -30,7 +30,7 @@ my $hardware_product_id = $pg->db->insert(
 	{
 		name   => 'test hw product',
 		alias  => 'alias',
-		vendor => $hardware_vendor_id,
+		hardware_vendor_id => $hardware_vendor_id,
 		generation_name => 'Joyent-G1',
 	},
 	{ returning => ['id'] }
@@ -45,7 +45,7 @@ my $zpool_profile_id = $pg->db->insert(
 my $hardware_profile_id = $pg->db->insert(
 	'hardware_product_profile',
 	{
-		product_id    => $hardware_product_id,
+		hardware_product_id    => $hardware_product_id,
 		zpool_id      => $zpool_profile_id,
 		rack_unit     => 1,
 		purpose       => 'test',

--- a/t/model/ValidationPlan.t
+++ b/t/model/ValidationPlan.t
@@ -37,7 +37,7 @@ my $hardware_product_id = $pg->db->insert(
 	{
 		name   => 'test hw product',
 		alias  => 'alias',
-		vendor => $hardware_vendor_id,
+		hardware_vendor_id => $hardware_vendor_id,
 		generation_name => 'Joyent-G1',
 	},
 	{ returning => ['id'] }
@@ -52,7 +52,7 @@ my $zpool_profile_id = $pg->db->insert(
 my $hardware_profile_id = $pg->db->insert(
 	'hardware_product_profile',
 	{
-		product_id    => $hardware_product_id,
+		hardware_product_id    => $hardware_product_id,
 		zpool_id      => $zpool_profile_id,
 		rack_unit     => 1,
 		purpose       => 'test',

--- a/t/model/ValidationResult.t
+++ b/t/model/ValidationResult.t
@@ -31,7 +31,7 @@ my $hardware_product_id = $pg->db->insert(
 	{
 		name   => 'test hw product',
 		alias  => 'alias',
-		vendor => $hardware_vendor_id
+		hardware_vendor_id => $hardware_vendor_id
 	},
 	{ returning => ['id'] }
 )->hash->{id};

--- a/t/model/ValidationState.t
+++ b/t/model/ValidationState.t
@@ -41,7 +41,7 @@ my $hardware_product_id = $pg->db->insert(
 	{
 		name   => 'test hw product',
 		alias  => 'alias',
-		vendor => $hardware_vendor_id,
+		hardware_vendor_id => $hardware_vendor_id,
 		generation_name => 'Joyent-G1',
 	},
 	{ returning => ['id'] }
@@ -56,7 +56,7 @@ my $zpool_profile_id = $pg->db->insert(
 my $hardware_profile_id = $pg->db->insert(
 	'hardware_product_profile',
 	{
-		product_id    => $hardware_product_id,
+		hardware_product_id    => $hardware_product_id,
 		zpool_id      => $zpool_profile_id,
 		rack_unit     => 1,
 		purpose       => 'test',

--- a/t/pod-coverage.t
+++ b/t/pod-coverage.t
@@ -10,7 +10,9 @@ my @skip_modules = (
 );
 
 # regexps of sub names that are always trusted
-my @also_private = ();
+my @also_private = qw(
+    BUILDARGS
+);
 
 # module => [ regexps of sub names to be trusted ]
 my %trustme = (


### PR DESCRIPTION
Clean up a lot of inconsistency between FK column and table names. Some of these are necessary for DBIC work as DBIC generates queries using the relationship name as table aliases, and some of these were creating ambiguous SQL.