### PR TITLE
Adds a fallback to legacy product name in DeviceReport#process and removes two json schema requirements for device reports

### DIFF
--- a/json-schema/input.yaml
+++ b/json-schema/input.yaml
@@ -125,8 +125,6 @@ definitions:
         required:
           - cpu0
           - cpu1
-          - exhaust
-          - inlet
         properties:
           cpu0:
             type: number

--- a/lib/Conch/Legacy/Control/DeviceReport.pm
+++ b/lib/Conch/Legacy/Control/DeviceReport.pm
@@ -45,32 +45,9 @@ Record device report and device details from the report
 =cut
 
 sub record_device_report {
-	my ( $schema, $dr, $raw_report ) = @_;
-
-	my $hw;
-
-	if ($dr->{device_type} && $dr->{device_type} eq "switch")
-	{
-		$hw = $schema->resultset('HardwareProduct')->find(
-		{
-			name => $dr->{product_name}
-		}
-		);
-		$hw or die $log->critical("Product $dr->{product_name} not found");
-	} else {
-		$hw = $schema->resultset('HardwareProduct')->find(
-		{
-			sku => $dr->{sku}
-		}
-		);
-		$hw or die $log->critical("Product $dr->{sku} not found");
-	}
+	my ( $schema, $dr, $raw_report, $hw ) = @_;
 
 	my $hw_profile = $hw->hardware_product_profile;
-	$hw_profile
-		or die $log->criticalf(
-		"Hardware product '%s' exists but does not have a hardware profile",
-		$hw->name );
 
 	$log->info("Ready to record report for Device $dr->{serial_number}");
 

--- a/t/integration/00_only_1_user_loaded.t
+++ b/t/integration/00_only_1_user_loaded.t
@@ -331,8 +331,9 @@ subtest 'Relay List' => sub {
 subtest 'Device Report' => sub {
 	my $report =
 		io->file('t/integration/resource/passing-device-report.json')->slurp;
-	$t->post_ok( '/device/TEST', { 'Content-Type' => 'application/json' }, $report )->status_is(409)
-		->json_like( '/error', qr/Hardware product SKU '.+' does not exist/ );
+	$t->post_ok( '/device/TEST', {
+		'Content-Type' => 'application/json'
+	}, $report )->status_is(409);
 
 	$t->post_ok( '/device/TEST', json => { serial_number => 'TEST' } )
 		->status_is(400)->json_like( '/error', qr/Missing property/ );

--- a/t/integration/01_hardware_products_loaded.t
+++ b/t/integration/01_hardware_products_loaded.t
@@ -59,8 +59,9 @@ subtest 'Relay List' => sub {
 subtest 'Device Report' => sub {
 	my $report =
 		io->file('t/integration/resource/passing-device-report.json')->slurp;
-	$t->post_ok( '/device/TEST', { 'Content-Type' => 'application/json' }, $report )->status_is(409)
-		->json_like( '/error', qr/Hardware product SKU '.+' does not exist/ );
+	$t->post_ok( '/device/TEST', {
+		'Content-Type' => 'application/json'
+	}, $report )->status_is(409);
 };
 
 subtest 'Hardware Product' => sub {


### PR DESCRIPTION
Addresses joyent/conch#351 - This PR applies to release/v2.15 exclusively. Additional PRs for 2.16 and master will follow later as appropriate