### PR TITLE
fix creation, re-use of validation_state records

### DIFF
--- a/lib/Conch/Model/ValidationState.pm
+++ b/lib/Conch/Model/ValidationState.pm
@@ -94,14 +94,14 @@ sub mark_completed ( $self, $status ) {
 	return $self;
 }
 
-=head2 latest_completed_for_device_plan
+=head2 latest_for_device_plan
 
-Find the latest completed validation state for a given Device and Validation
+Find the latest validation state for a given Device and Validation
 Plan, or return undef
 
 =cut
 
-sub latest_completed_for_device_plan ( $class, $device_id, $plan_id ) {
+sub latest_for_device_plan ( $class, $device_id, $plan_id ) {
 	my $fields = join( ', ', @$attrs );
 	my $ret = Conch::Pg->new->db->query(
 		qq{
@@ -109,9 +109,8 @@ sub latest_completed_for_device_plan ( $class, $device_id, $plan_id ) {
 		from validation_state
 		where
 			device_id = ? and
-			completed is not null and
 			validation_plan_id = ?
-		order by completed desc
+		order by created desc
 		limit 1
 		},
 		$device_id, $plan_id
@@ -254,6 +253,7 @@ sub update ($self, $new_results = []) {
 			$self->validation_results->@*;
 
 	my $state = $self;
+	# this code should never execute - the caller has always created the record first.
 	if (not $self->status) {
 		$state = Conch::Model::ValidationState->create(
 			$self->device_id,

--- a/t/model/ValidationPlan.t
+++ b/t/model/ValidationPlan.t
@@ -170,26 +170,23 @@ subtest "run validation plan" => sub {
 		$device->id,
 		{}
 	);
-	is( scalar( grep { $_->status eq 'error' } $error_state->validation_results->@* ), 1 );
+	is( scalar $error_state->validation_results->@*, 1 );
 	is( $error_state->status, 'error',
 		'Validation state should be error because result errored' );
 
-	# note this is actually the same db row as $error_state
 	my $fail_state = $validation_plan->run_with_state(
 		$device->id,
 		{ product_name => 'bad' }
 	);
-	is( scalar( grep { $_->status eq 'fail' } $fail_state->validation_results->@* ), 1 );
-
+	is( scalar $fail_state->validation_results->@*, 1 );
 	is( $fail_state->status, 'fail',
 		'Validation state should be fail because result failed' );
 
-	# note this is actually the same db row as $error_state and $fail_state
 	my $pass_state = $validation_plan->run_with_state(
 		$device->id,
 		{ product_name => 'Joyent-G1' }
 	);
-	is( scalar( grep { $_->status eq 'pass' } $fail_state->validation_results->@* ), 1 );
+	is( scalar $pass_state->validation_results->@*, 1 );
 	is( $pass_state->status, 'pass',
 		'Validation state should be pass because all results passed' );
 };

--- a/t/model/ValidationState.t
+++ b/t/model/ValidationState.t
@@ -109,9 +109,9 @@ subtest "modify validation state" => sub {
 		'Validation state now has a completed value' );
 };
 
-subtest "latest completed validation state" => sub {
+subtest "latest validation state" => sub {
 	my $latest =
-		Conch::Model::ValidationState->latest_completed_for_device_plan(
+		Conch::Model::ValidationState->latest_for_device_plan(
 		$device->id, $validation_plan->id );
 	isa_ok( $latest, 'Conch::Model::ValidationState' );
 
@@ -120,7 +120,7 @@ subtest "latest completed validation state" => sub {
 	$new_state->mark_completed('pass');
 
 	my $new_latest =
-		Conch::Model::ValidationState->latest_completed_for_device_plan(
+		Conch::Model::ValidationState->latest_for_device_plan(
 		$device->id, $validation_plan->id );
 	is_deeply( $new_state, $new_latest );
 };


### PR DESCRIPTION
On plan execution, we actually want to search for the latest validation_state entry, regardless
of status, to consider reusing it. If the latest state entry is marked complete, then we create
a new one; otherwise, we pick up where we left off.

This also means my fix in #483 was not quite right. :/

This fix is intended for v2.19; in v2.21 we will always create new validation_state records, as
part of changes for #459.