### PR TITLE
remove user creation from workspace invitation flow

### DIFF
--- a/json-schema/input.yaml
+++ b/json-schema/input.yaml
@@ -336,7 +336,7 @@ definitions:
         anyOf:
           - type: 'null'
           - type: string
-  WorkspaceInvite:
+  WorkspaceAddUser:
     type: object
     additionalProperties: false
     required:

--- a/lib/Conch/Command/create_user.pm
+++ b/lib/Conch/Command/create_user.pm
@@ -61,7 +61,7 @@ sub run {
 
     if ($opt->send_email) {
         say 'sending email to ', $opt->email, '...';
-        $self->app->send_mail(new_user_invite => { map { $_ => $opt->$_ } qw(name email password) });
+        $self->app->send_mail(welcome_new_user => { map { $_ => $opt->$_ } qw(name email password) });
     }
 }
 

--- a/lib/Conch/Controller/User.pm
+++ b/lib/Conch/Controller/User.pm
@@ -322,7 +322,7 @@ Creates a user. System admin only.
 
 Optionally takes a query parameters:
 
-* 'send_invite_mail' (defaulting to true), to send an email to the user with the new password
+* 'send_mail' (defaulting to true), to send an email to the user with the new password
 * 'is_admin' (defaulting to false), to set the is_admin flag.
 
 =cut
@@ -358,7 +358,7 @@ sub create ($c) {
 	});
 	$c->log->info('created user: ' . $user->name . ', email: ' . $user->email . ', id: ' . $user->id);
 
-	if ($c->req->query_params->param('send_invite_mail') // 1) {
+	if ($c->req->query_params->param('send_mail') // 1) {
 		$c->log->info('sending "welcome new user" mail to user ' . $user->name);
 		$c->send_mail(welcome_new_user => {
 			(map { $_ => $user->$_ } qw(name email)),

--- a/lib/Conch/Mail.pm
+++ b/lib/Conch/Mail.pm
@@ -136,20 +136,19 @@ sub welcome_new_user {
 
 	my $template = qq{Hello,
 
-    You have been invited to join Joyent Conch. An account has been created for
-    you. Please log into https://conch.joyent.us using the credentials
-    below:
+An account has been created for you in Joyent Conch.
+Please log into https://conch.joyent.us using the credentials below:
 
     Username: $name
     Email:    $email
     Password: $password
 
-    Thank you,
-    Joyent Build Ops Team
-    };
+Thank you,
+Joyent Build Ops Team
+};
 
 	$self->send_mail_with_template($template, $headers)
-		&& $self->log->info("New user invite successfully sent to $email.");
+		&& $self->log->info("New user email successfully sent to $email.");
 }
 
 1;

--- a/lib/Conch/Mail.pm
+++ b/lib/Conch/Mail.pm
@@ -37,18 +37,18 @@ sub send_mail_with_template {
 	return 1;
 }
 
-=head2 new_user_invite
+=head2 workspace_add_user
 
-Template for the email for inviting a new user
+Template for the email sent when adding a user to a workspace
 
 =cut
 
-sub new_user_invite {
+sub workspace_add_user {
 	my $self = shift;
 	my ($args)   = @_;
 	my $name     = $args->{name};
 	my $email    = $args->{email};
-	my $password = $args->{password};
+	my $workspace = $args->{workspace};
 
 	my $to = $email;
 	$to = "$name <$to>" if $name ne $email;
@@ -61,20 +61,14 @@ sub new_user_invite {
 
 	my $template = qq{Hello,
 
-    You have been invited to join Joyent Conch. An account has been created for
-    you. Please log into https://conch.joyent.us using the credentials
-    below:
+You have been added to the "$workspace" workspace at Joyent Conch.
 
-    Username: $name
-    Email:    $email
-    Password: $password
-
-    Thank you,
-    Joyent Build Ops Team
-    };
+Thank you,
+Joyent Build Ops Team
+};
 
 	$self->send_mail_with_template($template, $headers)
-		&& $self->log->info("New user invite successfully sent to $email.");
+		&& $self->log->info("User-added-to-workspace email successfully sent to $email.");
 }
 
 =head2 changed_user_password

--- a/lib/Conch/Plugin/Mail.pm
+++ b/lib/Conch/Plugin/Mail.pm
@@ -12,10 +12,9 @@ Conch::Plugin::Mail - Sets up a helper to send emails
 
 Provides the helper sub 'send_mail' to the app and controllers:
 
-	$c->send_mail('new_user_invite', {
+	$c->send_mail('workspace_add_user', {
 		name => 'bob',
 		email => 'bob@conch.joyent.us',
-		password => 'whargarbl',
 	});
 
 =cut

--- a/lib/Conch/Route/Workspace.pm
+++ b/lib/Conch/Route/Workspace.pm
@@ -102,7 +102,7 @@ sub workspace_routes {
         # GET /workspace/:workspace_id/user
         $with_workspace->get('/user')->to('workspace_user#list');
         # POST /workspace/:workspace_id/user
-        $with_workspace->post('/user')->to('workspace_user#invite');
+        $with_workspace->post('/user')->to('workspace_user#add_user');
         # DELETE /workspace/:workspace_id/user/#target_user
         $with_workspace->delete('/user/#target_user')->to('workspace_user#remove');
     }

--- a/t/integration/00_only_1_user_loaded.t
+++ b/t/integration/00_only_1_user_loaded.t
@@ -241,11 +241,16 @@ subtest 'Workspaces' => sub {
 	is($t->app->db_user_workspace_roles->count, 1,
 		'currently one user_workspace_role entry');
 
-	$t->post_ok("/workspace/$global_ws_id/user?send_invite_mail=0" => json => {
+	$t->post_ok('/user?send_invite_mail=0',
+		json => { email => 'test_workspace@conch.joyent.us', name => 'test_workspace', password => '123' })
+		->status_is(201, 'created new user test_workspace')
+		->json_schema_is('User');
+
+	$t->post_ok("/workspace/$global_ws_id/user?send_mail=0" => json => {
 			user => 'test_workspace@conch.joyent.us',
 			role => 'rw',
 		})
-		->status_is(201);
+		->status_is(201, 'added the user to the GLOBAL workspace');
 
 	is($t->app->db_user_workspace_roles->count, 2,
 		'now there is another user_workspace_role entry');
@@ -259,21 +264,21 @@ subtest 'Workspaces' => sub {
 		'new user can access this workspace',
 	);
 
-	$t->post_ok("/workspace/$global_ws_id/user?send_invite_mail=0" => json => {
+	$t->post_ok("/workspace/$global_ws_id/user?send_mail=0" => json => {
 			user => 'test_workspace@conch.joyent.us',
 			role => 'rw',
 		})
-		->status_is(200, 'redundant invitations do nothing');
+		->status_is(200, 'redundant add requests do nothing');
 
 	is($t->app->db_user_workspace_roles->count, 2,
 		'still just two user_workspace_role entries');
 
-	$t->post_ok("/workspace/$global_ws_id/user?send_invite_mail=0" => json => {
+	$t->post_ok("/workspace/$global_ws_id/user?send_mail=0" => json => {
 			user => 'test_workspace@conch.joyent.us',
 			role => 'ro',
 		})
 		->status_is(400)
-		->json_is({ error => "user test_workspace\@conch.joyent.us already has rw access to workspace $global_ws_id: cannot downgrade role to ro" });
+		->json_is({ error => "user test_workspace already has rw access to workspace $global_ws_id: cannot downgrade role to ro" });
 
 	$t->get_ok('/user/email=test_workspace@conch.joyent.us')
 		->status_is(200)
@@ -312,7 +317,7 @@ subtest 'Workspaces' => sub {
 			},
 			{
 				id    => $test_user_id,
-				name  => 'test_workspace@conch.joyent.us',
+				name  => 'test_workspace',
 				email => 'test_workspace@conch.joyent.us',
 				role  => 'rw',
 			}
@@ -466,7 +471,7 @@ subtest 'Sub-Workspace' => sub {
 			},
 			{
 				id    => $test_user_id,
-				name  => 'test_workspace@conch.joyent.us',
+				name  => 'test_workspace',
 				email => 'test_workspace@conch.joyent.us',
 				role  => 'rw',
 				role_via => $global_ws_id,
@@ -486,30 +491,30 @@ subtest 'Sub-Workspace' => sub {
 			},
 			{
 				id    => $test_user_id,
-				name  => 'test_workspace@conch.joyent.us',
+				name  => 'test_workspace',
 				email => 'test_workspace@conch.joyent.us',
 				role  => 'rw',
 				role_via => $global_ws_id,
 			},
 		), 'data for users who can access grandchild workspace');
 
-	$t->post_ok("/workspace/$grandsub_ws_id/user?send_invite_mail=0" => json => {
+	$t->post_ok("/workspace/$grandsub_ws_id/user?send_mail=0" => json => {
 			user => 'test_workspace@conch.joyent.us',
 			role => 'rw',
 		})
-		->status_is(200, 'redundant invitations do nothing');
+		->status_is(200, 'redundant add requests do nothing');
 
 	is($t->app->db_user_workspace_roles->count, 2,
 		'still just two user_workspace_role entries');
 
-	$t->post_ok("/workspace/$grandsub_ws_id/user?send_invite_mail=0" => json => {
+	$t->post_ok("/workspace/$grandsub_ws_id/user?send_mail=0" => json => {
 			user => 'test_workspace@conch.joyent.us',
 			role => 'ro',
 		})
 		->status_is(400)
-		->json_is({ error => "user test_workspace\@conch.joyent.us already has rw access to workspace $grandsub_ws_id via workspace $global_ws_id: cannot downgrade role to ro" });
+		->json_is({ error => "user test_workspace already has rw access to workspace $grandsub_ws_id via workspace $global_ws_id: cannot downgrade role to ro" });
 
-	$t->post_ok("/workspace/$grandsub_ws_id/user?send_invite_mail=0" => json => {
+	$t->post_ok("/workspace/$grandsub_ws_id/user?send_mail=0" => json => {
 			user => 'test_workspace@conch.joyent.us',
 			role => 'admin',
 		})
@@ -520,23 +525,23 @@ subtest 'Sub-Workspace' => sub {
 
 	# now let's try manipulating permissions on the workspace in the middle of the heirarchy
 
-	$t->post_ok("/workspace/$sub_ws_id/user?send_invite_mail=0" => json => {
+	$t->post_ok("/workspace/$sub_ws_id/user?send_mail=0" => json => {
 			user => 'test_workspace@conch.joyent.us',
 			role => 'rw',
 		})
-		->status_is(200, 'redundant invitations do nothing');
+		->status_is(200, 'redundant add requests do nothing');
 
-	$t->post_ok("/workspace/$sub_ws_id/user?send_invite_mail=0" => json => {
+	$t->post_ok("/workspace/$sub_ws_id/user?send_mail=0" => json => {
 			user => 'test_workspace@conch.joyent.us',
 			role => 'ro',
 		})
 		->status_is(400)
-		->json_is({ error => "user test_workspace\@conch.joyent.us already has rw access to workspace $sub_ws_id via workspace $global_ws_id: cannot downgrade role to ro" });
+		->json_is({ error => "user test_workspace already has rw access to workspace $sub_ws_id via workspace $global_ws_id: cannot downgrade role to ro" });
 
 	is($t->app->db_user_workspace_roles->count, 3,
 		'still just three user_workspace_role entries');
 
-	$t->post_ok("/workspace/$sub_ws_id/user?send_invite_mail=0" => json => {
+	$t->post_ok("/workspace/$sub_ws_id/user?send_mail=0" => json => {
 			user => 'test_workspace@conch.joyent.us',
 			role => 'admin',
 		})

--- a/t/integration/00_only_1_user_loaded.t
+++ b/t/integration/00_only_1_user_loaded.t
@@ -241,7 +241,7 @@ subtest 'Workspaces' => sub {
 	is($t->app->db_user_workspace_roles->count, 1,
 		'currently one user_workspace_role entry');
 
-	$t->post_ok('/user?send_invite_mail=0',
+	$t->post_ok('/user?send_mail=0',
 		json => { email => 'test_workspace@conch.joyent.us', name => 'test_workspace', password => '123' })
 		->status_is(201, 'created new user test_workspace')
 		->json_schema_is('User');
@@ -789,13 +789,13 @@ subtest 'JWT authentication' => sub {
 subtest 'modify another user' => sub {
 
 	$t->post_ok(
-		'/user?send_invite_mail=0',
+		'/user?send_mail=0',
 		json => { name => 'me', email => 'foo@conch.joyent.us' })
 		->status_is(400, 'user name "me" is prohibited')
 		->json_is({ error => 'user name "me" is prohibited' });
 
 	$t->post_ok(
-		'/user?send_invite_mail=0',
+		'/user?send_mail=0',
 		json => { name => 'conch', email => 'foo@conch.joyent.us' })
 		->status_is(409, 'cannot create user with a duplicate name')
 		->json_schema_is('UserError')
@@ -811,7 +811,7 @@ subtest 'modify another user' => sub {
 			});
 
 	$t->post_ok(
-		'/user?send_invite_mail=0',
+		'/user?send_mail=0',
 		json => { name => 'foo', email => 'conch@conch.joyent.us' })
 		->status_is(409, 'cannot create user with a duplicate email address')
 		->json_schema_is('UserError')
@@ -827,7 +827,7 @@ subtest 'modify another user' => sub {
 			});
 
 	$t->post_ok(
-		'/user?send_invite_mail=0',
+		'/user?send_mail=0',
 		json => { name => 'conch', email => 'CONCH@conch.JOYENT.us' })
 		->status_is(409, 'emails are not case sensitive when checking for duplicate users')
 		->json_schema_is('UserError')
@@ -843,7 +843,7 @@ subtest 'modify another user' => sub {
 			});
 
 	$t->post_ok(
-		'/user?send_invite_mail=0',
+		'/user?send_mail=0',
 		json => { email => 'foo@conch.joyent.us', name => 'foo', password => '123' })
 		->status_is(201, 'created new user foo')
 		->json_schema_is('User')
@@ -871,7 +871,7 @@ subtest 'modify another user' => sub {
 		}, 'returned all the right fields (and not the password)');
 
 	$t->post_ok(
-		'/user?send_invite_mail=0',
+		'/user?send_mail=0',
 		json => { email => 'foo@conch.joyent.us', name => 'foo', password => '123' })
 		->status_is(409, 'cannot create the same user again')
 		->json_schema_is('UserError')
@@ -1064,7 +1064,7 @@ subtest 'modify another user' => sub {
 	ok($new_user->deactivated, 'user still exists, but is marked deactivated');
 
 	$t->post_ok(
-		'/user?send_invite_mail=0',
+		'/user?send_mail=0',
 		json => { email => 'foo@conch.joyent.us', name => 'foo', password => '123' })
 		->status_is(201, 'created user "again"');
 	my $second_new_user_id = $t->tx->res->json->{id};

--- a/t/integration/04_test_datacenter_loaded.t
+++ b/t/integration/04_test_datacenter_loaded.t
@@ -471,7 +471,7 @@ subtest 'Permissions' => sub {
 			)->status_is(403)->json_is( "/error", "Forbidden" );
 		};
 
-		subtest "Can't invite a user" => sub {
+		subtest "Can't add a user to workspace" => sub {
 			$t->post_ok(
 				"/workspace/$global_ws_id/user",
 				json => {
@@ -546,7 +546,7 @@ subtest 'Permissions' => sub {
 			)->status_is(403)->json_is( "/error", "Forbidden" );
 		};
 
-		subtest "Can't invite a user" => sub {
+		subtest "Can't add a user to workspace" => sub {
 			$t->post_ok(
 				"/workspace/$global_ws_id/user",
 				json => {


### PR DESCRIPTION
Email template adjusted accordingly.
This also gives us the bonus that newly created users will get a proper "name" entry.
Identifiers renamed to remove mention of "invitations".

Note that the "send_invite_mail" query parameter is now "send_mail".

closes #452.
