### PR TITLE
port conch-stats endpoints to conch

### DIFF
--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -1446,4 +1446,74 @@ definitions:
     type: array
     items:
       $ref: /definitions/HardwareVendor
+  DeviceTotals:
+    type: object
+    additionalProperties: false
+    required:
+      - all
+      - compute
+      - servers
+      - storage
+      - switches
+    patternProperties:
+      .:
+        type: array
+        items:
+          type: object
+          additionalProperties: false
+          required:
+            - alias
+            - health
+            - count
+          properties:
+            alias:
+              type: string
+            health:
+              type: string
+              enum:
+                - PASS
+                - FAIL
+                - UNKNOWN
+                - ERROR
+            count:
+              type: integer
+  DeviceTotalsCirconus:
+    type: object
+    properties:
+      storage:
+        type: object
+        additionalProperties: false
+        required:
+          - count
+        properties:
+          count:
+            type: integer
+      compute:
+        type: object
+        additionalProperties: false
+        required:
+          - count
+        properties:
+          count:
+            type: integer
+    additionalProperties:  # additional keys will be hardware product aliases
+      type: object
+      additionalProperties: false
+      required:
+        - health
+        - count
+      properties:
+        health:
+          type: object
+          additionalProperties: false
+          required:
+            - PASS
+            - FAIL
+            - UNKNOWN
+          patternProperties:
+            ^(PASS|FAIL|UNKNOWN|ERROR)$:
+              type: integer
+        count:
+          type: integer
+
 # vim: set sts=2 sw=2 et :

--- a/lib/Conch/DB/Result.pm
+++ b/lib/Conch/DB/Result.pm
@@ -1,0 +1,36 @@
+package Conch::DB::Result;
+use v5.26;
+use warnings;
+use parent 'DBIx::Class::Core';
+
+=head1 NAME
+
+Conch::DB::Result
+
+=head1 DESCRIPTION
+
+Base class for our result classes, to allow us to add on additional functionality from what is
+available in core DBIx::Class.
+
+=cut
+
+__PACKAGE__->load_components(
+    '+Conch::DB::InflateColumn::Time',  # inflates 'timestamp with time zone' columns to Conch::Time
+    '+Conch::DB::ToJSON',               # provides serialization hooks
+);
+
+1;
+__END__
+
+=pod
+
+=head1 LICENSING
+
+Copyright Joyent, Inc.
+
+This Source Code Form is subject to the terms of the Mozilla Public License,
+v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+one at http://mozilla.org/MPL/2.0/.
+
+=cut
+# vim: set ts=4 sts=4 sw=4 et :

--- a/lib/Conch/DB/Result.pm
+++ b/lib/Conch/DB/Result.pm
@@ -17,6 +17,7 @@ available in core DBIx::Class.
 __PACKAGE__->load_components(
     '+Conch::DB::InflateColumn::Time',  # inflates 'timestamp with time zone' columns to Conch::Time
     '+Conch::DB::ToJSON',               # provides serialization hooks
+    'Helper::Row::SelfResultSet',       # provides self_rs
 );
 
 1;

--- a/lib/Conch/DB/Result/Datacenter.pm
+++ b/lib/Conch/DB/Result/Datacenter.pm
@@ -13,21 +13,12 @@ Conch::DB::Result::Datacenter
 use strict;
 use warnings;
 
-use base 'DBIx::Class::Core';
 
-=head1 COMPONENTS LOADED
-
-=over 4
-
-=item * L<Conch::DB::InflateColumn::Time>
-
-=item * L<Conch::DB::ToJSON>
-
-=back
+=head1 BASE CLASS: L<Conch::DB::Result>
 
 =cut
 
-__PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
+use base 'Conch::DB::Result';
 
 =head1 TABLE: C<datacenter>
 
@@ -142,8 +133,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-23 12:46:05
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:nDozaA7v0DmvQEu/mxrVYw
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:Sz3CAwhrEK4P1uKUeF1sOA
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/DB/Result/DatacenterRack.pm
+++ b/lib/Conch/DB/Result/DatacenterRack.pm
@@ -13,21 +13,12 @@ Conch::DB::Result::DatacenterRack
 use strict;
 use warnings;
 
-use base 'DBIx::Class::Core';
 
-=head1 COMPONENTS LOADED
-
-=over 4
-
-=item * L<Conch::DB::InflateColumn::Time>
-
-=item * L<Conch::DB::ToJSON>
-
-=back
+=head1 BASE CLASS: L<Conch::DB::Result>
 
 =cut
 
-__PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
+use base 'Conch::DB::Result';
 
 =head1 TABLE: C<datacenter_rack>
 
@@ -220,8 +211,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-31 14:35:45
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:rp54t6OBoORDtrmPo6xVRA
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:81rv/emZRzKAJ5ERaa13UA
 
 __PACKAGE__->add_columns(
     '+deactivated' => { is_serializable => 0 },

--- a/lib/Conch/DB/Result/DatacenterRackLayout.pm
+++ b/lib/Conch/DB/Result/DatacenterRackLayout.pm
@@ -13,21 +13,12 @@ Conch::DB::Result::DatacenterRackLayout
 use strict;
 use warnings;
 
-use base 'DBIx::Class::Core';
 
-=head1 COMPONENTS LOADED
-
-=over 4
-
-=item * L<Conch::DB::InflateColumn::Time>
-
-=item * L<Conch::DB::ToJSON>
-
-=back
+=head1 BASE CLASS: L<Conch::DB::Result>
 
 =cut
 
-__PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
+use base 'Conch::DB::Result';
 
 =head1 TABLE: C<datacenter_rack_layout>
 
@@ -191,8 +182,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-07 11:03:51
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:SIB+Lq+AfaSnC6SVu04/RA
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:4oddD+l7DyZbcE8VoH0iTA
 
 sub TO_JSON {
     my $self = shift;

--- a/lib/Conch/DB/Result/DatacenterRackRole.pm
+++ b/lib/Conch/DB/Result/DatacenterRackRole.pm
@@ -13,21 +13,12 @@ Conch::DB::Result::DatacenterRackRole
 use strict;
 use warnings;
 
-use base 'DBIx::Class::Core';
 
-=head1 COMPONENTS LOADED
-
-=over 4
-
-=item * L<Conch::DB::InflateColumn::Time>
-
-=item * L<Conch::DB::ToJSON>
-
-=back
+=head1 BASE CLASS: L<Conch::DB::Result>
 
 =cut
 
-__PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
+use base 'Conch::DB::Result';
 
 =head1 TABLE: C<datacenter_rack_role>
 
@@ -159,8 +150,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-15 16:36:51
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:rC+B5mcISQbPhR5KOEiWEg
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:sOI9flK9L0dRIv1JoAfx4A
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/DB/Result/DatacenterRoom.pm
+++ b/lib/Conch/DB/Result/DatacenterRoom.pm
@@ -13,21 +13,12 @@ Conch::DB::Result::DatacenterRoom
 use strict;
 use warnings;
 
-use base 'DBIx::Class::Core';
 
-=head1 COMPONENTS LOADED
-
-=over 4
-
-=item * L<Conch::DB::InflateColumn::Time>
-
-=item * L<Conch::DB::ToJSON>
-
-=back
+=head1 BASE CLASS: L<Conch::DB::Result>
 
 =cut
 
-__PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
+use base 'Conch::DB::Result';
 
 =head1 TABLE: C<datacenter_room>
 
@@ -174,8 +165,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-23 12:46:05
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:WMR+xeS8FDHZv5ZKXOj+Eg
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:VnQpwZpWW/1+atS/OY+twA
 
 sub TO_JSON {
     my $self = shift;

--- a/lib/Conch/DB/Result/Device.pm
+++ b/lib/Conch/DB/Result/Device.pm
@@ -13,21 +13,12 @@ Conch::DB::Result::Device
 use strict;
 use warnings;
 
-use base 'DBIx::Class::Core';
 
-=head1 COMPONENTS LOADED
-
-=over 4
-
-=item * L<Conch::DB::InflateColumn::Time>
-
-=item * L<Conch::DB::ToJSON>
-
-=back
+=head1 BASE CLASS: L<Conch::DB::Result>
 
 =cut
 
-__PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
+use base 'Conch::DB::Result';
 
 =head1 TABLE: C<device>
 
@@ -403,8 +394,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-11 10:48:50
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:ijn9d8WDVkKqiVdlgCLNog
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:4V3uuMhmsA47LT8AHUR7hw
 
 __PACKAGE__->add_columns(
     '+deactivated' => { is_serializable => 0 },

--- a/lib/Conch/DB/Result/DeviceDisk.pm
+++ b/lib/Conch/DB/Result/DeviceDisk.pm
@@ -13,21 +13,12 @@ Conch::DB::Result::DeviceDisk
 use strict;
 use warnings;
 
-use base 'DBIx::Class::Core';
 
-=head1 COMPONENTS LOADED
-
-=over 4
-
-=item * L<Conch::DB::InflateColumn::Time>
-
-=item * L<Conch::DB::ToJSON>
-
-=back
+=head1 BASE CLASS: L<Conch::DB::Result>
 
 =cut
 
-__PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
+use base 'Conch::DB::Result';
 
 =head1 TABLE: C<device_disk>
 
@@ -227,8 +218,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-15 16:00:18
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:oRShjuPwcoBUM3m1GeziYw
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:ITWGPAqyFE1N7TaJtekWQw
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/DB/Result/DeviceEnvironment.pm
+++ b/lib/Conch/DB/Result/DeviceEnvironment.pm
@@ -13,21 +13,12 @@ Conch::DB::Result::DeviceEnvironment
 use strict;
 use warnings;
 
-use base 'DBIx::Class::Core';
 
-=head1 COMPONENTS LOADED
-
-=over 4
-
-=item * L<Conch::DB::InflateColumn::Time>
-
-=item * L<Conch::DB::ToJSON>
-
-=back
+=head1 BASE CLASS: L<Conch::DB::Result>
 
 =cut
 
-__PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
+use base 'Conch::DB::Result';
 
 =head1 TABLE: C<device_environment>
 
@@ -150,8 +141,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-15 16:00:18
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:H5QxK/7r1p/dNtiA/W+Ieg
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:USmhWNDONJ+HOVb5opulbw
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/DB/Result/DeviceLocation.pm
+++ b/lib/Conch/DB/Result/DeviceLocation.pm
@@ -13,21 +13,12 @@ Conch::DB::Result::DeviceLocation
 use strict;
 use warnings;
 
-use base 'DBIx::Class::Core';
 
-=head1 COMPONENTS LOADED
-
-=over 4
-
-=item * L<Conch::DB::InflateColumn::Time>
-
-=item * L<Conch::DB::ToJSON>
-
-=back
+=head1 BASE CLASS: L<Conch::DB::Result>
 
 =cut
 
-__PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
+use base 'Conch::DB::Result';
 
 =head1 TABLE: C<device_location>
 
@@ -174,8 +165,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-07 11:03:51
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:LpNt7rqcrIhdvmOF3uEl8A
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:l+e5FWX4O5rbKCxIndx5EQ
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/DB/Result/DeviceLog.pm
+++ b/lib/Conch/DB/Result/DeviceLog.pm
@@ -13,21 +13,12 @@ Conch::DB::Result::DeviceLog
 use strict;
 use warnings;
 
-use base 'DBIx::Class::Core';
 
-=head1 COMPONENTS LOADED
-
-=over 4
-
-=item * L<Conch::DB::InflateColumn::Time>
-
-=item * L<Conch::DB::ToJSON>
-
-=back
+=head1 BASE CLASS: L<Conch::DB::Result>
 
 =cut
 
-__PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
+use base 'Conch::DB::Result';
 
 =head1 TABLE: C<device_log>
 
@@ -130,8 +121,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-15 16:00:18
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:8LjZ8jSCrpMDhU4A3GCBkA
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:WKpwjv60weq+v6+S1UAO9Q
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/DB/Result/DeviceMemory.pm
+++ b/lib/Conch/DB/Result/DeviceMemory.pm
@@ -13,21 +13,12 @@ Conch::DB::Result::DeviceMemory
 use strict;
 use warnings;
 
-use base 'DBIx::Class::Core';
 
-=head1 COMPONENTS LOADED
-
-=over 4
-
-=item * L<Conch::DB::InflateColumn::Time>
-
-=item * L<Conch::DB::ToJSON>
-
-=back
+=head1 BASE CLASS: L<Conch::DB::Result>
 
 =cut
 
-__PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
+use base 'Conch::DB::Result';
 
 =head1 TABLE: C<device_memory>
 
@@ -164,8 +155,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-15 16:00:18
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:RXzsEkT4aWJSthjR1G0zQw
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:CLDRBVg9meK3HhODJiGkLg
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/DB/Result/DeviceNeighbor.pm
+++ b/lib/Conch/DB/Result/DeviceNeighbor.pm
@@ -13,21 +13,12 @@ Conch::DB::Result::DeviceNeighbor
 use strict;
 use warnings;
 
-use base 'DBIx::Class::Core';
 
-=head1 COMPONENTS LOADED
-
-=over 4
-
-=item * L<Conch::DB::InflateColumn::Time>
-
-=item * L<Conch::DB::ToJSON>
-
-=back
+=head1 BASE CLASS: L<Conch::DB::Result>
 
 =cut
 
-__PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
+use base 'Conch::DB::Result';
 
 =head1 TABLE: C<device_neighbor>
 
@@ -150,8 +141,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-23 14:03:46
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:iUlmXpxPIKB6gjKVJYSvGQ
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:4JMwkqCy+XV/fq7egG823A
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/DB/Result/DeviceNic.pm
+++ b/lib/Conch/DB/Result/DeviceNic.pm
@@ -13,21 +13,12 @@ Conch::DB::Result::DeviceNic
 use strict;
 use warnings;
 
-use base 'DBIx::Class::Core';
 
-=head1 COMPONENTS LOADED
-
-=over 4
-
-=item * L<Conch::DB::InflateColumn::Time>
-
-=item * L<Conch::DB::ToJSON>
-
-=back
+=head1 BASE CLASS: L<Conch::DB::Result>
 
 =cut
 
-__PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
+use base 'Conch::DB::Result';
 
 =head1 TABLE: C<device_nic>
 
@@ -193,8 +184,8 @@ __PACKAGE__->might_have(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-31 08:36:51
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:5c5curiRphx6kzhdwsYxwQ
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:3IUBSxX6sn0jXd5M8JyA2w
 
 __PACKAGE__->add_columns(
     '+created' => { is_serializable => 0 },

--- a/lib/Conch/DB/Result/DeviceRelayConnection.pm
+++ b/lib/Conch/DB/Result/DeviceRelayConnection.pm
@@ -13,21 +13,12 @@ Conch::DB::Result::DeviceRelayConnection
 use strict;
 use warnings;
 
-use base 'DBIx::Class::Core';
 
-=head1 COMPONENTS LOADED
-
-=over 4
-
-=item * L<Conch::DB::InflateColumn::Time>
-
-=item * L<Conch::DB::ToJSON>
-
-=back
+=head1 BASE CLASS: L<Conch::DB::Result>
 
 =cut
 
-__PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
+use base 'Conch::DB::Result';
 
 =head1 TABLE: C<device_relay_connection>
 
@@ -133,8 +124,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-15 16:00:18
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:QUhNgVRZJ6Q1HzNuIROKOw
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:Cwe7/ifRc3ZEBkcYvJfR8A
 
 __PACKAGE__->has_many(
   "user_relay_connections",

--- a/lib/Conch/DB/Result/DeviceReport.pm
+++ b/lib/Conch/DB/Result/DeviceReport.pm
@@ -13,21 +13,12 @@ Conch::DB::Result::DeviceReport
 use strict;
 use warnings;
 
-use base 'DBIx::Class::Core';
 
-=head1 COMPONENTS LOADED
-
-=over 4
-
-=item * L<Conch::DB::InflateColumn::Time>
-
-=item * L<Conch::DB::ToJSON>
-
-=back
+=head1 BASE CLASS: L<Conch::DB::Result>
 
 =cut
 
-__PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
+use base 'Conch::DB::Result';
 
 =head1 TABLE: C<device_report>
 
@@ -115,9 +106,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-05 11:42:56
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:EjnnwoQa9POKGwZgosddRw
-
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:BKyeGmASKyOXjdG8sMvCnA
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration
 1;

--- a/lib/Conch/DB/Result/DeviceSetting.pm
+++ b/lib/Conch/DB/Result/DeviceSetting.pm
@@ -13,21 +13,12 @@ Conch::DB::Result::DeviceSetting
 use strict;
 use warnings;
 
-use base 'DBIx::Class::Core';
 
-=head1 COMPONENTS LOADED
-
-=over 4
-
-=item * L<Conch::DB::InflateColumn::Time>
-
-=item * L<Conch::DB::ToJSON>
-
-=back
+=head1 BASE CLASS: L<Conch::DB::Result>
 
 =cut
 
-__PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
+use base 'Conch::DB::Result';
 
 =head1 TABLE: C<device_settings>
 
@@ -143,8 +134,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-15 16:00:18
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:ZHNDjoTOcxMKkAbruby7Ew
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:oIqHRhi1AxLO+g4r7lJxRg
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/DB/Result/DeviceSpec.pm
+++ b/lib/Conch/DB/Result/DeviceSpec.pm
@@ -13,21 +13,12 @@ Conch::DB::Result::DeviceSpec
 use strict;
 use warnings;
 
-use base 'DBIx::Class::Core';
 
-=head1 COMPONENTS LOADED
-
-=over 4
-
-=item * L<Conch::DB::InflateColumn::Time>
-
-=item * L<Conch::DB::ToJSON>
-
-=back
+=head1 BASE CLASS: L<Conch::DB::Result>
 
 =cut
 
-__PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
+use base 'Conch::DB::Result';
 
 =head1 TABLE: C<device_spec>
 
@@ -153,8 +144,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-22 17:58:22
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:oxznkSR0H2zemYTYFYvg9w
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:rqbEbPjxEubPHX8XjtXPdA
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/DB/Result/HardwareProduct.pm
+++ b/lib/Conch/DB/Result/HardwareProduct.pm
@@ -13,21 +13,12 @@ Conch::DB::Result::HardwareProduct
 use strict;
 use warnings;
 
-use base 'DBIx::Class::Core';
 
-=head1 COMPONENTS LOADED
-
-=over 4
-
-=item * L<Conch::DB::InflateColumn::Time>
-
-=item * L<Conch::DB::ToJSON>
-
-=back
+=head1 BASE CLASS: L<Conch::DB::Result>
 
 =cut
 
-__PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
+use base 'Conch::DB::Result';
 
 =head1 TABLE: C<hardware_product>
 
@@ -265,8 +256,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-11 10:48:50
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:5qBRhcqOj3Wo9blYxaYA3g
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:WE00FsIieOu8a63Gx+SgUQ
 
 use Class::Method::Modifiers;
 

--- a/lib/Conch/DB/Result/HardwareProductProfile.pm
+++ b/lib/Conch/DB/Result/HardwareProductProfile.pm
@@ -13,21 +13,12 @@ Conch::DB::Result::HardwareProductProfile
 use strict;
 use warnings;
 
-use base 'DBIx::Class::Core';
 
-=head1 COMPONENTS LOADED
-
-=over 4
-
-=item * L<Conch::DB::InflateColumn::Time>
-
-=item * L<Conch::DB::ToJSON>
-
-=back
+=head1 BASE CLASS: L<Conch::DB::Result>
 
 =cut
 
-__PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
+use base 'Conch::DB::Result';
 
 =head1 TABLE: C<hardware_product_profile>
 
@@ -346,8 +337,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-05 11:42:57
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:aL2Ytxfg8GWzDm/BGaRhaw
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:JBNrQzItI96VKDeO0wUm3A
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/DB/Result/HardwareProfileSetting.pm
+++ b/lib/Conch/DB/Result/HardwareProfileSetting.pm
@@ -13,21 +13,12 @@ Conch::DB::Result::HardwareProfileSetting
 use strict;
 use warnings;
 
-use base 'DBIx::Class::Core';
 
-=head1 COMPONENTS LOADED
-
-=over 4
-
-=item * L<Conch::DB::InflateColumn::Time>
-
-=item * L<Conch::DB::ToJSON>
-
-=back
+=head1 BASE CLASS: L<Conch::DB::Result>
 
 =cut
 
-__PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
+use base 'Conch::DB::Result';
 
 =head1 TABLE: C<hardware_profile_setting>
 
@@ -151,8 +142,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-23 13:52:47
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:0Q3VBDR1HzZE9FHUXUXwHw
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:KvHWDkAyL/ECyYpL1eOTZw
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/DB/Result/HardwareVendor.pm
+++ b/lib/Conch/DB/Result/HardwareVendor.pm
@@ -13,21 +13,12 @@ Conch::DB::Result::HardwareVendor
 use strict;
 use warnings;
 
-use base 'DBIx::Class::Core';
 
-=head1 COMPONENTS LOADED
-
-=over 4
-
-=item * L<Conch::DB::InflateColumn::Time>
-
-=item * L<Conch::DB::ToJSON>
-
-=back
+=head1 BASE CLASS: L<Conch::DB::Result>
 
 =cut
 
-__PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
+use base 'Conch::DB::Result';
 
 =head1 TABLE: C<hardware_vendor>
 
@@ -128,8 +119,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-06 12:39:57
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:0lFsTVCHhSuzj3ZdPyUL6w
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:gmW4bZ0/3phr8u3IIMdryQ
 
 __PACKAGE__->add_columns(
     '+deactivated' => { is_serializable => 0 },

--- a/lib/Conch/DB/Result/Migration.pm
+++ b/lib/Conch/DB/Result/Migration.pm
@@ -13,21 +13,12 @@ Conch::DB::Result::Migration
 use strict;
 use warnings;
 
-use base 'DBIx::Class::Core';
 
-=head1 COMPONENTS LOADED
-
-=over 4
-
-=item * L<Conch::DB::InflateColumn::Time>
-
-=item * L<Conch::DB::ToJSON>
-
-=back
+=head1 BASE CLASS: L<Conch::DB::Result>
 
 =cut
 
-__PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
+use base 'Conch::DB::Result';
 
 =head1 TABLE: C<migration>
 
@@ -83,8 +74,8 @@ __PACKAGE__->add_columns(
 __PACKAGE__->set_primary_key("id");
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-15 16:00:18
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:nDPIyVMBfEW7v/Hjw4xTcw
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:hyl49PiJbIKla/K14uYZTQ
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/DB/Result/Relay.pm
+++ b/lib/Conch/DB/Result/Relay.pm
@@ -13,21 +13,12 @@ Conch::DB::Result::Relay
 use strict;
 use warnings;
 
-use base 'DBIx::Class::Core';
 
-=head1 COMPONENTS LOADED
-
-=over 4
-
-=item * L<Conch::DB::InflateColumn::Time>
-
-=item * L<Conch::DB::ToJSON>
-
-=back
+=head1 BASE CLASS: L<Conch::DB::Result>
 
 =cut
 
-__PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
+use base 'Conch::DB::Result';
 
 =head1 TABLE: C<relay>
 
@@ -157,8 +148,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-15 16:00:18
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:pKmEjRpL4UAvg2hdWIpQew
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:OI7LN23DmloIV1FBrPHuJQ
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/DB/Result/UserAccount.pm
+++ b/lib/Conch/DB/Result/UserAccount.pm
@@ -13,21 +13,12 @@ Conch::DB::Result::UserAccount
 use strict;
 use warnings;
 
-use base 'DBIx::Class::Core';
 
-=head1 COMPONENTS LOADED
-
-=over 4
-
-=item * L<Conch::DB::InflateColumn::Time>
-
-=item * L<Conch::DB::ToJSON>
-
-=back
+=head1 BASE CLASS: L<Conch::DB::Result>
 
 =cut
 
-__PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
+use base 'Conch::DB::Result';
 
 =head1 TABLE: C<user_account>
 
@@ -196,8 +187,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-30 10:52:38
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:1vfzM3wgxggRB2gZ0JsIQg
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:Jm+NeLdAhkNdgJi7WGbk0Q
 
 __PACKAGE__->add_columns(
     '+password_hash' => { is_serializable => 0 },

--- a/lib/Conch/DB/Result/UserRelayConnection.pm
+++ b/lib/Conch/DB/Result/UserRelayConnection.pm
@@ -13,21 +13,12 @@ Conch::DB::Result::UserRelayConnection
 use strict;
 use warnings;
 
-use base 'DBIx::Class::Core';
 
-=head1 COMPONENTS LOADED
-
-=over 4
-
-=item * L<Conch::DB::InflateColumn::Time>
-
-=item * L<Conch::DB::ToJSON>
-
-=back
+=head1 BASE CLASS: L<Conch::DB::Result>
 
 =cut
 
-__PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
+use base 'Conch::DB::Result';
 
 =head1 TABLE: C<user_relay_connection>
 
@@ -134,8 +125,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-15 16:00:18
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:4qDobImznzLPv9gJEe0GDw
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:drSdhmwO7nywsYdhBX0U/Q
 
 1;
 __END__

--- a/lib/Conch/DB/Result/UserSessionToken.pm
+++ b/lib/Conch/DB/Result/UserSessionToken.pm
@@ -13,21 +13,12 @@ Conch::DB::Result::UserSessionToken
 use strict;
 use warnings;
 
-use base 'DBIx::Class::Core';
 
-=head1 COMPONENTS LOADED
-
-=over 4
-
-=item * L<Conch::DB::InflateColumn::Time>
-
-=item * L<Conch::DB::ToJSON>
-
-=back
+=head1 BASE CLASS: L<Conch::DB::Result>
 
 =cut
 
-__PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
+use base 'Conch::DB::Result';
 
 =head1 TABLE: C<user_session_token>
 
@@ -97,8 +88,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-15 16:00:18
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:XI6FDRwWEpZ560jcBlEAIQ
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:3duPGO9UY9pz/5QRI2IGiQ
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/DB/Result/UserSetting.pm
+++ b/lib/Conch/DB/Result/UserSetting.pm
@@ -13,21 +13,12 @@ Conch::DB::Result::UserSetting
 use strict;
 use warnings;
 
-use base 'DBIx::Class::Core';
 
-=head1 COMPONENTS LOADED
-
-=over 4
-
-=item * L<Conch::DB::InflateColumn::Time>
-
-=item * L<Conch::DB::ToJSON>
-
-=back
+=head1 BASE CLASS: L<Conch::DB::Result>
 
 =cut
 
-__PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
+use base 'Conch::DB::Result';
 
 =head1 TABLE: C<user_settings>
 
@@ -130,8 +121,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-15 16:00:18
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:hkTTe+USSZ8cfuxmhrjsug
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:ZtmRL/vAb58KypeokO46+A
 
 1;
 __END__

--- a/lib/Conch/DB/Result/UserWorkspaceRole.pm
+++ b/lib/Conch/DB/Result/UserWorkspaceRole.pm
@@ -13,21 +13,12 @@ Conch::DB::Result::UserWorkspaceRole
 use strict;
 use warnings;
 
-use base 'DBIx::Class::Core';
 
-=head1 COMPONENTS LOADED
-
-=over 4
-
-=item * L<Conch::DB::InflateColumn::Time>
-
-=item * L<Conch::DB::ToJSON>
-
-=back
+=head1 BASE CLASS: L<Conch::DB::Result>
 
 =cut
 
-__PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
+use base 'Conch::DB::Result';
 
 =head1 TABLE: C<user_workspace_role>
 
@@ -129,8 +120,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-15 16:00:18
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:ZpvirPKnyjKsMiUay+5z+g
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:p9qNxtAg/+xQTSSB9KCHTA
 
 1;
 __END__

--- a/lib/Conch/DB/Result/Validation.pm
+++ b/lib/Conch/DB/Result/Validation.pm
@@ -13,21 +13,12 @@ Conch::DB::Result::Validation
 use strict;
 use warnings;
 
-use base 'DBIx::Class::Core';
 
-=head1 COMPONENTS LOADED
-
-=over 4
-
-=item * L<Conch::DB::InflateColumn::Time>
-
-=item * L<Conch::DB::ToJSON>
-
-=back
+=head1 BASE CLASS: L<Conch::DB::Result>
 
 =cut
 
-__PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
+use base 'Conch::DB::Result';
 
 =head1 TABLE: C<validation>
 
@@ -194,8 +185,8 @@ __PACKAGE__->many_to_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-15 16:00:18
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:winvvGplspOdGGhsCWPLnw
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:Xi5ASzt2zuwUhj0wjj3a8A
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/DB/Result/ValidationPlan.pm
+++ b/lib/Conch/DB/Result/ValidationPlan.pm
@@ -13,21 +13,12 @@ Conch::DB::Result::ValidationPlan
 use strict;
 use warnings;
 
-use base 'DBIx::Class::Core';
 
-=head1 COMPONENTS LOADED
-
-=over 4
-
-=item * L<Conch::DB::InflateColumn::Time>
-
-=item * L<Conch::DB::ToJSON>
-
-=back
+=head1 BASE CLASS: L<Conch::DB::Result>
 
 =cut
 
-__PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
+use base 'Conch::DB::Result';
 
 =head1 TABLE: C<validation_plan>
 
@@ -146,8 +137,8 @@ Composing rels: L</validation_plan_members> -> validation
 __PACKAGE__->many_to_many("validations", "validation_plan_members", "validation");
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-15 16:00:18
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:ut6zhrENx4hc7ZKoEx1Y7Q
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:DJEB3Pqtab0ycOFOSnyg5A
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/DB/Result/ValidationPlanMember.pm
+++ b/lib/Conch/DB/Result/ValidationPlanMember.pm
@@ -13,21 +13,12 @@ Conch::DB::Result::ValidationPlanMember
 use strict;
 use warnings;
 
-use base 'DBIx::Class::Core';
 
-=head1 COMPONENTS LOADED
-
-=over 4
-
-=item * L<Conch::DB::InflateColumn::Time>
-
-=item * L<Conch::DB::ToJSON>
-
-=back
+=head1 BASE CLASS: L<Conch::DB::Result>
 
 =cut
 
-__PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
+use base 'Conch::DB::Result';
 
 =head1 TABLE: C<validation_plan_member>
 
@@ -107,8 +98,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-15 16:00:18
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:5mAUvorzjj7oCbraiXJRAA
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:dZeoHWywkUv1QfTQ+HWxqA
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/DB/Result/ValidationResult.pm
+++ b/lib/Conch/DB/Result/ValidationResult.pm
@@ -13,21 +13,12 @@ Conch::DB::Result::ValidationResult
 use strict;
 use warnings;
 
-use base 'DBIx::Class::Core';
 
-=head1 COMPONENTS LOADED
-
-=over 4
-
-=item * L<Conch::DB::InflateColumn::Time>
-
-=item * L<Conch::DB::ToJSON>
-
-=back
+=head1 BASE CLASS: L<Conch::DB::Result>
 
 =cut
 
-__PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
+use base 'Conch::DB::Result';
 
 =head1 TABLE: C<validation_result>
 
@@ -235,8 +226,8 @@ __PACKAGE__->many_to_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-15 16:00:18
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:aoxtvnNZ/7ObRSZ7ZHD8Dg
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:9AqtWUD7GrQfppyKgyIcXw
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/DB/Result/ValidationState.pm
+++ b/lib/Conch/DB/Result/ValidationState.pm
@@ -13,21 +13,12 @@ Conch::DB::Result::ValidationState
 use strict;
 use warnings;
 
-use base 'DBIx::Class::Core';
 
-=head1 COMPONENTS LOADED
-
-=over 4
-
-=item * L<Conch::DB::InflateColumn::Time>
-
-=item * L<Conch::DB::ToJSON>
-
-=back
+=head1 BASE CLASS: L<Conch::DB::Result>
 
 =cut
 
-__PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
+use base 'Conch::DB::Result';
 
 =head1 TABLE: C<validation_state>
 
@@ -185,8 +176,8 @@ __PACKAGE__->many_to_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-15 16:00:18
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:qiLA2OdB5EDN8jbNjL7r4A
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:20uQOHmwWHrYgjGvOZWeaQ
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/DB/Result/ValidationStateMember.pm
+++ b/lib/Conch/DB/Result/ValidationStateMember.pm
@@ -13,21 +13,12 @@ Conch::DB::Result::ValidationStateMember
 use strict;
 use warnings;
 
-use base 'DBIx::Class::Core';
 
-=head1 COMPONENTS LOADED
-
-=over 4
-
-=item * L<Conch::DB::InflateColumn::Time>
-
-=item * L<Conch::DB::ToJSON>
-
-=back
+=head1 BASE CLASS: L<Conch::DB::Result>
 
 =cut
 
-__PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
+use base 'Conch::DB::Result';
 
 =head1 TABLE: C<validation_state_member>
 
@@ -107,8 +98,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-15 16:00:18
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:LcOWdF2Rjp6XiSn1sin2Vg
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:3aEz5aEgtuv96u7AJIl+Lg
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/DB/Result/Workspace.pm
+++ b/lib/Conch/DB/Result/Workspace.pm
@@ -13,21 +13,12 @@ Conch::DB::Result::Workspace
 use strict;
 use warnings;
 
-use base 'DBIx::Class::Core';
 
-=head1 COMPONENTS LOADED
-
-=over 4
-
-=item * L<Conch::DB::InflateColumn::Time>
-
-=item * L<Conch::DB::ToJSON>
-
-=back
+=head1 BASE CLASS: L<Conch::DB::Result>
 
 =cut
 
-__PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
+use base 'Conch::DB::Result';
 
 =head1 TABLE: C<workspace>
 
@@ -188,8 +179,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-15 16:00:18
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:96B5UxM9jw3vthI9lzh0ag
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:EanLDWK51qjrTjllNz0tYQ
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/DB/Result/WorkspaceDatacenterRack.pm
+++ b/lib/Conch/DB/Result/WorkspaceDatacenterRack.pm
@@ -13,21 +13,12 @@ Conch::DB::Result::WorkspaceDatacenterRack
 use strict;
 use warnings;
 
-use base 'DBIx::Class::Core';
 
-=head1 COMPONENTS LOADED
-
-=over 4
-
-=item * L<Conch::DB::InflateColumn::Time>
-
-=item * L<Conch::DB::ToJSON>
-
-=back
+=head1 BASE CLASS: L<Conch::DB::Result>
 
 =cut
 
-__PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
+use base 'Conch::DB::Result';
 
 =head1 TABLE: C<workspace_datacenter_rack>
 
@@ -112,8 +103,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-10 12:42:41
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:bZG71yYzm5yyrLIQeehNgA
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:H3iBzFcjRcpUxquRQlFxaw
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/DB/Result/WorkspaceDatacenterRoom.pm
+++ b/lib/Conch/DB/Result/WorkspaceDatacenterRoom.pm
@@ -13,21 +13,12 @@ Conch::DB::Result::WorkspaceDatacenterRoom
 use strict;
 use warnings;
 
-use base 'DBIx::Class::Core';
 
-=head1 COMPONENTS LOADED
-
-=over 4
-
-=item * L<Conch::DB::InflateColumn::Time>
-
-=item * L<Conch::DB::ToJSON>
-
-=back
+=head1 BASE CLASS: L<Conch::DB::Result>
 
 =cut
 
-__PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
+use base 'Conch::DB::Result';
 
 =head1 TABLE: C<workspace_datacenter_room>
 
@@ -112,8 +103,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-10 12:42:41
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:r649ScOmXCpeg5x+5L3+Ig
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:20qZ1+OVPZLtowFrqmHh2g
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/DB/Result/ZpoolProfile.pm
+++ b/lib/Conch/DB/Result/ZpoolProfile.pm
@@ -13,21 +13,12 @@ Conch::DB::Result::ZpoolProfile
 use strict;
 use warnings;
 
-use base 'DBIx::Class::Core';
 
-=head1 COMPONENTS LOADED
-
-=over 4
-
-=item * L<Conch::DB::InflateColumn::Time>
-
-=item * L<Conch::DB::ToJSON>
-
-=back
+=head1 BASE CLASS: L<Conch::DB::Result>
 
 =cut
 
-__PACKAGE__->load_components("+Conch::DB::InflateColumn::Time", "+Conch::DB::ToJSON");
+use base 'Conch::DB::Result';
 
 =head1 TABLE: C<zpool_profile>
 
@@ -170,8 +161,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-15 16:00:18
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:Au8qF34EAWTg8fNyK2HOig
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:MQ5Kj52FgdJnrAYfHXirIw
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/Route.pm
+++ b/lib/Conch/Route.pm
@@ -77,6 +77,9 @@ sub all_routes {
 	$root->post('/logout')->to('login#session_logout');
 	$root->post('/reset_password')->to('login#reset_password');
 
+	# GET /workspace/:workspace/device-totals
+	$root->get('/workspace/:workspace/device-totals')->to('workspace_device#device_totals');
+
 	# all routes after this point require authentication
 
 	my $secured = $root->under('/')->to('login#authenticate');

--- a/schema-loader.yaml
+++ b/schema-loader.yaml
@@ -13,11 +13,13 @@ loader_options:
 
   default_resultset_class: +Conch::DB::ResultSet
 
-  components:
-    - +Conch::DB::InflateColumn::Time
-    - +Conch::DB::ToJSON
+  result_base_class: Conch::DB::Result
 
   rel_name_map:
     user: user_account
     DeviceNeighbor:
       mac: device_nic
+
+  # this is usually more useful than not, but take care that you don't blow away any changes
+  # not yet in git!
+  overwrite_modifications: 1

--- a/t/integration/crud/unsecured-endpoints.t
+++ b/t/integration/crud/unsecured-endpoints.t
@@ -1,0 +1,107 @@
+use v5.26;
+use warnings;
+
+use Test::More;
+use Test::Warnings;
+use Test::Conch::Datacenter;
+
+my $t = Test::Conch::Datacenter->new();
+
+$t->get_ok("/ping")->status_is(200)->json_is( '/status' => 'ok' );
+$t->get_ok("/version")->status_is(200);
+
+
+subtest 'device totals' => sub {
+
+    # TODO: DBIx::Class::EasyFixture can make this nicer across lots of tests.
+
+    my $global_ws_id = $t->app->db_workspaces->search({ name => 'GLOBAL' })->get_column('id')->single;
+    my $farce = $t->app->db_hardware_products->hri->find({ alias => 'Farce 10' });
+    my $test_compute = $t->app->db_hardware_products->hri->find({ alias => 'Test Compute' });
+
+    # find a rack
+    my $datacenter_rack = $t->app->db_datacenter_racks->search({}, { rows => 1 })->single;
+
+    # add the rack to the global workspace
+    $datacenter_rack->create_related('workspace_datacenter_racks' => { workspace_id => $global_ws_id });
+
+    # create/update some rack layouts
+    $datacenter_rack->update_or_create_related('datacenter_rack_layouts', $_) foreach (
+        {
+            hardware_product_id => $farce->{id},
+            rack_unit_start => 1,
+        },
+        {
+            hardware_product_id => $test_compute->{id},
+            rack_unit_start => 5,
+        },
+    );
+
+    # create a few devices and locate them in this rack
+    $t->app->db_devices->create($_) foreach (
+        {
+            id => 'test farce',
+            hardware_product_id => $farce->{id},
+            state => 'ignore',
+            health => 'FAIL',
+            device_location => { rack_id => $datacenter_rack->id, rack_unit_start => 1 },
+        },
+        {
+            id => 'test compute',
+            hardware_product_id => $test_compute->{id},
+            state => 'ignore',
+            health => 'PASS',
+            device_location => { rack_id => $datacenter_rack->id, rack_unit_start => 5 },
+        },
+    );
+
+    # doctor the configs so they match the hw products we already have in the test data.
+    $t->app->stash('config')->%* = (
+        $t->app->stash('config')->%*,
+        switch_aliases => [ 'Farce 10' ],
+        server_aliases => [],
+        storage_aliases => [ 'Test Storage' ],
+        compute_aliases => [ 'Test Compute' ],
+    );
+
+    $t->get_ok("/workspace/123/device-totals")
+        ->status_is(404);
+
+    $t->get_ok("/workspace/$global_ws_id/device-totals")
+        ->status_is(200)
+        ->json_schema_is('DeviceTotals')
+        ->json_is({
+            all => [
+                { alias => 'Farce 10', count => 1, health => 'FAIL' },
+                { alias => 'Test Compute', count => 1, health => 'PASS' }
+            ],
+            switches => [
+                { alias => 'Farce 10', count => 1, health => 'FAIL' },
+            ],
+            servers => [
+                { alias => 'Test Compute', count => 1, health => 'PASS' }
+            ],
+            storage => [],
+            compute => [
+                { alias => 'Test Compute', count => 1, health => 'PASS' }
+            ],
+        });
+
+    $t->get_ok("/workspace/$global_ws_id/device-totals.circ")
+        ->status_is(200)
+        ->json_schema_is('DeviceTotalsCirconus')
+        ->json_is({
+            'Farce 10' => {
+                health => { PASS => 0, FAIL => 1, UNKNOWN => 0 },
+                count => 1,
+            },
+            'Test Compute' => {
+                health => { PASS => 1, FAIL => 0, UNKNOWN => 0 },
+                count => 1,
+            },
+            compute => { count => 1 },
+        });
+};
+
+done_testing;
+# vim: set ts=4 sts=4 sw=4 et :


### PR DESCRIPTION
closes #434.
    
The only endpoint being used presently is /workspace/:workspace/device-totals.
This change also requires a config change (see buildops-infra).
