### PR TITLE
Fix Session Expiration

### DIFF
--- a/lib/Conch/Controller/Login.pm
+++ b/lib/Conch/Controller/Login.pm
@@ -17,7 +17,6 @@ use Mojo::IOLoop;
 use Mojo::JWT;
 use Try::Tiny;
 use Conch::UUID 'is_uuid';
-use List::Util 'min';
 
 with 'Conch::Role::MojoLog';
 
@@ -57,7 +56,7 @@ sub _create_jwt ($c, $user_id, $expires_delta = undef) {
 	$c->cookie(
 		jwt_sig => $sig,
 		{
-			expires => min($expires_abs, time + 3600),
+			expires => $expires_abs,
 			secure => $c->req->is_secure,
 			httponly => 1,
 		},


### PR DESCRIPTION
JWT Tokens are set to expire in 1 or 30 day timeframe, but the implementation currently splits them and stores the signature in a cookie that expires in an hour. 

This PR fixes session expiration on the signature cookie to match the JWT Token.

It should be back-portable to v2.19.x