### PR TITLE
save device_report_id on validation_state; never re-use old records

### DIFF
--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -777,6 +777,7 @@ definitions:
       - device_id
       - status
       - validation_plan_id
+      - device_report_id
     properties:
       id:
         $ref: /definitions/uuid
@@ -798,6 +799,10 @@ definitions:
           - pass
       validation_plan_id:
         $ref: /definitions/uuid
+      device_report_id:
+        anyOf:
+          - type: 'null'  # XXX temporary! will be not-nullable later.
+          - $ref: /definitions/uuid
   ValidationStatesWithResults:
     type: array
     items:
@@ -813,6 +818,7 @@ definitions:
       - results
       - status
       - validation_plan_id
+      - device_report_id
     properties:
       id:
         $ref: /definitions/uuid
@@ -837,6 +843,8 @@ definitions:
           - fail
           - pass
       validation_plan_id:
+        $ref: /definitions/uuid
+      device_report_id:
         $ref: /definitions/uuid
   WorkspaceRelays:
     type: array

--- a/lib/Conch/Command/update_validation_states.pm
+++ b/lib/Conch/Command/update_validation_states.pm
@@ -1,0 +1,89 @@
+package Conch::Command::update_validation_states;
+
+=pod
+
+=head1 NAME
+
+update_validation_states - view the workspace heirarchy
+
+=head1 SYNOPSIS
+
+    update_validation_states [long options...]
+
+        --help  print usage message and exit
+
+=cut
+
+use Mojo::Base 'Mojolicious::Command', -signatures;
+use Getopt::Long::Descriptive;
+
+has description => 'Set validation_state.device_report_id in all historical records';
+
+has usage => sub { shift->extract_usage };  # extracts from SYNOPSIS
+
+sub run ($self) {
+
+    local @ARGV = @_;
+    my ($opt, $usage) = describe_options(
+        # the descriptions aren't actually used anymore (mojo uses the synopsis instead)... but
+        # the 'usage' text block can be accessed with $usage->text
+        'update_validation_states %o',
+        [],
+        [ 'help',           'print usage message and exit', { shortcircuit => 1 } ],
+    );
+
+    say Conch::Time->now, '  working...';
+
+    # do work inside a transaction, in case there is a problem...
+    my $schema = $self->app->schema;
+    $schema->txn_do(sub {
+        $schema->storage->dbh_do(sub {
+            my ($storage, $dbh) = @_;
+
+            my $rows = $dbh->do(<<'SQL');
+update validation_state
+     set device_report_id =
+         (select device_report.id from device_report
+             join device on device.id = validation_state.device_id
+             where device_report.created <= validation_state.completed
+             order by device_report.created desc limit 1)
+     where device_report_id is null and validation_state.completed is not null;
+SQL
+
+            say Conch::Time->now, '  ', $rows, ' complete validation_state rows updated.';
+
+            $rows = $dbh->do(<<'SQL');
+update validation_state
+     set device_report_id =
+         (select device_report.id from device_report
+             join device on device.id = validation_state.device_id
+             where device_report.created <= validation_state.created
+             order by device_report.created desc limit 1)
+where device_report_id is null and validation_state.completed is null;
+SQL
+
+            say Conch::Time->now, '  ', $rows, ' incomplete validation_state rows updated.';
+        });
+    });
+
+    say Conch::Time->now, '  done.  Rows remaining with null device_report_id: ',
+        $self->app->db_validation_states->search({ device_report_id => undef })->count;
+    say 'You may now run the deployment migration that sets validation_state.device_report_id to not-nullable.';
+}
+
+
+1;
+__END__
+
+=pod
+
+=head1 LICENSING
+
+Copyright Joyent, Inc.
+
+This Source Code Form is subject to the terms of the Mozilla Public License,
+v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+one at http://mozilla.org/MPL/2.0/.
+
+=cut
+# vim: set ts=4 sts=4 sw=4 et :

--- a/lib/Conch/Controller/DeviceReport.pm
+++ b/lib/Conch/Controller/DeviceReport.pm
@@ -138,7 +138,8 @@ sub process ($c) {
 	$c->log->debug("Running validation plan ".$validation_plan->id);
 	my $validation_state = $validation_plan->run_with_state(
 		$device->id,
-		$unserialized_report, # FIXME this needs to be a DBIC object so we can tie the validation results to a the report ID
+		$device_report->id,
+		$unserialized_report,
 	);
 	$c->log->debug("Validations ran with result: ".$validation_state->status);
 

--- a/lib/Conch/DB/Result/DeviceReport.pm
+++ b/lib/Conch/DB/Result/DeviceReport.pm
@@ -105,9 +105,24 @@ __PACKAGE__->belongs_to(
   { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
 );
 
+=head2 validation_states
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:BKyeGmASKyOXjdG8sMvCnA
+Type: has_many
+
+Related object: L<Conch::DB::Result::ValidationState>
+
+=cut
+
+__PACKAGE__->has_many(
+  "validation_states",
+  "Conch::DB::Result::ValidationState",
+  { "foreign.device_report_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
+
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-10-02 12:48:14
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:SCMwf87pfqnuE5416rVt8g
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration
 1;

--- a/lib/Conch/DB/Result/ValidationState.pm
+++ b/lib/Conch/DB/Result/ValidationState.pm
@@ -67,6 +67,13 @@ __PACKAGE__->table("validation_state");
   data_type: 'timestamp with time zone'
   is_nullable: 1
 
+=head2 device_report_id
+
+  data_type: 'uuid'
+  is_foreign_key: 1
+  is_nullable: 1
+  size: 16
+
 =cut
 
 __PACKAGE__->add_columns(
@@ -100,6 +107,8 @@ __PACKAGE__->add_columns(
   },
   "completed",
   { data_type => "timestamp with time zone", is_nullable => 1 },
+  "device_report_id",
+  { data_type => "uuid", is_foreign_key => 1, is_nullable => 1, size => 16 },
 );
 
 =head1 PRIMARY KEY
@@ -129,6 +138,26 @@ __PACKAGE__->belongs_to(
   "Conch::DB::Result::Device",
   { id => "device_id" },
   { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
+);
+
+=head2 device_report
+
+Type: belongs_to
+
+Related object: L<Conch::DB::Result::DeviceReport>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "device_report",
+  "Conch::DB::Result::DeviceReport",
+  { id => "device_report_id" },
+  {
+    is_deferrable => 0,
+    join_type     => "LEFT",
+    on_delete     => "NO ACTION",
+    on_update     => "NO ACTION",
+  },
 );
 
 =head2 validation_plan
@@ -176,8 +205,8 @@ __PACKAGE__->many_to_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:20uQOHmwWHrYgjGvOZWeaQ
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-10-02 12:48:14
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:TttSipbS2r7dPvfEg6Bk2A
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/sql/migrations/0060-validation_state-device_report_id.sql
+++ b/sql/migrations/0060-validation_state-device_report_id.sql
@@ -1,0 +1,16 @@
+SELECT run_migration(60, $$
+
+    alter table validation_state add column device_report_id uuid;
+
+    create index validation_state_device_report_id_idx on validation_state (device_report_id);
+
+    alter table validation_state
+        add constraint validation_state_device_report_id_fkey foreign key (device_report_id)
+            references device_report(id);
+
+    create index validation_state_created_idx on validation_state (created);
+    create index validation_state_completed_idx on validation_state (completed);
+
+    create index device_report_created_idx on device_report (created);
+
+$$);

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -735,7 +735,8 @@ CREATE TABLE public.validation_state (
     validation_plan_id uuid NOT NULL,
     created timestamp with time zone DEFAULT now() NOT NULL,
     status public.validation_status_enum DEFAULT 'processing'::public.validation_status_enum NOT NULL,
-    completed timestamp with time zone
+    completed timestamp with time zone,
+    device_report_id uuid
 );
 
 
@@ -1326,6 +1327,13 @@ CREATE INDEX device_nic_ipaddr_idx ON public.device_nic USING btree (ipaddr);
 
 
 --
+-- Name: device_report_created_idx; Type: INDEX; Schema: public; Owner: conch
+--
+
+CREATE INDEX device_report_created_idx ON public.device_report USING btree (created);
+
+
+--
 -- Name: device_report_device_id_created_idx; Type: INDEX; Schema: public; Owner: conch
 --
 
@@ -1452,6 +1460,20 @@ CREATE UNIQUE INDEX validation_plan_name_idx ON public.validation_plan USING btr
 
 
 --
+-- Name: validation_state_completed_idx; Type: INDEX; Schema: public; Owner: conch
+--
+
+CREATE INDEX validation_state_completed_idx ON public.validation_state USING btree (completed);
+
+
+--
+-- Name: validation_state_created_idx; Type: INDEX; Schema: public; Owner: conch
+--
+
+CREATE INDEX validation_state_created_idx ON public.validation_state USING btree (created);
+
+
+--
 -- Name: validation_state_device_id_idx; Type: INDEX; Schema: public; Owner: conch
 --
 
@@ -1463,6 +1485,13 @@ CREATE INDEX validation_state_device_id_idx ON public.validation_state USING btr
 --
 
 CREATE INDEX validation_state_device_id_validation_plan_id_completed_idx ON public.validation_state USING btree (device_id, validation_plan_id, completed DESC) WHERE (completed IS NOT NULL);
+
+
+--
+-- Name: validation_state_device_report_id_idx; Type: INDEX; Schema: public; Owner: conch
+--
+
+CREATE INDEX validation_state_device_report_id_idx ON public.validation_state USING btree (device_report_id);
 
 
 --
@@ -1822,6 +1851,14 @@ ALTER TABLE ONLY public.validation_result
 
 ALTER TABLE ONLY public.validation_state
     ADD CONSTRAINT validation_state_device_id_fkey FOREIGN KEY (device_id) REFERENCES public.device(id);
+
+
+--
+-- Name: validation_state validation_state_device_report_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: conch
+--
+
+ALTER TABLE ONLY public.validation_state
+    ADD CONSTRAINT validation_state_device_report_id_fkey FOREIGN KEY (device_report_id) REFERENCES public.device_report(id);
 
 
 --

--- a/t/model/ValidationPlan.t
+++ b/t/model/ValidationPlan.t
@@ -69,7 +69,7 @@ my $hardware_profile_id = $pg->db->insert(
 )->hash->{id};
 
 my $device = Conch::Model::Device->create( 'coffee', $hardware_product_id );
-
+my $device_report = $t->app->db_device_reports->create({ device_id => 'coffee', report => '{}' });
 
 my $validation_plan;
 subtest "Create validation plan" => sub {
@@ -138,6 +138,7 @@ subtest "run validation plan" => sub {
 		sub {
 			$validation_plan->run_with_state(
 				'bad_device',
+				$device_report->id,
 				{}
 			);
 		},
@@ -147,6 +148,7 @@ subtest "run validation plan" => sub {
 		sub {
 			$validation_plan->run_with_state(
 				$device->id,
+				$device_report->id,
 				'bad'
 			);
 		},
@@ -157,6 +159,7 @@ subtest "run validation plan" => sub {
 		0, 'Validation plan should have no validations' );
 	my $new_state = $validation_plan->run_with_state(
 		$device->id,
+		$device_report->id,
 		{}
 	);
 	ok( $new_state->completed );
@@ -168,6 +171,7 @@ subtest "run validation plan" => sub {
 
 	my $error_state = $validation_plan->run_with_state(
 		$device->id,
+		$device_report->id,
 		{}
 	);
 	is( scalar $error_state->validation_results->@*, 1 );
@@ -176,6 +180,7 @@ subtest "run validation plan" => sub {
 
 	my $fail_state = $validation_plan->run_with_state(
 		$device->id,
+		$device_report->id,
 		{ product_name => 'bad' }
 	);
 	is( scalar $fail_state->validation_results->@*, 1 );
@@ -184,6 +189,7 @@ subtest "run validation plan" => sub {
 
 	my $pass_state = $validation_plan->run_with_state(
 		$device->id,
+		$device_report->id,
 		{ product_name => 'Joyent-G1' }
 	);
 	is( scalar $pass_state->validation_results->@*, 1 );

--- a/t/model/ValidationResult.t
+++ b/t/model/ValidationResult.t
@@ -17,6 +17,9 @@ my $pgtmp = mk_tmp_db();
 $pgtmp or die;
 my $pg    = Conch::Pg->new( $pgtmp->uri );
 
+use Test::Conch;
+my $t = Test::Conch->new(pg => $pgtmp);
+
 my $validation_plan =
 	Conch::Model::ValidationPlan->create( 'test', 'test validation plan' );
 
@@ -37,12 +40,13 @@ my $hardware_product_id = $pg->db->insert(
 )->hash->{id};
 
 my $device = Conch::Model::Device->create( 'coffee', $hardware_product_id );
+my $device_report = $t->app->db_device_reports->create({ device_id => 'coffee', report => '{}' });
 
 BAIL_OUT("Could not create a validation plan and device ")
 	unless $validation_plan->id && $device->id;
 
 my $validation_state =
-	Conch::Model::ValidationState->create( $device->id, $validation_plan->id );
+	Conch::Model::ValidationState->create( $device->id, $device_report->id, $validation_plan->id );
 
 my $validation = Conch::Model::Validation->create( 'test', 1, 'test validation',
 	'Test::Validation' );

--- a/t/model/ValidationState.t
+++ b/t/model/ValidationState.t
@@ -73,6 +73,7 @@ my $hardware_profile_id = $pg->db->insert(
 )->hash->{id};
 
 my $device = Conch::Model::Device->create( 'coffee', $hardware_product_id );
+my $device_report = $t->app->db_device_reports->create({ device_id => 'coffee', report => '{}' });
 
 BAIL_OUT("Could not create a validation plan and device ")
 	unless $validation_plan->id && $device->id;
@@ -80,7 +81,7 @@ BAIL_OUT("Could not create a validation plan and device ")
 my $validation_state;
 subtest "Create validation state" => sub {
 	$validation_state =
-		Conch::Model::ValidationState->create( $device->id, $validation_plan->id );
+		Conch::Model::ValidationState->create( $device->id, $device_report->id, $validation_plan->id );
 	isa_ok( $validation_state, 'Conch::Model::ValidationState' );
 	ok( $validation_state->id );
 	is( $validation_state->device_id,          $device->id );
@@ -116,7 +117,7 @@ subtest "latest validation state" => sub {
 	isa_ok( $latest, 'Conch::Model::ValidationState' );
 
 	my $new_state =
-		Conch::Model::ValidationState->create( $device->id, $validation_plan->id );
+		Conch::Model::ValidationState->create( $device->id, $device_report->id, $validation_plan->id );
 	$new_state->mark_completed('pass');
 
 	my $new_latest =
@@ -156,6 +157,7 @@ $validation_plan->add_validation($real_validation);
 subtest 'latest_completed_grouped_states_for_device' => sub {
 	my $latest_state = $validation_plan->run_with_state(
 		$device->id,
+		$device_report->id,
 		{ product_name => 'test hw product' }
 	);
 	my $groups =
@@ -174,6 +176,7 @@ subtest 'latest_completed_grouped_states_for_device' => sub {
 	my $new_state =
 		$validation_plan_1->run_with_state(
 			$device->id,
+			$device_report->id,
 			{}
 		);
 	my $new_results = $new_state->validation_results;


### PR DESCRIPTION
Includes a standalone script to update existing validation_state records; after this is run,
validation_state.device_report_id may be safely changed to not-nullable (which will be done in
a subsequent deployment migration).

Closes #459.