### PR TITLE
fix: do not create duplicate validation_state records

### DIFF
--- a/lib/Conch/Model/ValidationState.pm
+++ b/lib/Conch/Model/ValidationState.pm
@@ -254,7 +254,7 @@ sub update ($self, $new_results = []) {
 			$self->validation_results->@*;
 
 	my $state = $self;
-	if($self->status) {
+	if (not $self->status) {
 		$state = Conch::Model::ValidationState->create(
 			$self->device_id,
 			$self->validation_plan_id,

--- a/t/model/ValidationPlan.t
+++ b/t/model/ValidationPlan.t
@@ -170,23 +170,26 @@ subtest "run validation plan" => sub {
 		$device->id,
 		{}
 	);
-	is( scalar $error_state->validation_results->@*, 1 );
+	is( scalar( grep { $_->status eq 'error' } $error_state->validation_results->@* ), 1 );
 	is( $error_state->status, 'error',
 		'Validation state should be error because result errored' );
 
+	# note this is actually the same db row as $error_state
 	my $fail_state = $validation_plan->run_with_state(
 		$device->id,
 		{ product_name => 'bad' }
 	);
-	is( scalar $fail_state->validation_results->@*, 1 );
+	is( scalar( grep { $_->status eq 'fail' } $fail_state->validation_results->@* ), 1 );
+
 	is( $fail_state->status, 'fail',
 		'Validation state should be fail because result failed' );
 
+	# note this is actually the same db row as $error_state and $fail_state
 	my $pass_state = $validation_plan->run_with_state(
 		$device->id,
 		{ product_name => 'Joyent-G1' }
 	);
-	is( scalar $pass_state->validation_results->@*, 1 );
+	is( scalar( grep { $_->status eq 'pass' } $fail_state->validation_results->@* ), 1 );
 	is( $pass_state->status, 'pass',
 		'Validation state should be pass because all results passed' );
 };


### PR DESCRIPTION
`Conch::Model::ValidationPlan::run_with_state` might call
`Conch::Model::ValidationState->create` before `->update`, and that
first record is being discarded because its 'status' record is already
defined (via the default value in the db schema).
    
This leaked record is then found by
`Conch::Model::ValidationState->latest_completed_for_device_plan` and
re-used on the next report, so it's not catastrophic, but the duplicate
records will cause a foreign key violation in upcoming code so we need
to fix it now.