### PR TITLE
fix broken json schemas

### DIFF
--- a/json-schema/input.yaml
+++ b/json-schema/input.yaml
@@ -348,7 +348,7 @@ definitions:
         type: string
       description:
         anyOf:
-          - type: null
+          - type: 'null'
           - type: string
   WorkspaceInvite:
     type: object

--- a/json-schema/input.yaml
+++ b/json-schema/input.yaml
@@ -1,5 +1,8 @@
 ---
 definitions:
+  uuid:
+    type: string
+    pattern: "^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"
   DatacenterCreate:
     type: object
     additionalProperties: false
@@ -21,8 +24,7 @@ definitions:
     additionalProperties: false
     properties:
       id:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       vendor:
         type: string
       region:
@@ -39,8 +41,7 @@ definitions:
       - az
     properties:
       datacenter:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       az:
         type: string
       alias:
@@ -52,8 +53,7 @@ definitions:
     additionalProperties: false
     properties:
       datacenter:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       az:
         type: string
       alias:
@@ -125,8 +125,7 @@ definitions:
       state:
         type: string
       system_uuid:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       temp:
         type: object
         required:
@@ -154,11 +153,9 @@ definitions:
       name:
         type: string
       datacenter_room_id:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       role:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
   RackUpdate:
     type: object
     additionalProperties: false
@@ -166,11 +163,9 @@ definitions:
       name:
         type: string
       datacenter_room_id:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       role:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       serial_number:
         type: string
       asset_tag:
@@ -203,11 +198,9 @@ definitions:
       - ru_start
     properties:
       rack_id:    # TODO: this really should be datacenter_rack_id
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       product_id: # TODO: this really should be hardware_product_id
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       ru_start: # TODO: this really should be rack_unit_start
         type: integer
   RackLayoutUpdate:
@@ -215,11 +208,9 @@ definitions:
     additionalProperties: false
     properties:
       rack_id:    # TODO: this really should be datacenter_rack_id
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       product_id: # TODO: this really should be hardware_product_id
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       ru_start: # TODO: this really should be rack_unit_start
         type: integer
   DBHardwareProductCreate:
@@ -237,8 +228,7 @@ definitions:
       prefix:
         type: string
       vendor:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       specification:
         type: string
       sku:
@@ -254,8 +244,7 @@ definitions:
       - id
     properties:
       id:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       name:
         type: string
       alias:
@@ -263,8 +252,7 @@ definitions:
       prefix:
         type: string
       vendor:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       specification:
         type: string
       sku:
@@ -323,8 +311,7 @@ definitions:
       - id
     properties:
       id:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
   WorkspaceAddRack:
     type: object
     additionalProperties: false
@@ -332,8 +319,7 @@ definitions:
       - id
     properties:
       id:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       serial_number:
         type: string
       asset_tag:

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -949,6 +949,41 @@ definitions:
         role_via:
           description: this is the id of the workspace where the permissions came from
           $ref: /definitions/uuid
+  DatacenterRoomsDetailed:
+    type: array
+    items:
+      $ref: /definitions/DatacenterRoomDetailed
+  DatacenterRoomDetailed:
+    type: object
+    additionalProperties: false
+    required:
+      - id
+      - az
+      - alias
+      - vendor_name
+      - datacenter
+      - created
+      - updated
+    properties:
+      id:
+        $ref: /definitions/uuid
+      az:
+        type: string
+      alias:
+        anyOf:
+          - type: string
+          - type: 'null'
+      vendor_name:
+        type: string
+      datacenter:
+        description: datacenter id
+        $ref: /definitions/uuid
+      created:
+        type: string
+        format: date-time
+      updated:
+        type: string
+        format: date-time
   Rooms:
     type: array
     items:

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -1,5 +1,8 @@
 ---
 definitions:
+  uuid:
+    type: string
+    pattern: "^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"
   Error:
     type: object
     additionalProperties: false
@@ -53,8 +56,7 @@ definitions:
         type: string
         format: date-time
       hardware_product:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       health:
         type: string
       hostname:
@@ -85,8 +87,7 @@ definitions:
       state:
         type: string
       system_uuid:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       triton_setup:
         anyOf:
           - type: string
@@ -94,8 +95,7 @@ definitions:
           - type: 'null'
       triton_uuid:
         anyOf:
-          - type: string
-            format: uuid
+          - $ref: /definitions/uuid
           - type: 'null'
       updated:
         type: string
@@ -184,8 +184,7 @@ definitions:
         type: string
         format: date-time
       hardware_product:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       health:
         type: string
       hostname:
@@ -214,12 +213,10 @@ definitions:
       system_uuid:
         anyOf:
           - type: 'null'
-          - type: string
-            format: uuid
+          - $ref: /definitions/uuid
       triton_uuid:
         anyOf:
-          - type: string
-            format: uuid
+          - $ref: /definitions/uuid
           - type: 'null'
       triton_setup:
         anyOf:
@@ -305,8 +302,7 @@ definitions:
       serial_number:
         type: string
       system_uuid:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       state:
         type: string
       bios_version:
@@ -332,8 +328,7 @@ definitions:
           - vendor_name
         properties:
           id:
-            type: string
-            format: uuid
+            $ref: /definitions/uuid
           name:
             type: string
           vendor_name:
@@ -348,8 +343,7 @@ definitions:
           - unit
         properties:
           id:
-            type: string
-            format: uuid
+            $ref: /definitions/uuid
           name:
             type: string
           role:
@@ -369,8 +363,7 @@ definitions:
           - vendor
         properties:
           id:
-            type: string
-            format: uuid
+            $ref: /definitions/uuid
             description: Hardware product ID
           name:
             type: string
@@ -401,8 +394,7 @@ definitions:
       - specification
     properties:
       id:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       name:
         type: string
       alias:
@@ -471,8 +463,7 @@ definitions:
               - type: string
               - type: 'null'
           id:
-            type: string
-            format: uuid
+            $ref: /definitions/uuid
           nics_num:
             type: integer
           psu_total:
@@ -538,8 +529,7 @@ definitions:
                   - vdev_t
                 properties:
                   id:
-                    type: string
-                    format: uuid
+                    $ref: /definitions/uuid
                   name:
                     anyOf:
                       - type: string
@@ -570,8 +560,7 @@ definitions:
           additionalProperties: false
           properties:
             id:
-              type: string
-              format: uuid
+              $ref: /definitions/uuid
             name:
               type: string
             role:
@@ -603,8 +592,7 @@ definitions:
       - slots
     properties:
       id:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       name:
         type: string
       role:
@@ -632,8 +620,7 @@ definitions:
               type: string
               description: Hardware product alias
             id:
-              type: string
-              format: uuid
+              $ref: /definitions/uuid
               description: Hardware product ID
             name:
               type: string
@@ -665,8 +652,7 @@ definitions:
       - updated
     properties:
       id:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       name:
         type: string
       version:
@@ -693,8 +679,7 @@ definitions:
       - created
     properties:
       id:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       name:
         type: string
       description:
@@ -718,8 +703,7 @@ definitions:
       - validation_id
     properties:
       id:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       category:
         type: string
       component_id:
@@ -729,8 +713,7 @@ definitions:
       device_id:
         type: string
       hardware_product_id:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       hint:
         anyOf:
           - type: 'null'
@@ -746,8 +729,7 @@ definitions:
           - fail
           - pass
       validation_id:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
   ValidationState:
     type: object
     additionalProperties: false
@@ -760,8 +742,7 @@ definitions:
       - validation_plan_id
     properties:
       id:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       completed:
         anyOf:
           - type: 'null'
@@ -779,8 +760,7 @@ definitions:
           - fail
           - pass
       validation_plan_id:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
   ValidationStatesWithResults:
     type: array
     items:
@@ -798,8 +778,7 @@ definitions:
       - validation_plan_id
     properties:
       id:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       completed:
         anyOf:
           - type: 'null'
@@ -821,8 +800,7 @@ definitions:
           - fail
           - pass
       validation_plan_id:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
   WorkspaceRelays:
     type: array
     items:
@@ -865,8 +843,7 @@ definitions:
         additionalProperties: false
         properties:
           rack_id:
-            type: string
-            format: uuid
+            $ref: /definitions/uuid
           rack_name:
             type: string
           role_name:
@@ -907,8 +884,7 @@ definitions:
         type: string
       report_id:
         anyOf:
-          - type: string
-            format: uuid
+          - $ref: /definitions/uuid
           - type: 'null'
   WorkspaceAndRole:
     type: object
@@ -921,8 +897,7 @@ definitions:
       - role
     properties:
       id:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       name:
         type: string
       description:
@@ -931,8 +906,7 @@ definitions:
           - type: 'null'
       parent_id:
         anyOf:
-          - type: string
-            format: uuid
+          - $ref: /definitions/uuid
           - type: 'null'
       role:
         type: string
@@ -942,8 +916,7 @@ definitions:
           - admin
       role_via:
         description: the id of the workspace where the permissions came from
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
   WorkspacesAndRoles:
     type: array
     items:
@@ -967,8 +940,7 @@ definitions:
           type: string
         role_via:
           description: this is the id of the workspace where the permissions came from
-          type: string
-          format: uuid
+          $ref: /definitions/uuid
   Rooms:
     type: array
     items:
@@ -983,8 +955,7 @@ definitions:
       - vendor_name
     properties:
       id:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       az:
         type: string
       alias:
@@ -1067,8 +1038,7 @@ definitions:
           type: string
           format: date-time
         id:
-          type: string
-          format: uuid
+          $ref: /definitions/uuid
         max_retries:
           type: number
         name:
@@ -1081,11 +1051,9 @@ definitions:
           type: string
           format: date-time
         validation_plan_id:
-          type: string
-          format: uuid
+          $ref: /definitions/uuid
         workflow_id:
-          type: string
-          format: uuid
+          $ref: /definitions/uuid
   Workflow:
     type: object
     additionalProperties: false
@@ -1099,8 +1067,7 @@ definitions:
       - preflight
     properties:
       id:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       name:
         type: string
       created:
@@ -1118,8 +1085,7 @@ definitions:
           - type: 'null'
           - type: array
             items:
-                type: string
-                format: uuid
+              $ref: /definitions/uuid
   WorkflowStatus:
     type: object
     additionalProperties: false
@@ -1133,16 +1099,14 @@ definitions:
       device_id:
         type: string
       id:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       status:
         type: string
       created:
         type: string
         format: date-time
       workflow_id:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
   Workflows:
     type: array
     items:
@@ -1175,8 +1139,7 @@ definitions:
       force_retry:
         type: number
       id:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       overridden:
         type: number
       retry_count:
@@ -1184,13 +1147,11 @@ definitions:
       state:
         type: string
       validation_state_id:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       validation_status:
         type: string
       workflow_step_id:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
   Racks:
     type: array
     items:
@@ -1209,16 +1170,13 @@ definitions:
       - updated
     properties:
       id:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       name:
         type: string
       datacenter_room_id:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       role:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       serial_number:
         anyOf:
           - type: string
@@ -1244,8 +1202,7 @@ definitions:
       - updated
     properties:
       id:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       name:
         type: string
       rack_size:
@@ -1276,14 +1233,11 @@ definitions:
       - updated
     properties:
       id:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       rack_id:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       product_id:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       ru_start: # TODO: this really should be rack_unit_start
         type: integer
       created:
@@ -1308,15 +1262,13 @@ definitions:
       - updated
     properties:
       id:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       name:
         type: string
       alias:
         type: string
       vendor:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       created:
         type: string
         format: date-time
@@ -1353,8 +1305,7 @@ definitions:
       - name
     properties:
       id:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       email:
         type: string
         format: email
@@ -1396,8 +1347,7 @@ definitions:
       - workspaces
     properties:
       id:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       name:
         type: string
       email:
@@ -1435,8 +1385,7 @@ definitions:
       - updated
     properties:
       id:
-        type: string
-        format: uuid
+        $ref: /definitions/uuid
       name:
         type: string
       created:

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -294,6 +294,7 @@ definitions:
       - system_uuid
       - state
       - bios_version
+      - os
       - processor
       - memory
     properties:
@@ -307,6 +308,13 @@ definitions:
         type: string
       bios_version:
         type: string
+      os:
+        type: object
+        required:
+          - hostname
+        properties:
+          hostname:
+            type: string
       processor:
         type: object
       memory:

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -43,12 +43,12 @@ definitions:
       asset_tag:
         anyOf:
           - type: string
-          - type: null
+          - type: 'null'
         description: this field is deprecated and will no longer be present.
       boot_phase:
         anyOf:
           - type: string
-          - type: null
+          - type: 'null'
       created:
         type: string
         format: date-time
@@ -60,19 +60,19 @@ definitions:
       hostname:
         anyOf:
           - type: string
-          - type: null
+          - type: 'null'
       id:
         type: string
       graduated:
         anyOf:
           - type: string
             format: date-time
-          - type: null
+          - type: 'null'
       last_seen:
         anyOf:
           - type: string
             format: date-time
-          - type: null
+          - type: 'null'
       latest_report:
         anyOf:
           - $ref: /definitions/DeviceReport
@@ -81,7 +81,7 @@ definitions:
         anyOf:
           - type: string
             format: date-time
-          - type: null
+          - type: 'null'
       state:
         type: string
       system_uuid:
@@ -91,12 +91,12 @@ definitions:
         anyOf:
           - type: string
             format: date-time
-          - type: null
+          - type: 'null'
       triton_uuid:
         anyOf:
           - type: string
             format: uuid
-          - type: null
+          - type: 'null'
       updated:
         type: string
         format: date-time
@@ -104,16 +104,16 @@ definitions:
         anyOf:
           - type: string
             format: date-time
-          - type: null
+          - type: 'null'
       validated:
         anyOf:
           - type: string
             format: date-time
-          - type: null
+          - type: 'null'
       location:
         anyOf:
           - $ref: "#/definitions/DeviceLocation"
-          - type: null
+          - type: 'null'
       nics: # NOTE: see also DeviceNic
         type: array
         items:
@@ -138,15 +138,15 @@ definitions:
             peer_mac:
               anyOf:
                 - type: string
-                - type: null
+                - type: 'null'
             peer_port:
               anyOf:
                 - type: string
-                - type: null
+                - type: 'null'
             peer_switch:
               anyOf:
                 - type: string
-                - type: null
+                - type: 'null'
   Devices:
     type: array
     items:
@@ -174,12 +174,12 @@ definitions:
       asset_tag:
         anyOf:
           - type: string
-          - type: null
+          - type: 'null'
         deprecated: this field is deprecated and will no longer be present.
       boot_phase:
         anyOf:
           - type: string
-          - type: null
+          - type: 'null'
       created:
         type: string
         format: date-time
@@ -191,41 +191,41 @@ definitions:
       hostname:
         anyOf:
           - type: string
-          - type: null
+          - type: 'null'
       id:
         type: string
       graduated:
         anyOf:
           - type: string
             format: date-time
-          - type: null
+          - type: 'null'
       last_seen:
         anyOf:
           - type: string
             format: date-time
-          - type: null
+          - type: 'null'
       latest_triton_reboot:
         anyOf:
           - type: string
             format: date-time
-          - type: null
+          - type: 'null'
       state:
         type: string
       system_uuid:
         anyOf:
-          - type: null
+          - type: 'null'
           - type: string
             format: uuid
       triton_uuid:
         anyOf:
           - type: string
             format: uuid
-          - type: null
+          - type: 'null'
       triton_setup:
         anyOf:
           - type: string
             format: date-time
-          - type: null
+          - type: 'null'
       updated:
         type: string
         format: date-time
@@ -233,12 +233,12 @@ definitions:
         anyOf:
           - type: string
             format: date-time
-          - type: null
+          - type: 'null'
       validated:
         anyOf:
           - type: string
             format: date-time
-          - type: null
+          - type: 'null'
 
   DeviceNics:
     type: array
@@ -273,22 +273,22 @@ definitions:
       state:
         anyOf:
           - type: string
-          - type: null
+          - type: 'null'
       speed:
         anyOf:
           - type: string
-          - type: null
+          - type: 'null'
       ipaddr:
         anyOf:
           - type: string
             format: ipv4
           - type: string
             format: ipv6
-          - type: null
+          - type: 'null'
       mtu:
         anyOf:
           - type: integer
-          - type: null
+          - type: 'null'
   DeviceReport:
     type: object
     required:
@@ -415,20 +415,20 @@ definitions:
       generation_name:
         anyOf:
           - type: string
-          - type: null
+          - type: 'null'
       legacy_product_name:
         anyOf:
           - type: string
-          - type: null
+          - type: 'null'
       sku:
         anyOf:
           - type: string
-          - type: null
+          - type: 'null'
 
       specification:
         anyOf:
           - type: string
-          - type: null
+          - type: 'null'
       profile:
         type: object
         additionalProperties: false
@@ -459,7 +459,7 @@ definitions:
           bios_firmware:
             anyOf:
               - type: string
-              - type: null
+              - type: 'null'
           cpu_num:
             type: integer
           cpu_type:
@@ -469,7 +469,7 @@ definitions:
           hba_firmware:
             anyOf:
               - type: string
-              - type: null
+              - type: 'null'
           id:
             type: string
             format: uuid
@@ -486,49 +486,50 @@ definitions:
           sas_num:
             anyOf:
               - type: integer
-              - type: null
+              - type: 'null'
           sas_size:
             anyOf:
               - type: integer
-              - type: null
+              - type: 'null'
           sas_slots:
             anyOf:
               - type: integer
-              - type: null
+              - type: 'null'
           sata_num:
             anyOf:
               - type: integer
-              - type: null
+              - type: 'null'
           sata_size:
             anyOf:
               - type: integer
-              - type: null
+              - type: 'null'
           sata_slots:
             anyOf:
               - type: string
-              - type: null
+              - type: 'null'
           ssd_num:
             anyOf:
               - type: integer
-              - type: null
+              - type: 'null'
           ssd_size:
             anyOf:
               - type: integer
-              - type: null
+              - type: 'null'
           ssd_slots:
             anyOf:
               - type: string
-              - type: null
+              - type: 'null'
           usb_num:
             anyOf:
               - type: integer
-              - type: null
+              - type: 'null'
           zpool:
             anyOf:
               - type: object
                 additionalProperties: false
                 required:
                   - id
+                  - name
                   - cache
                   - log
                   - disk_per
@@ -539,6 +540,10 @@ definitions:
                   id:
                     type: string
                     format: uuid
+                  name:
+                    anyOf:
+                      - type: string
+                      - type: 'null'
                   cache:
                     type: integer
                   log:
@@ -546,14 +551,14 @@ definitions:
                   disk_per:
                     anyOf:
                       - type: integer
-                      - type: null
+                      - type: 'null'
                   spare:
                     type: integer
                   vdev_n:
                     type: integer
                   vdev_t:
                     type: string
-              - type: null
+              - type: 'null'
   WorkspaceRackSummary:
     type: object
     additionalProperties: false
@@ -640,10 +645,10 @@ definitions:
               type: string
               description: Hardware product vendor
             occupant:
-              description: Device assigned to this slot or null
+              description: Device assigned to this slot, if any
               anyOf:
                 - $ref: "#/definitions/Device"
-                - type: null
+                - type: 'null'
   Validations:
     type: array
     items:
@@ -719,7 +724,7 @@ definitions:
         type: string
       component_id:
         anyOf:
-          - type: null
+          - type: 'null'
           - type: string
       device_id:
         type: string
@@ -728,7 +733,7 @@ definitions:
         format: uuid
       hint:
         anyOf:
-          - type: null
+          - type: 'null'
           - type: string
       message:
         type: string
@@ -759,7 +764,7 @@ definitions:
         format: uuid
       completed:
         anyOf:
-          - type: null
+          - type: 'null'
           - type: string
             format: date-time
       created:
@@ -797,7 +802,7 @@ definitions:
         format: uuid
       completed:
         anyOf:
-          - type: null
+          - type: 'null'
           - type: string
             format: date-time
       created:
@@ -839,7 +844,7 @@ definitions:
       alias:
         anyOf:
           - type: string
-          - type: null
+          - type: 'null'
       created:
         type: string
         format: date-time
@@ -854,7 +859,7 @@ definitions:
       ipaddr:
         anyOf:
           - type: string
-          - type: null
+          - type: 'null'
       location:
         type: object
         additionalProperties: false
@@ -897,14 +902,14 @@ definitions:
       location:
         anyOf:
           - $ref: "#/definitions/DeviceLocation"
-          - type: null
+          - type: 'null'
       health:
         type: string
       report_id:
         anyOf:
           - type: string
             format: uuid
-          - type: null
+          - type: 'null'
   WorkspaceAndRole:
     type: object
     additionalProperties: false
@@ -923,12 +928,12 @@ definitions:
       description:
         anyOf:
           - type: string
-          - type: null
+          - type: 'null'
       parent_id:
         anyOf:
           - type: string
             format: uuid
-          - type: null
+          - type: 'null'
       role:
         type: string
         enum:
@@ -985,7 +990,7 @@ definitions:
       alias:
         anyOf:
           - type: string
-          - type: null
+          - type: 'null'
       vendor_name:
         type: string
   Relays:
@@ -1007,7 +1012,7 @@ definitions:
       alias:
         anyOf:
           - type: string
-          - type: null
+          - type: 'null'
       created:
         type: string
         format: date-time
@@ -1016,18 +1021,18 @@ definitions:
       ipaddr:
         anyOf:
           - type: string
-          - type: null
+          - type: 'null'
       ssh_port:
         anyOf:
           - type: number
-          - type: null
+          - type: 'null'
       updated:
         type: string
         format: date-time
       version:
         anyOf:
           - type: string
-          - type: null
+          - type: 'null'
   Ping:
     type: object
     additionalProperties: false
@@ -1110,7 +1115,7 @@ definitions:
         type: number
       steps:
         anyOf:
-          - type: null
+          - type: 'null'
           - type: array
             items:
                 type: string
@@ -1217,11 +1222,11 @@ definitions:
       serial_number:
         anyOf:
           - type: string
-          - type: null
+          - type: 'null'
       asset_tag:
         anyOf:
           - type: string
-          - type: null
+          - type: 'null'
       created:
         type: string
         format: date-time
@@ -1321,23 +1326,23 @@ definitions:
       specification:
         anyOf:
           - type: object
-          - type: null
+          - type: 'null'
       sku:
         anyOf:
           - type: string
-          - type: null
+          - type: 'null'
       generation_name:
         anyOf:
           - type: string
-          - type: null
+          - type: 'null'
       legacy_product_name:
         anyOf:
           - type: string
-          - type: null
+          - type: 'null'
       prefix:
         anyOf:
           - type: string
-          - type: null
+          - type: 'null'
 
   User:
     type: object
@@ -1364,7 +1369,7 @@ definitions:
             type: string
             format: date-time
           -
-            type: null
+            type: 'null'
   UserError:
     type: object
     additionalProperties: false
@@ -1403,7 +1408,7 @@ definitions:
         format: date-time
       last_login:
         anyOf:
-          - type: null
+          - type: 'null'
           - type: string
             format: date-time
       refuse_session_auth:

--- a/lib/Conch/Controller/Datacenter.pm
+++ b/lib/Conch/Controller/Datacenter.pm
@@ -66,6 +66,8 @@ sub get_one ($c) {
 
 Get all rooms for the given datacenter
 
+Response matches the DatacenterRoomsDetailed json schema.
+
 =cut
 
 sub get_rooms ($c) {

--- a/lib/Conch/Controller/DatacenterRoom.pm
+++ b/lib/Conch/Controller/DatacenterRoom.pm
@@ -42,6 +42,8 @@ sub find_datacenter_room ($c) {
 
 Get all datacenter rooms
 
+Response uses the DatacenterRoomsDetailed json schema.
+
 =cut
 
 sub get_all ($c) {
@@ -57,6 +59,8 @@ sub get_all ($c) {
 =head2 get_one
 
 Get a single datacenter room
+
+Response uses the DatacenterRoomDetailed json schema.
 
 =cut
 

--- a/lib/Conch/Model/WorkspaceRack.pm
+++ b/lib/Conch/Model/WorkspaceRack.pm
@@ -97,7 +97,7 @@ sub rack_layout ( $self, $rack ) {
 		my $slot = { rack_unit_start => $rack_unit_start };
 
 		if ($device) {
-			$slot->{occupant} = $device;
+			$slot->{occupant} = Conch::Model::Device->new($device->%*);
 		}
 		else {
 			$slot->{occupant} = undef;

--- a/lib/Test/Conch.pm
+++ b/lib/Test/Conch.pm
@@ -5,7 +5,6 @@ use Mojo::Base 'Test::Mojo';
 
 use Test::More ();
 use Test::ConchTmpDB 'mk_tmp_db';
-use Conch::UUID 'is_uuid';
 use JSON::Validator;
 use Path::Tiny;
 use Test::Deep ();
@@ -57,10 +56,6 @@ has 'validator' => sub {
     my $validator = JSON::Validator->new;
     $validator->schema($spec_file);
 
-    # add UUID validation
-    my $valid_formats = $validator->formats;
-    $valid_formats->{uuid} = \&is_uuid;
-    $validator->formats($valid_formats);
     $validator;
 };
 

--- a/t/integration/crud/datacenter.t
+++ b/t/integration/crud/datacenter.t
@@ -28,7 +28,10 @@ $t->get_ok("/dc")->status_is(200)->json_is('/0/region', 'test-region-1');
 my $dc_id = $t->tx->res->json->[0]->{id};
 $t->get_ok("/dc/$dc_id")->status_is(200)->json_is('/region', 'test-region-1');
 
-$t->get_ok("/dc/$dc_id/rooms")->status_is(200)->json_is('/0/az', 'test-region-1a');
+$t->get_ok("/dc/$dc_id/rooms")
+	->status_is(200)
+	->json_schema_is('DatacenterRoomsDetailed')
+	->json_is('/0/az', 'test-region-1a');
 
 
 #########
@@ -57,11 +60,16 @@ $t->get_ok("/dc/$idd")->status_is(404);
 
 ###########
 
-$t->get_ok("/room")->status_is(200)->json_is('/0/az', 'test-region-1a');
+$t->get_ok("/room")
+	->status_is(200)
+	->json_schema_is('DatacenterRoomsDetailed')
+	->json_is('/0/az', 'test-region-1a');
 my $room_id = $t->tx->res->json->[0]->{id};
 
 $t->get_ok("/room/". $room_id)
-	->status_is(200)->json_is('/az', 'test-region-1a');
+	->status_is(200)
+	->json_schema_is('DatacenterRoomDetailed')
+	->json_is('/az', 'test-region-1a');
 
 $t->get_ok("/room/$room_id/racks")->status_is(200)
 	->json_is('/0/name', 'Test Rack')

--- a/t/integration/crud/racks.t
+++ b/t/integration/crud/racks.t
@@ -25,7 +25,10 @@ BAIL_OUT("Login failed") if $t->tx->res->code != 200;
 
 my $fake_id = $uuid->create_str();
 
-$t->get_ok("/room")->status_is(200);
+$t->get_ok("/room")
+	->status_is(200)
+	->json_schema_is('DatacenterRoomsDetailed');
+
 my $room_id = $t->tx->res->json->[0]->{id};
 
 $t->get_ok('/rack_role')->status_is(200);


### PR DESCRIPTION
- every `type: null` was interpreted as `type: whatever`
- removed code for uuid validation, replacing with a pattern type
- updated DeviceReport schema to reflect changes in conch-json-schemas
- a few more misc response schemas and tests.

Note! this may result in some runtime errors, if inputs no longer validate against the stricter schemas in input.yaml.