### PR TITLE
fix json encoding of device report

### DIFF
--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -75,9 +75,8 @@ definitions:
           - type: null
       latest_report:
         anyOf:
-          - type: string
-            format: uuid
-          - type: null
+          - $ref: /definitions/DeviceReport
+          - type: 'null'
       latest_triton_reboot:
         anyOf:
           - type: string
@@ -292,7 +291,6 @@ definitions:
           - type: null
   DeviceReport:
     type: object
-    additionalProperties: false
     required:
       - product_name
       - serial_number

--- a/lib/Conch/Controller/Device.pm
+++ b/lib/Conch/Controller/Device.pm
@@ -104,14 +104,11 @@ sub get ($c) {
 
 	my $maybe_location = Conch::Model::DeviceLocation->new->lookup($device->id);
 
-	# this bit of the query is SLOW, so we don't add it to the prefetch list.
-	my $latest_report = $device->latest_report;
-
 	# TODO: we can collapse this all down to a self-contained serializer once the
 	# DeviceLocation query has been converted to a prefetchable relationship.
 	my $detailed_device = +{
 		%{ $device->TO_JSON },
-		latest_report => ($latest_report ? $latest_report->report : undef),
+		latest_report => $device->latest_report,
 		nics => [ map {
 			my $device_nic = $_;
 			$device_nic->deactivated ? () :

--- a/lib/Conch/Controller/WorkspaceProblem.pm
+++ b/lib/Conch/Controller/WorkspaceProblem.pm
@@ -82,8 +82,12 @@ sub _get_problems ($c) {
 		$failing_problems->{$device_id}{location} =
 			_device_rack_location( $schema, $device_id );
 
-		my $report = $device->latest_report;
-		$failing_problems->{$device_id}{report_id} = $report->id;
+		$failing_problems->{$device_id}{report_id} =
+			$device->related_resultset('device_reports')
+				->order_by({ -desc => 'created' })
+				->rows(1)
+				->get_column('id')
+				->single;
 	}
 
 	my $unreported_problems = {};
@@ -101,8 +105,12 @@ sub _get_problems ($c) {
 
 		$unlocated_problems->{$device_id}{health} = $device->health;
 
-		my $report = $device->latest_report;
-		$unlocated_problems->{$device_id}{report_id} = $report->id;
+		$unlocated_problems->{$device_id}{report_id} =
+			$device->related_resultset('device_reports')
+				->order_by({ -desc => 'created' })
+				->rows(1)
+				->get_column('id')
+				->single;
 	}
 
 	return {

--- a/lib/Conch/DB/Result/Device.pm
+++ b/lib/Conch/DB/Result/Device.pm
@@ -409,14 +409,25 @@ sub TO_JSON {
     return $data;
 }
 
-# be careful! this is an expensive query, so think twice before adding it to a prefetch on a
-# query for many devices.
-__PACKAGE__->might_have(
-    'latest_report',
-    'Conch::DB::Result::DeviceReport',
-    { 'foreign.device_id' => 'self.id' },
-    { order_by => { -desc => 'created' }, rows => 1 },
-);
+use Mojo::JSON 'from_json';
+
+=head2 latest_report
+
+Returns the JSON-decoded content from the most recent device report.
+
+=cut
+
+sub latest_report {
+    my $self = shift;
+
+    my $json = $self->related_resultset('device_reports')
+        ->order_by({ -desc => 'created' })
+        ->rows(1)
+        ->get_column('report')
+        ->single;
+
+    defined $json ? from_json($json) : undef;
+}
 
 1;
 __END__

--- a/lib/Conch/DB/ResultSet.pm
+++ b/lib/Conch/DB/ResultSet.pm
@@ -19,6 +19,8 @@ __PACKAGE__->load_components(
     'Helper::ResultSet::OneRow',                # provides one_row
     'Helper::ResultSet::Shortcut::HRI',         # provides hri: raw unblessed + uninflated data
     'Helper::ResultSet::Shortcut::Prefetch',    # provides prefetch
+    'Helper::ResultSet::Shortcut::OrderBy',     # provides order_by
+    'Helper::ResultSet::Shortcut::Rows',        # provides rows
 );
 
 1;

--- a/t/integration/04_test_datacenter_loaded.t
+++ b/t/integration/04_test_datacenter_loaded.t
@@ -134,7 +134,7 @@ subtest 'Device Report' => sub {
 
 	my $device = $t->app->db_devices->find($t->tx->res->json->{device_id});
 	cmp_deeply(
-		decode_json($device->latest_report->report),
+		$device->latest_report,
 		decode_json($report),
 		'json blob stored in the db matches report on disk',
 	);
@@ -170,7 +170,8 @@ subtest 'Single device' => sub {
 		->json_like( '/error', qr/not found/ );
 
 	$t->get_ok('/device/TEST')->status_is(200)
-		->json_schema_is('DetailedDevice');
+		->json_schema_is('DetailedDevice')
+		->json_is('/latest_report/product_name' => 'Joyent-S1');
 
 	my $device_id = $t->tx->res->json->{id};
 	my @macs = map { $_->{mac} } $t->tx->res->json->{nics}->@*;


### PR DESCRIPTION
- removed latest_report relationship (it is not helpful to wrap the
  query like this, as it is too slow to use in prefetches)
- fixed the buggy DetailedDevice json schema that never caught this
- added latest_report helper sub, which fetches just the report string
  itself and decodes it.
- fixed other queries on device_report to only fetch the desired id,
  skipping fetching the huge report string that it doesn't need.

closes #465.