### PR TITLE
remove the build.validated workaround now that the relay/rebooter fix has been in production for a while. 

### DIFF
--- a/lib/Conch/Controller/DeviceSettings.pm
+++ b/lib/Conch/Controller/DeviceSettings.pm
@@ -59,13 +59,6 @@ sub set_single ($c) {
 		{ $setting_key => $setting_value }
 	);
 
-	# TODO: This hard-coded setting dispatch is added for backwards
-	# compatibility with Conch v1.0.0.  It is to be removed once Conch-Relay
-	# and Conch-Rebooter are updated to use /device/:id/validated
-	if ($setting_key eq 'build.validated') {
-		$c->stash('current_device')->set_validated();
-	}
-
 	$c->status(200);
 }
 

--- a/t/integration/04_test_datacenter_loaded.t
+++ b/t/integration/04_test_datacenter_loaded.t
@@ -213,13 +213,6 @@ subtest 'Single device' => sub {
 			->content_is('');
 		$t->get_ok('/device/TEST/settings/foo.bar')->status_is(404)
 			->json_like( '/error', qr/foo\.bar/ );
-
-		$t->post_ok(
-			'/device/TEST/settings/build.validated',
-			json => { 'build.validated' => 1 }
-		)->status_is(200);
-		$t->get_ok('/device/TEST')->status_is(200)
-			->json_like( '/validated', qr/^\d{4}-\d\d-\d\d/ );
 	};
 
 	subtest 'Device Roles And Services' => sub {


### PR DESCRIPTION
Fixes #160