### PR TITLE
speed up device_settings queries

### DIFF
--- a/lib/Conch/Controller/DeviceReport.pm
+++ b/lib/Conch/Controller/DeviceReport.pm
@@ -344,14 +344,16 @@ sub _record_device_configuration {
 sub _add_reboot_count {
 	my $device = shift;
 
-	my $reboot_count = $device->device_settings->find_or_new({
+	my $reboot_count = $device->find_or_new_related('device_settings', {
+		deactivated => undef,
 		name => 'reboot_count'
 	});
-	$reboot_count->updated( \'NOW()' );
 
 	if ( $reboot_count->in_storage ) {
-		$reboot_count->value( 1 + $reboot_count->value );
-		$reboot_count->update;
+		$reboot_count->update({
+			value => 1 + $reboot_count->value,
+			updated => \'NOW()',
+		});
 	}
 	else {
 		$reboot_count->value(0);

--- a/sql/migrations/0052-device_settings-index.sql
+++ b/sql/migrations/0052-device_settings-index.sql
@@ -1,0 +1,5 @@
+SELECT run_migration(52, $$
+
+    create index device_settings_device_id_idx on device_settings (device_id);
+
+$$);

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1218,6 +1218,13 @@ CREATE INDEX device_report_device_id_created_idx ON public.device_report USING b
 
 
 --
+-- Name: device_settings_device_id_idx; Type: INDEX; Schema: public; Owner: conch
+--
+
+CREATE INDEX device_settings_device_id_idx ON public.device_settings USING btree (device_id);
+
+
+--
 -- Name: device_settings_device_id_name_idx; Type: INDEX; Schema: public; Owner: conch
 --
 


### PR DESCRIPTION
- add index on device_id
- search using existing name+(deactivated is null) index
- abort earlier when there are no changes to a single setting

closes #433.