### PR TITLE
After deleting a user, that email address cannot be reused in a new user.

### DIFF
--- a/lib/Conch/Controller/User.pm
+++ b/lib/Conch/Controller/User.pm
@@ -317,14 +317,8 @@ sub create ($c) {
 	# this would cause horrible clashes with our /user routes!
 	return $c->status(400, { error => 'user name "me" is prohibited', }) if $name eq 'me';
 
-	# we don't use lookup_by_* because they only search active users.
-	if (my $user = $c->db_user_accounts->search({
-			-or => [
-				{ name => $name },
-				\[ 'lower(email) = lower(?)', $email ],
-			]
-		})->first)
-	{
+	if (my $user = $c->db_user_accounts->lookup_by_email($email)
+			|| $c->db_user_accounts->lookup_by_name($name)) {
 		return $c->status(409, {
 			error => 'duplicate user found',
 			user => { map { $_ => $user->$_ } qw(id email name created deactivated) },

--- a/lib/Conch/Controller/User.pm
+++ b/lib/Conch/Controller/User.pm
@@ -368,7 +368,11 @@ sub deactivate ($c) {
 		});
 	}
 
-	$c->log->warn('user ' . $c->stash('user')->name . ' deactivating user ' . $user->name);
+	my $workspaces = join(', ', map { $_->workspace->name . ' (' . $_->role . ')' }
+		$user->search_related('user_workspace_roles',{}, { join => 'workspace' }));
+
+	$c->log->warn('user ' . $c->stash('user')->name . ' deactivating user ' . $user->name
+		. ($workspaces ? ", member of workspaces: $workspaces" : ''));
 	$user->update({ password => $c->random_string, deactivated => \'NOW()' });
 
 	if ($c->req->query_params->param('clear_tokens') // 1) {

--- a/lib/Conch/DB/Result/UserAccount.pm
+++ b/lib/Conch/DB/Result/UserAccount.pm
@@ -133,32 +133,6 @@ __PACKAGE__->add_columns(
 
 __PACKAGE__->set_primary_key("id");
 
-=head1 UNIQUE CONSTRAINTS
-
-=head2 C<user_account_email_key>
-
-=over 4
-
-=item * L</email>
-
-=back
-
-=cut
-
-__PACKAGE__->add_unique_constraint("user_account_email_key", ["email"]);
-
-=head2 C<user_account_name_key>
-
-=over 4
-
-=item * L</name>
-
-=back
-
-=cut
-
-__PACKAGE__->add_unique_constraint("user_account_name_key", ["name"]);
-
 =head1 RELATIONS
 
 =head2 user_relay_connections
@@ -222,8 +196,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-15 16:00:18
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:mVW8QcKBqvYOVU42HkfvbQ
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-30 10:52:38
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:1vfzM3wgxggRB2gZ0JsIQg
 
 __PACKAGE__->add_columns(
     '+password_hash' => { is_serializable => 0 },

--- a/sql/migrations/0042-user_account-email-uniqueness.sql
+++ b/sql/migrations/0042-user_account-email-uniqueness.sql
@@ -1,0 +1,8 @@
+SELECT run_migration(42, $$
+
+    alter table user_account drop constraint if exists user_account_email_key;
+    alter table user_account drop constraint if exists user_account_name_key;
+    create unique index user_account_email_key on user_account (email) where deactivated is null;
+    create unique index user_account_name_key on user_account (name) where deactivated is null;
+
+$$);

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1235,22 +1235,6 @@ ALTER TABLE ONLY public.relay
 
 
 --
--- Name: user_account user_account_email_key; Type: CONSTRAINT; Schema: public; Owner: conch
---
-
-ALTER TABLE ONLY public.user_account
-    ADD CONSTRAINT user_account_email_key UNIQUE (email);
-
-
---
--- Name: user_account user_account_name_key; Type: CONSTRAINT; Schema: public; Owner: conch
---
-
-ALTER TABLE ONLY public.user_account
-    ADD CONSTRAINT user_account_name_key UNIQUE (name);
-
-
---
 -- Name: user_account user_account_pkey; Type: CONSTRAINT; Schema: public; Owner: conch
 --
 
@@ -1405,6 +1389,20 @@ CREATE UNIQUE INDEX device_settings_device_id_name_idx ON public.device_settings
 --
 
 CREATE INDEX device_validate_report_id_idx ON public.device_validate USING btree (report_id);
+
+
+--
+-- Name: user_account_email_key; Type: INDEX; Schema: public; Owner: conch
+--
+
+CREATE UNIQUE INDEX user_account_email_key ON public.user_account USING btree (email) WHERE (deactivated IS NULL);
+
+
+--
+-- Name: user_account_name_key; Type: INDEX; Schema: public; Owner: conch
+--
+
+CREATE UNIQUE INDEX user_account_name_key ON public.user_account USING btree (name) WHERE (deactivated IS NULL);
 
 
 --


### PR DESCRIPTION
(sungo wrote this)
I was testing workspace invites in the shell. I created a user via /workspace/:id/invite and then deleted them via `DELETE /usr/email=<REDACTED>`. When I attempted to invite that same email address again, the API threw a 500 with 

`DBIx::Class::Storage::DBI::_dbh_execute(): DBI Exception: DBD::Pg::st execute failed: ERROR:  duplicate key value violates unique constraint \"user_account_email_key\"\nDETAIL:  Key (email)=(<REDACTED>) already exists. [for Statement \"INSERT INTO user_account ( email, name, password_hash) VALUES ( ?, ?, ? ) RETURNING id\" with ParamValues: 1='<REDACTED>', 2='<REDACTED>', 3='<REDACTED2>'] at /usr/home/sungo/src/conch/bin/../lib/Conch/Controller/WorkspaceUser.pm line 89`

My naive assumption is that we need to adjust the constraint on the email field to only apply to users where deactived=null