### PR TITLE
do not store device report if it matches a previous report

### DIFF
--- a/lib/Conch/Controller/Device.pm
+++ b/lib/Conch/Controller/Device.pm
@@ -110,7 +110,7 @@ sub get ($c) {
 	# DeviceLocation query has been converted to a prefetchable relationship.
 	my $detailed_device = +{
 		%{ $device->TO_JSON },
-		latest_report => $device->latest_report,
+		latest_report => $device->latest_report_data,
 		nics => [ map {
 			my $device_nic = $_;
 			$device_nic->deactivated ? () :

--- a/lib/Conch/DB/Result/Device.pm
+++ b/lib/Conch/DB/Result/Device.pm
@@ -411,22 +411,35 @@ sub TO_JSON {
 
 use Mojo::JSON 'from_json';
 
-=head2 latest_report
+=head2 latest_report_data
 
 Returns the JSON-decoded content from the most recent device report.
 
 =cut
 
-sub latest_report {
+sub latest_report_data {
     my $self = shift;
 
-    my $json = $self->related_resultset('device_reports')
-        ->order_by({ -desc => 'created' })
-        ->rows(1)
-        ->get_column('report')
-        ->single;
+    my $json = $self->self_rs->latest_device_report->get_column('report')->single;
 
     defined $json ? from_json($json) : undef;
+}
+
+=head2 latest_report_matches
+
+Checks if the latest report's json matches the passed-in json-encoded content (comparing using
+native jsonb operators).
+
+=cut
+
+sub latest_report_matches {
+    my ($self, $jsonb) = @_;
+
+    $self->self_rs
+        ->latest_device_report
+        ->as_subselect_rs
+        ->search({ report => \[ '= ?::jsonb', $jsonb ] })
+        ->count;
 }
 
 1;

--- a/lib/Conch/DB/Result/DeviceReport.pm
+++ b/lib/Conch/DB/Result/DeviceReport.pm
@@ -53,6 +53,19 @@ __PACKAGE__->table("device_report");
   is_nullable: 0
   original: {default_value => \"now()"}
 
+=head2 last_received
+
+  data_type: 'timestamp with time zone'
+  default_value: current_timestamp
+  is_nullable: 0
+  original: {default_value => \"now()"}
+
+=head2 received_count
+
+  data_type: 'integer'
+  default_value: 1
+  is_nullable: 0
+
 =cut
 
 __PACKAGE__->add_columns(
@@ -74,6 +87,15 @@ __PACKAGE__->add_columns(
     is_nullable   => 0,
     original      => { default_value => \"now()" },
   },
+  "last_received",
+  {
+    data_type     => "timestamp with time zone",
+    default_value => \"current_timestamp",
+    is_nullable   => 0,
+    original      => { default_value => \"now()" },
+  },
+  "received_count",
+  { data_type => "integer", default_value => 1, is_nullable => 0 },
 );
 
 =head1 PRIMARY KEY
@@ -121,8 +143,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-10-02 12:48:14
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:SCMwf87pfqnuE5416rVt8g
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-10-10 16:00:59
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:BI5mc8aaPtXrJKY4EdtlVw
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration
 1;

--- a/lib/Conch/DB/ResultSet/Device.pm
+++ b/lib/Conch/DB/ResultSet/Device.pm
@@ -58,6 +58,21 @@ sub devices_without_location {
     });
 }
 
+=head2 latest_device_report
+
+Returns a resultset that finds the most recent device report matching the device(s). This is
+not a window function, so only one report is returned for all matching devices, not one report
+per device! (We probably never need to do the latter.)
+
+=cut
+
+sub latest_device_report {
+    my $self = shift;
+    $self->related_resultset('device_reports')
+        ->order_by({ -desc => 'device_reports.created' })
+        ->rows(1);
+}
+
 1;
 __END__
 

--- a/sql/migrations/0061-device_report-received_count.sql
+++ b/sql/migrations/0061-device_report-received_count.sql
@@ -1,0 +1,12 @@
+SELECT run_migration(61, $$
+
+    alter table device_report
+        add column last_received timestamp with time zone,
+        add column received_count integer default 1 not null;
+
+    update device_report set last_received = created;
+
+    alter table device_report alter last_received set default now(),
+                              alter last_received set not null;
+
+$$);

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -399,7 +399,9 @@ CREATE TABLE public.device_report (
     id uuid DEFAULT public.gen_random_uuid() NOT NULL,
     device_id text NOT NULL,
     report jsonb NOT NULL,
-    created timestamp with time zone DEFAULT now() NOT NULL
+    created timestamp with time zone DEFAULT now() NOT NULL,
+    last_received timestamp with time zone DEFAULT now() NOT NULL,
+    received_count integer DEFAULT 1 NOT NULL
 );
 
 


### PR DESCRIPTION
Instead, we look up the validation_state record we generated last time and return it again.

closes #460.