### PR TITLE
Location headers in redirects can be relative, to avoid forcing to the same proxy

### DIFF
--- a/lib/Conch/Controller/Device.pm
+++ b/lib/Conch/Controller/Device.pm
@@ -202,7 +202,7 @@ sub graduate($c) {
 	$c->log->debug("Marked $device_id as graduated");
 
 	$c->status(303);
-	$c->redirect_to( $c->url_for("/device/$device_id")->to_abs );
+	$c->redirect_to($c->url_for("/device/$device_id"));
 }
 
 =head2 set_triton_reboot
@@ -218,7 +218,7 @@ sub set_triton_reboot ($c) {
 	$c->log->debug("Marked ".$device->id." as rebooted into triton");
 
 	$c->status(303);
-	$c->redirect_to( $c->url_for( '/device/' . $device->id )->to_abs );
+	$c->redirect_to($c->url_for('/device/' . $device->id));
 }
 
 =head2 set_triton_uuid
@@ -238,7 +238,7 @@ sub set_triton_uuid ($c) {
 	$c->log->debug("Set the triton uuid for device ".$device->id." to $input->{triton_uuid}");
 
 	$c->status(303);
-	$c->redirect_to( $c->url_for( '/device/' . $device->id )->to_abs );
+	$c->redirect_to($c->url_for('/device/' . $device->id));
 }
 
 =head2 set_triton_setup
@@ -274,7 +274,7 @@ sub set_triton_setup ($c) {
 	$c->log->debug("Device $device_id marked as set up for triton");
 
 	$c->status(303);
-	$c->redirect_to( $c->url_for("/device/$device_id")->to_abs );
+	$c->redirect_to($c->url_for("/device/$device_id"));
 }
 
 =head2 set_asset_tag
@@ -293,7 +293,7 @@ sub set_asset_tag ($c) {
 	$c->log->debug("Set the asset tag for device ".$device->id." to $input->{asset_tag}");
 
 	$c->status(303);
-	$c->redirect_to( $c->url_for( '/device/' . $device->id )->to_abs );
+	$c->redirect_to($c->url_for('/device/' . $device->id));
 }
 
 =head2 set_validated
@@ -311,7 +311,7 @@ sub set_validated($c) {
 	$c->log->debug("Marked the device $device_id as validated");
 
 	$c->status(303);
-	$c->redirect_to( $c->url_for("/device/$device_id")->to_abs );
+	$c->redirect_to($c->url_for("/device/$device_id"));
 }
 
 1;

--- a/lib/Conch/Controller/DeviceLocation.pm
+++ b/lib/Conch/Controller/DeviceLocation.pm
@@ -69,7 +69,7 @@ sub set ($c) {
 	) unless $assign;
 
 	$c->status(303);
-	$c->redirect_to( $c->url_for("/device/$device_id/location")->to_abs );
+	$c->redirect_to($c->url_for("/device/$device_id/location"));
 }
 
 

--- a/lib/Conch/Controller/Login.pm
+++ b/lib/Conch/Controller/Login.pm
@@ -89,11 +89,12 @@ sub authenticate ($c) {
 	}
 
 	# basic auth: look for user:password in the URL
-	my $abs_url = $c->req->url->to_abs;
+	my $url = $c->req->url->to_abs;
+	if ($url->userinfo) {
 
-	if ( $abs_url->userinfo ) {
 		$c->log->debug('attempting to authenticate with user:password...');
-		my ($name, $password) = ($abs_url->username, $abs_url->password);
+		my ($name, $password) = ($url->username, $url->password);
+
 		$c->log->debug('looking up user by name ' . $name . '...');
 		my $user = $c->db_user_accounts->lookup_by_name($name);
 

--- a/lib/Conch/Controller/WorkspaceRack.pm
+++ b/lib/Conch/Controller/WorkspaceRack.pm
@@ -187,7 +187,7 @@ sub add ($c) {
 	$c->db_datacenter_racks->search({ id => $rack_id })->update($input) if keys %$input;
 
 	$c->status(303);
-	$c->redirect_to( $c->url_for->to_abs . "/$rack_id" );
+	$c->redirect_to($c->url_for('/workspace/'.$c->stash('workspace_id')."/rack/$rack_id"));
 }
 
 

--- a/t/integration/04_test_datacenter_loaded.t
+++ b/t/integration/04_test_datacenter_loaded.t
@@ -119,7 +119,7 @@ subtest 'Workspace Racks' => sub {
 				asset_tag => 'deadbeef',
 			})
 			->status_is(303)
-			->header_like(Location => qr!/workspace/$sub_ws_id/rack/$rack_id!);
+			->location_is("/workspace/$sub_ws_id/rack/$rack_id");
 
 		$t->get_ok("/workspace/$sub_ws_id/rack")
 			->status_is(200)
@@ -291,7 +291,7 @@ subtest 'Single device' => sub {
 
 		$t->post_ok('/device/TEST/graduate')
 			->status_is(303)
-			->header_like( Location => qr!/device/TEST$! );
+			->location_is('/device/TEST');
 
 		$t->post_ok('/device/TEST/triton_setup')
 			->status_is(409)
@@ -300,7 +300,7 @@ subtest 'Single device' => sub {
 
 		$t->post_ok('/device/TEST/triton_reboot')
 			->status_is(303)
-			->header_like( Location => qr!/device/TEST$! );
+			->location_is('/device/TEST');
 
 		$t->post_ok('/device/TEST/triton_uuid')
 			->status_is( 400, 'Request body required' );
@@ -311,11 +311,11 @@ subtest 'Single device' => sub {
 
 		$t->post_ok('/device/TEST/triton_uuid', json => { triton_uuid => $uuid->create_str() })
 			->status_is(303)
-			->header_like( Location => qr!/device/TEST$! );
+			->location_is('/device/TEST');
 
 		$t->post_ok('/device/TEST/triton_setup')
 			->status_is(303)
-			->header_like( Location => qr!/device/TEST$! );
+			->location_is('/device/TEST');
 
 		$t->post_ok('/device/TEST/asset_tag')
 			->status_is( 400, 'Request body required' );
@@ -326,11 +326,11 @@ subtest 'Single device' => sub {
 
 		$t->post_ok('/device/TEST/asset_tag', json => { asset_tag => 'asset_tag' })
 			->status_is(303)
-			->header_like( Location => qr!/device/TEST$! );
+			->location_is('/device/TEST');
 
 		$t->post_ok('/device/TEST/validated')
 			->status_is(303)
-			->header_like( Location => qr!/device/TEST$! );
+			->location_is('/device/TEST');
 
 		$t->post_ok('/device/TEST/validated')
 			->status_is(204)
@@ -734,7 +734,7 @@ subtest 'Device location' => sub {
 
 	$t->post_ok( '/device/TEST/location',
 		json => { rack_id => $rack_id, rack_unit => 3 } )->status_is(303)
-		->header_like( Location => qr!/device/TEST/location$! );
+		->location_is('/device/TEST/location');
 
 	$t->delete_ok('/device/TEST/location')->status_is(204, 'can delete device location');
 


### PR DESCRIPTION


and fix tests to check exact header content