### PR TITLE
Want ability to tag devices with arbitrary data

### DIFF
--- a/lib/Conch/DB/ResultSet/DatacenterRack.pm
+++ b/lib/Conch/DB/ResultSet/DatacenterRack.pm
@@ -1,0 +1,61 @@
+package Conch::DB::ResultSet::DatacenterRack;
+use v5.26;
+use warnings;
+use parent 'Conch::DB::ResultSet';
+
+=head1 NAME
+
+Conch::DB::ResultSet::DatacenterRack
+
+=head1 DESCRIPTION
+
+Interface to queries involving racks.
+
+=head1 METHODS
+
+=head2 associated_workspaces
+
+Chainable resultset (in the Conch::DB::ResultSet::Workspace namespace) that finds all
+workspaces that are associated with the specified rack(s) (either directly, or via a
+datacenter_room).
+
+To go in the other direction, see L<Conch::DB::ResultSet::Workspace/associated_racks>.
+
+=cut
+
+sub associated_workspaces {
+    my $self = shift;
+
+    my $rack_workspace_ids = $self->search_related('workspace_datacenter_racks')
+        ->get_column('workspace_id');
+
+    my $rack_room_workspace_ids = $self->search_related('datacenter_room')
+        ->search_related('workspace_datacenter_rooms')
+        ->get_column('workspace_id');
+
+    $self->result_source->schema->resultset('Workspace')->search(
+        {
+            'workspace.id' => [
+                { -in => $rack_workspace_ids->as_query },
+                { -in => $rack_room_workspace_ids->as_query },
+            ],
+        },
+        { alias => 'workspace' },
+    );
+}
+
+1;
+__END__
+
+=pod
+
+=head1 LICENSING
+
+Copyright Joyent, Inc.
+
+This Source Code Form is subject to the terms of the Mozilla Public License,
+v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+one at http://mozilla.org/MPL/2.0/.
+
+=cut
+# vim: set ts=4 sts=4 sw=4 et :

--- a/lib/Conch/DB/ResultSet/UserWorkspaceRole.pm
+++ b/lib/Conch/DB/ResultSet/UserWorkspaceRole.pm
@@ -1,4 +1,4 @@
-package Conch::DB::ResultSet::Device;
+package Conch::DB::ResultSet::UserWorkspaceRole;
 use v5.26;
 use warnings;
 use parent 'Conch::DB::ResultSet';
@@ -8,18 +8,18 @@ use List::Util 'none';
 
 =head1 NAME
 
-Conch::DB::ResultSet::Device
+Conch::DB::ResultSet::UserWorkspaceRole
 
 =head1 DESCRIPTION
 
-Interface to queries involving devices.
+Interface to queries involving user/workspace permissions.
 
 =head1 METHODS
 
 =head2 user_has_permission
 
-Checks that the provided user_id has (at least) the specified permission in at least one
-workspace associated with the specified device(s).
+Returns a count of the number of specified user_workspace_role rows that grant the specified
+permission level.  (Normally you'd treat this as a boolean check.)
 
 =cut
 
@@ -29,11 +29,10 @@ sub user_has_permission {
     Carp::croak('permission must be one of: ro, rw, admin')
         if none { $permission eq $_ } qw(ro rw admin);
 
-    $self->related_resultset('device_location')
-        ->related_resultset('rack')
-        ->associated_workspaces
-        ->related_resultset('user_workspace_roles')
-        ->user_has_permission($user_id, $permission);
+    $self->search({
+        user_id => $user_id,
+        role => { '>=' => \[ q{?::user_workspace_role_enum}, $permission ] },
+    })->count;
 }
 
 1;

--- a/lib/Conch/DB/ResultSet/Workspace.pm
+++ b/lib/Conch/DB/ResultSet/Workspace.pm
@@ -43,6 +43,8 @@ SELECT workspace_recursive.id FROM workspace_recursive
 Chainable resultset (in the Conch::DB::ResultSet::DatacenterRack namespace) that finds all
 racks that are in this workspace (either directly, or via a datacenter_room).
 
+To go in the other direction, see L<Conch::DB::ResultSet::DatacenterRack/associated_workspaces>.
+
 =cut
 
 sub associated_racks {

--- a/t/integration/04_test_datacenter_loaded.t
+++ b/t/integration/04_test_datacenter_loaded.t
@@ -130,6 +130,18 @@ subtest 'Device Report' => sub {
 	);
 };
 
+subtest 'Assign device to a location' => sub {
+	$t->post_ok(
+		"/workspace/$id/rack/$rack_id/layout",
+		json => {
+			TEST => 1
+		}
+	)->status_is(200);
+
+	$t->get_ok('/device/TEST/location')->status_is(200);
+
+};
+
 subtest 'Single device' => sub {
 
 	$t->get_ok('/device/nonexistant')->status_is(404)
@@ -326,18 +338,6 @@ subtest 'Single device' => sub {
 			->json_is('/id' => $d_role->id);
 		is_deeply($t->tx->res->json, $d_role->TO_JSON);
 	};
-
-};
-
-subtest 'Assigned device' => sub {
-	$t->post_ok(
-		"/workspace/$id/rack/$rack_id/layout",
-		json => {
-			TEST => 1
-		}
-	)->status_is(200);
-
-	$t->get_ok('/device/TEST/location')->status_is(200);
 
 };
 


### PR DESCRIPTION
(bdha wrote this)
Topicbox thread [here](https://joyent.topicbox.com/groups/buildops/Tc2a485ea5b745319-M53575c0b501d580bb48c7558/device-tagging).

We are going to use Device Settings for this. Most of the heavy lifting here will be done in https://github.com/joyent/conch-shell/issues/129. Settings with `tag.` prefixes will be treated as tags, and all other device settings will be used as they have been.

Nominally the only change in the API needed is:

We would like to ensure that the API does not allow non-workspace admins to overwrite non-`tag.` settings. We need to clean up our own device setting usage during builds.

Users with rw perms should be able to modify `tag.` settings, but nothing else.