### PR TITLE
rename columns for rack unit size, position; add FK; adjust formatting of WorkspaceRack response

### DIFF
--- a/json-schema/input.yaml
+++ b/json-schema/input.yaml
@@ -205,10 +205,10 @@ definitions:
       rack_id:
         type: string
         format: uuid
-      product_id:
+      product_id: # TODO: this really should be hardware_product_id
         type: string
         format: uuid
-      ru_start:
+      ru_start: # TODO: this really should be rack_unit_start
         type: integer
   RackLayoutUpdate:
     type: object
@@ -217,10 +217,10 @@ definitions:
       rack_id:
         type: string
         format: uuid
-      product_id:
+      product_id: # TODO: this really should be hardware_product_id
         type: string
         format: uuid
-      ru_start:
+      ru_start: # TODO: this really should be rack_unit_start
         type: integer
   DBHardwareProductCreate:
     type: object

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -1337,7 +1337,7 @@ definitions:
       product_id:
         type: string
         format: uuid
-      ru_start:
+      ru_start: # TODO: this really should be rack_unit_start
         type: integer
       created:
         type: string

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -621,41 +621,43 @@ definitions:
       datacenter:
         type: string
       slots:
-        type: object
-        additionalProperties: false
-        patternProperties:
-          ^[0-9]+$:
-            type: object
-            additionalProperties: false
-            required:
-              - alias
-              - id
-              - name
-              - size
-              - vendor
-              - occupant
-            properties:
-              alias:
-                type: string
-                description: Hardware product alias
-              id:
-                type: string
-                format: uuid
-                description: Hardware product ID
-              name:
-                type: string
-                description: Hardware product name
-              size:
-                type: integer
-                description: Number of RUs for slot
-              vendor:
-                type: string
-                description: Hardware product vendor
-              occupant:
-                description: Device assigned to this slot or null
-                anyOf:
-                  - $ref: "#/definitions/Device"
-                  - type: null
+        type: array
+        items:
+          type: object
+          additionalProperties: false
+          required:
+            - rack_unit_start
+            - alias
+            - id
+            - name
+            - size
+            - vendor
+            - occupant
+          properties:
+            rack_unit_start:
+              type: integer
+              description: Starting RU slot position
+            alias:
+              type: string
+              description: Hardware product alias
+            id:
+              type: string
+              format: uuid
+              description: Hardware product ID
+            name:
+              type: string
+              description: Hardware product name
+            size:
+              type: integer
+              description: Number of RUs for slot
+            vendor:
+              type: string
+              description: Hardware product vendor
+            occupant:
+              description: Device assigned to this slot or null
+              anyOf:
+                - $ref: "#/definitions/Device"
+                - type: null
   Validations:
     type: array
     items:

--- a/lib/Conch/Controller/DatacenterRackLayout.pm
+++ b/lib/Conch/Controller/DatacenterRackLayout.pm
@@ -64,13 +64,14 @@ sub create ($c) {
 	}
 
 	if ($c->db_datacenter_rack_layouts->search(
-				{ rack_id => $input->{rack_id}, ru_start => $input->{ru_start} },
+				{ rack_id => $input->{rack_id}, rack_unit_start => $input->{ru_start} },
 			)->count) {
 		$c->log->debug('Conflict with ru_start value of '.$input->{ru_start});
 		return $c->status(400 => { error => 'ru_start conflict' });
 	}
 
 	$input->{hardware_product_id} = delete $input->{product_id};
+	$input->{rack_unit_start} = delete $input->{ru_start};
 
 	my $layout = $c->db_datacenter_rack_layouts->create($input);
 	$c->log->debug('Created datacenter rack layout '.$layout->id);
@@ -124,9 +125,9 @@ sub update ($c) {
 		}
 	}
 
-	if ($input->{ru_start} && ($input->{ru_start} != $c->stash('rack_layout')->ru_start)) {
+	if ($input->{ru_start} && ($input->{ru_start} != $c->stash('rack_layout')->rack_unit_start)) {
 		if ($c->db_datacenter_rack_layouts->search(
-					{ rack_id => $c->stash('rack_layout')->rack_id, ru_start => $input->{ru_start} }
+					{ rack_id => $c->stash('rack_layout')->rack_id, rack_unit_start => $input->{ru_start} }
 				)->count) {
 			$c->log->debug('Conflict with ru_start value of '.$input->{ru_start});
 			return $c->status(400 => { error => 'ru_start conflict' });
@@ -134,6 +135,8 @@ sub update ($c) {
 	}
 
 	$input->{hardware_product_id} = delete $input->{product_id} if exists $input->{product_id};
+	$input->{rack_unit_start} = delete $input->{ru_start} if exists $input->{ru_start};
+
 	$c->stash('rack_layout')->update({ %$input, updated => \'NOW()' });
 
 	return $c->status(303 => "/layout/".$c->stash('rack_layout')->id);

--- a/lib/Conch/Controller/DeviceLocation.pm
+++ b/lib/Conch/Controller/DeviceLocation.pm
@@ -45,6 +45,7 @@ Sets the location for a device, given a valid rack id and rack unit
 sub set ($c) {
 	my $device_id = $c->stash('device_id');
 	my $body      = $c->req->json;
+	# FIXME: validate incoming data against json schema
 	return $c->status( 400,
 		{ error => 'rack_id and rack_unit must be defined the the request object' }
 	) unless $body->{rack_id} && $body->{rack_unit};

--- a/lib/Conch/Controller/WorkspaceProblem.pm
+++ b/lib/Conch/Controller/WorkspaceProblem.pm
@@ -131,16 +131,18 @@ sub _device_rack_location {
 			$schema->resultset('DatacenterRoom')->find( { id => $rack_info->datacenter_room_id } );
 
 		# get the hardware product a device should be by rack location
+		# TODO: can just search for this directly via
+		# rack->datacenter_rack_layouts->hardware_product
 		my $target_hardware = $schema->resultset('HardwareProduct')->search(
 			{
 				'datacenter_rack_layouts.rack_id'  => $rack_info->id,
-				'datacenter_rack_layouts.ru_start' => $device_location->rack_unit,
+				'datacenter_rack_layouts.rack_unit_start' => $device_location->rack_unit_start,
 			},
 			{ join => 'datacenter_rack_layouts' }
 		)->single;
 
 		$location->{rack}{id}   = $device_location->rack_id;
-		$location->{rack}{unit} = $device_location->rack_unit;
+		$location->{rack}{unit} = $device_location->rack_unit_start;
 		$location->{rack}{name} = $rack_info->name;
 		$location->{rack}{role} = $rack_info->role->name;
 

--- a/lib/Conch/Controller/WorkspaceRack.pm
+++ b/lib/Conch/Controller/WorkspaceRack.pm
@@ -182,23 +182,23 @@ sub assign_layout ($c) {
 
 	return $c->status(403) if $uwr->role eq 'ro';
 	my $rack_id = $c->stash('current_ws_rack')->id;
-
+	# FIXME: validate incoming data against json schema
 	my $layout = $c->req->json;
 	my @errors;
 	my @updates;
 	foreach my $device_id ( keys %{$layout} ) {
-		my $rack_unit = $layout->{$device_id};
+		my $rack_unit_start = $layout->{$device_id};
 		my $loc = Conch::Model::DeviceLocation->new->assign(
 			$device_id,
 			$rack_id,
-			$rack_unit
+			$rack_unit_start,
 		);
 		if ($loc) {
 			push @updates, $device_id;
 		}
 		else {
 			push @errors,
-				"Slot $rack_unit does not exist in the layout for rack $rack_id";
+				"Slot $rack_unit_start does not exist in the layout for rack $rack_id";
 		}
 	}
 

--- a/lib/Conch/DB/Result/DatacenterRackLayout.pm
+++ b/lib/Conch/DB/Result/DatacenterRackLayout.pm
@@ -58,7 +58,7 @@ __PACKAGE__->table("datacenter_rack_layout");
   is_nullable: 0
   size: 16
 
-=head2 ru_start
+=head2 rack_unit_start
 
   data_type: 'integer'
   is_nullable: 0
@@ -91,7 +91,7 @@ __PACKAGE__->add_columns(
   { data_type => "uuid", is_foreign_key => 1, is_nullable => 0, size => 16 },
   "hardware_product_id",
   { data_type => "uuid", is_foreign_key => 1, is_nullable => 0, size => 16 },
-  "ru_start",
+  "rack_unit_start",
   { data_type => "integer", is_nullable => 0 },
   "created",
   {
@@ -123,24 +123,42 @@ __PACKAGE__->set_primary_key("id");
 
 =head1 UNIQUE CONSTRAINTS
 
-=head2 C<datacenter_rack_layout_rack_id_ru_start_key>
+=head2 C<datacenter_rack_layout_rack_id_rack_unit_start_key>
 
 =over 4
 
 =item * L</rack_id>
 
-=item * L</ru_start>
+=item * L</rack_unit_start>
 
 =back
 
 =cut
 
 __PACKAGE__->add_unique_constraint(
-  "datacenter_rack_layout_rack_id_ru_start_key",
-  ["rack_id", "ru_start"],
+  "datacenter_rack_layout_rack_id_rack_unit_start_key",
+  ["rack_id", "rack_unit_start"],
 );
 
 =head1 RELATIONS
+
+=head2 device_location
+
+Type: might_have
+
+Related object: L<Conch::DB::Result::DeviceLocation>
+
+=cut
+
+__PACKAGE__->might_have(
+  "device_location",
+  "Conch::DB::Result::DeviceLocation",
+  {
+    "foreign.rack_id"         => "self.rack_id",
+    "foreign.rack_unit_start" => "self.rack_unit_start",
+  },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
 
 =head2 hardware_product
 
@@ -173,8 +191,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-22 17:47:15
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:uo/aiCKpReIr67au4jKFQw
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-07 11:03:51
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:SIB+Lq+AfaSnC6SVu04/RA
 
 use Class::Method::Modifiers;
 
@@ -184,6 +202,7 @@ around TO_JSON => sub {
 
     my $data = $self->$orig(@_);
     $data->{product_id} = delete $data->{hardware_product_id};
+    $data->{ru_start} = delete $data->{rack_unit_start};
     return $data;
 };
 

--- a/lib/Conch/DB/Result/DeviceLocation.pm
+++ b/lib/Conch/DB/Result/DeviceLocation.pm
@@ -50,9 +50,10 @@ __PACKAGE__->table("device_location");
   is_nullable: 0
   size: 16
 
-=head2 rack_unit
+=head2 rack_unit_start
 
   data_type: 'integer'
+  is_foreign_key: 1
   is_nullable: 0
 
 =head2 created
@@ -76,8 +77,8 @@ __PACKAGE__->add_columns(
   { data_type => "text", is_foreign_key => 1, is_nullable => 0 },
   "rack_id",
   { data_type => "uuid", is_foreign_key => 1, is_nullable => 0, size => 16 },
-  "rack_unit",
-  { data_type => "integer", is_nullable => 0 },
+  "rack_unit_start",
+  { data_type => "integer", is_foreign_key => 1, is_nullable => 0 },
   "created",
   {
     data_type     => "timestamp with time zone",
@@ -108,24 +109,39 @@ __PACKAGE__->set_primary_key("device_id");
 
 =head1 UNIQUE CONSTRAINTS
 
-=head2 C<device_location_rack_id_rack_unit_key>
+=head2 C<device_location_rack_id_rack_unit_start_key>
 
 =over 4
 
 =item * L</rack_id>
 
-=item * L</rack_unit>
+=item * L</rack_unit_start>
 
 =back
 
 =cut
 
 __PACKAGE__->add_unique_constraint(
-  "device_location_rack_id_rack_unit_key",
-  ["rack_id", "rack_unit"],
+  "device_location_rack_id_rack_unit_start_key",
+  ["rack_id", "rack_unit_start"],
 );
 
 =head1 RELATIONS
+
+=head2 datacenter_rack_layout
+
+Type: belongs_to
+
+Related object: L<Conch::DB::Result::DatacenterRackLayout>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "datacenter_rack_layout",
+  "Conch::DB::Result::DatacenterRackLayout",
+  { rack_id => "rack_id", rack_unit_start => "rack_unit_start" },
+  { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
+);
 
 =head2 device
 
@@ -158,8 +174,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-15 16:00:18
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:5MliEY3BFtW3yP2osb89vw
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-07 11:03:51
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:LpNt7rqcrIhdvmOF3uEl8A
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/Model/WorkspaceRack.pm
+++ b/lib/Conch/Model/WorkspaceRack.pm
@@ -69,7 +69,7 @@ sub rack_layout ( $self, $rack ) {
 	$res->{datacenter} = $datacenter_room->{az};
 
 	foreach my $slot (@$rack_slots) {
-		my $ru_start = $slot->{ru_start};
+		my $rack_unit_start = $slot->{rack_unit_start};
 		my $hw       = $db->query(
 			q{
       SELECT hw.*, vendor.name AS vendor, profile.rack_unit as size
@@ -88,22 +88,22 @@ sub rack_layout ( $self, $rack ) {
       FROM device
       JOIN device_location loc on device.id = loc.device_id
       WHERE loc.rack_id = ?
-        AND loc.rack_unit = ?
-      }, $rack->id, $ru_start
+        AND loc.rack_unit_start = ?
+      }, $rack->id, $rack_unit_start
 		)->hash;
 
 		if ($device) {
-			$res->{slots}{$ru_start}{occupant} = $device;
+			$res->{slots}{$rack_unit_start}{occupant} = $device;
 		}
 		else {
-			$res->{slots}{$ru_start}{occupant} = undef;
+			$res->{slots}{$rack_unit_start}{occupant} = undef;
 		}
 
-		$res->{slots}{$ru_start}{id}     = $hw->{id};
-		$res->{slots}{$ru_start}{alias}  = $hw->{alias};
-		$res->{slots}{$ru_start}{name}   = $hw->{name};
-		$res->{slots}{$ru_start}{vendor} = $hw->{vendor};
-		$res->{slots}{$ru_start}{size}   = $hw->{size};
+		$res->{slots}{$rack_unit_start}{id}     = $hw->{id};
+		$res->{slots}{$rack_unit_start}{alias}  = $hw->{alias};
+		$res->{slots}{$rack_unit_start}{name}   = $hw->{name};
+		$res->{slots}{$rack_unit_start}{vendor} = $hw->{vendor};
+		$res->{slots}{$rack_unit_start}{size}   = $hw->{size};
 	}
 
 	return $res;

--- a/lib/Conch/Model/WorkspaceRack.pm
+++ b/lib/Conch/Model/WorkspaceRack.pm
@@ -68,6 +68,8 @@ sub rack_layout ( $self, $rack ) {
 	$res->{role}       = $rack->role_name;
 	$res->{datacenter} = $datacenter_room->{az};
 
+	my @slots;
+
 	foreach my $slot (@$rack_slots) {
 		my $rack_unit_start = $slot->{rack_unit_start};
 		my $hw       = $db->query(
@@ -92,19 +94,26 @@ sub rack_layout ( $self, $rack ) {
       }, $rack->id, $rack_unit_start
 		)->hash;
 
+		my $slot = { rack_unit_start => $rack_unit_start };
+
 		if ($device) {
-			$res->{slots}{$rack_unit_start}{occupant} = $device;
+			$slot->{occupant} = $device;
 		}
 		else {
-			$res->{slots}{$rack_unit_start}{occupant} = undef;
+			$slot->{occupant} = undef;
 		}
 
-		$res->{slots}{$rack_unit_start}{id}     = $hw->{id};
-		$res->{slots}{$rack_unit_start}{alias}  = $hw->{alias};
-		$res->{slots}{$rack_unit_start}{name}   = $hw->{name};
-		$res->{slots}{$rack_unit_start}{vendor} = $hw->{vendor};
-		$res->{slots}{$rack_unit_start}{size}   = $hw->{size};
+		$slot->{id}     = $hw->{id};
+		$slot->{alias}  = $hw->{alias};
+		$slot->{name}   = $hw->{name};
+		$slot->{vendor} = $hw->{vendor};
+		$slot->{size}   = $hw->{size};
+
+		push @slots, $slot;
 	}
+
+	@slots = sort { $a->{rack_unit_start} <=> $b->{rack_unit_start} } @slots;
+	$res->{slots} = \@slots;
 
 	return $res;
 }

--- a/lib/Conch/Validation.pm
+++ b/lib/Conch/Validation.pm
@@ -252,8 +252,8 @@ location in the rack a device occupies. Throws an error if the device hasn't
 been assigned a location.
 
 	my $datacenter_name = $self->device_location->datacenter->name;
-	my $rack_unit = $self->device_location->rack->unit;
-	my $rack_slots = $self->device_location->rack->slots;
+	my $rack_unit_start = $self->device_location->rack_unit;	# TODO Conch::DB::Result::DeviceLocation calls this rack_unit_start
+	my $rack_available_slots = $self->device_location->datacenter_rack->slots;
 
 =cut
 

--- a/lib/Conch/Validation/SwitchPeers.pm
+++ b/lib/Conch/Validation/SwitchPeers.pm
@@ -52,7 +52,7 @@ sub validate {
 	}
 
 	my @peer_ports = $self->_calculate_switch_peer_ports(
-		$device_location->rack_unit,
+		$device_location->rack_unit,	# TODO: Conch::DB::Result::DeviceLocation calls this rack_unit_start
 		$rack_slots,
 		$peer_vendor,
 	);
@@ -102,9 +102,9 @@ sub validate {
 }
 
 sub _calculate_switch_peer_ports {
-	my ( $self, $rack_unit, $rack_slots, $peer_vendor ) = @_;
+	my ( $self, $rack_unit_start, $rack_slots, $peer_vendor ) = @_;
 
-	my $rack_index = first { $rack_slots->[$_] == $rack_unit } 0 .. $rack_slots->$#*;
+	my $rack_index = first { $rack_slots->[$_] == $rack_unit_start } 0 .. $rack_slots->$#*;
 
 	defined $rack_index
 		or $self->die('Device assigned to rack unit not in rack layout');

--- a/sql/migrations/0049-rack-unit-size-position.sql
+++ b/sql/migrations/0049-rack-unit-size-position.sql
@@ -1,0 +1,22 @@
+SELECT run_migration(49, $$
+
+    alter table datacenter_rack_layout rename column ru_start to rack_unit_start;
+    alter table datacenter_rack_layout
+        rename constraint datacenter_rack_layout_rack_id_ru_start_key
+        to datacenter_rack_layout_rack_id_rack_unit_start_key;
+    alter table datacenter_rack_layout
+        drop constraint if exists datacenter_rack_layout_rack_id_ru_start_key1;
+
+    alter table device_location rename column rack_unit to rack_unit_start;
+    alter table device_location
+        rename constraint device_location_rack_id_rack_unit_key
+        to device_location_rack_id_rack_unit_start_key;
+
+
+    -- this gets us the 'device_location' relationship on Conch::DB::Result::DatacenterRackLayout
+    alter table device_location
+        add constraint datacenter_rack_layout_rack_id_rack_unit_start_key
+        foreign key (rack_id, rack_unit_start)
+        references public.datacenter_rack_layout(rack_id, rack_unit_start);
+
+$$);

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -171,7 +171,7 @@ CREATE TABLE public.datacenter_rack_layout (
     id uuid DEFAULT public.gen_random_uuid() NOT NULL,
     rack_id uuid NOT NULL,
     hardware_product_id uuid NOT NULL,
-    ru_start integer NOT NULL,
+    rack_unit_start integer NOT NULL,
     created timestamp with time zone DEFAULT now() NOT NULL,
     updated timestamp with time zone DEFAULT now() NOT NULL
 );
@@ -292,7 +292,7 @@ ALTER TABLE public.device_environment OWNER TO conch;
 CREATE TABLE public.device_location (
     device_id text NOT NULL,
     rack_id uuid NOT NULL,
-    rack_unit integer NOT NULL,
+    rack_unit_start integer NOT NULL,
     created timestamp with time zone DEFAULT now() NOT NULL,
     updated timestamp with time zone DEFAULT now() NOT NULL
 );
@@ -878,19 +878,11 @@ ALTER TABLE ONLY public.datacenter_rack_layout
 
 
 --
--- Name: datacenter_rack_layout datacenter_rack_layout_rack_id_ru_start_key; Type: CONSTRAINT; Schema: public; Owner: conch
+-- Name: datacenter_rack_layout datacenter_rack_layout_rack_id_rack_unit_start_key; Type: CONSTRAINT; Schema: public; Owner: conch
 --
 
 ALTER TABLE ONLY public.datacenter_rack_layout
-    ADD CONSTRAINT datacenter_rack_layout_rack_id_ru_start_key UNIQUE (rack_id, ru_start);
-
-
---
--- Name: datacenter_rack_layout datacenter_rack_layout_rack_id_ru_start_key1; Type: CONSTRAINT; Schema: public; Owner: conch
---
-
-ALTER TABLE ONLY public.datacenter_rack_layout
-    ADD CONSTRAINT datacenter_rack_layout_rack_id_ru_start_key1 UNIQUE (rack_id, ru_start);
+    ADD CONSTRAINT datacenter_rack_layout_rack_id_rack_unit_start_key UNIQUE (rack_id, rack_unit_start);
 
 
 --
@@ -966,11 +958,11 @@ ALTER TABLE ONLY public.device_location
 
 
 --
--- Name: device_location device_location_rack_id_rack_unit_key; Type: CONSTRAINT; Schema: public; Owner: conch
+-- Name: device_location device_location_rack_id_rack_unit_start_key; Type: CONSTRAINT; Schema: public; Owner: conch
 --
 
 ALTER TABLE ONLY public.device_location
-    ADD CONSTRAINT device_location_rack_id_rack_unit_key UNIQUE (rack_id, rack_unit);
+    ADD CONSTRAINT device_location_rack_id_rack_unit_start_key UNIQUE (rack_id, rack_unit_start);
 
 
 --
@@ -1406,6 +1398,14 @@ ALTER TABLE ONLY public.datacenter_rack_layout
 
 ALTER TABLE ONLY public.datacenter_rack_layout
     ADD CONSTRAINT datacenter_rack_layout_rack_id_fkey FOREIGN KEY (rack_id) REFERENCES public.datacenter_rack(id);
+
+
+--
+-- Name: device_location datacenter_rack_layout_rack_id_rack_unit_start_key; Type: FK CONSTRAINT; Schema: public; Owner: conch
+--
+
+ALTER TABLE ONLY public.device_location
+    ADD CONSTRAINT datacenter_rack_layout_rack_id_rack_unit_start_key FOREIGN KEY (rack_id, rack_unit_start) REFERENCES public.datacenter_rack_layout(rack_id, rack_unit_start);
 
 
 --

--- a/sql/test/03-test-datacenter.sql
+++ b/sql/test/03-test-datacenter.sql
@@ -13,21 +13,21 @@ INSERT INTO datacenter_rack (datacenter_room_id, name, datacenter_rack_role_id)
         ( SELECT id FROM datacenter_rack_role WHERE name =  'TEST_RACK_ROLE' )
     );
 
-INSERT INTO datacenter_rack_layout (rack_id, hardware_product_id, ru_start)
+INSERT INTO datacenter_rack_layout (rack_id, hardware_product_id, rack_unit_start)
     VALUES (
         ( SELECT id FROM datacenter_rack WHERE name = 'Test Rack' ),
         ( SELECT id FROM hardware_product WHERE name = '2-ssds-1-cpu'),
         1
     );
 
-INSERT INTO datacenter_rack_layout (rack_id, hardware_product_id, ru_start)
+INSERT INTO datacenter_rack_layout (rack_id, hardware_product_id, rack_unit_start)
     VALUES (
         ( SELECT id FROM datacenter_rack WHERE name = 'Test Rack' ),
         ( SELECT id FROM hardware_product WHERE name = '2-ssds-1-cpu'),
         3
     );
 
-INSERT INTO datacenter_rack_layout (rack_id, hardware_product_id, ru_start)
+INSERT INTO datacenter_rack_layout (rack_id, hardware_product_id, rack_unit_start)
     VALUES (
         ( SELECT id FROM datacenter_rack WHERE name = 'Test Rack' ),
         ( SELECT id FROM hardware_product WHERE name = '65-ssds-2-cpu'),

--- a/t/integration/04_test_datacenter_loaded.t
+++ b/t/integration/04_test_datacenter_loaded.t
@@ -150,6 +150,13 @@ subtest 'Assign device to a location' => sub {
 
 	$t->get_ok('/device/TEST/location')->status_is(200);
 
+	$t->get_ok("/workspace/$id/rack/$rack_id")
+		->status_is(200)
+		->json_schema_is('WorkspaceRack')
+		->json_is(
+			'/slots/0/rack_unit_start', 1,
+			'/slots/0/occupant/id', 'TEST',
+		);
 };
 
 subtest 'Single device' => sub {


### PR DESCRIPTION
renames some db columns for clarity, and changes the formatting of the `GET /workspace/:workspace_id/rack/:rack_id` endpoint.

@perigrin this mostly impacts you, so I don't want to merge this until you've signed off on it.