### PR TITLE
do not require user_account.name to be unique

### DIFF
--- a/json-schema/input.yaml
+++ b/json-schema/input.yaml
@@ -411,8 +411,8 @@ definitions:
       - role
     properties:
       user:
-        description: user name or email
         type: string
+        format: email
       role:
         type: string
         enum:

--- a/lib/Conch/Controller/Login.pm
+++ b/lib/Conch/Controller/Login.pm
@@ -92,11 +92,11 @@ sub authenticate ($c) {
 	my $url = $c->req->url->to_abs;
 	if ($url->userinfo) {
 
-		$c->log->debug('attempting to authenticate with user:password...');
-		my ($name, $password) = ($url->username, $url->password);
+		$c->log->debug('attempting to authenticate with email:password...');
+		my ($email, $password) = ($url->username, $url->password);
 
-		$c->log->debug('looking up user by name ' . $name . '...');
-		my $user = $c->db_user_accounts->lookup_by_name($name);
+		$c->log->debug('looking up user by email ' . $email . '...');
+		my $user = $c->db_user_accounts->lookup_by_email($email);
 
 		unless ($user) {
 			$c->log->debug('basic auth failed: user not found');
@@ -115,7 +115,7 @@ sub authenticate ($c) {
 		}
 
 		# pass through to whatever action the user was trying to reach
-		$c->log->debug('user ' . $user->name . ' accepted using basic auth');
+		$c->log->debug('user '.$user->name.' ('.$user->email.') accepted using basic auth');
 		$c->stash(user_id => $user->id);
 		$c->stash(user    => $user);
 		return 1;

--- a/lib/Conch/Controller/User.pm
+++ b/lib/Conch/Controller/User.pm
@@ -353,8 +353,7 @@ sub create ($c) {
 	# this would cause horrible clashes with our /user routes!
 	return $c->status(400, { error => 'user name "me" is prohibited', }) if $name eq 'me';
 
-	if (my $user = $c->db_user_accounts->lookup_by_email($email)
-			|| $c->db_user_accounts->lookup_by_name($name)) {
+	if (my $user = $c->db_user_accounts->lookup_by_email($email)) {
 		return $c->status(409, {
 			error => 'duplicate user found',
 			user => { map { $_ => $user->$_ } qw(id email name created deactivated) },

--- a/lib/Conch/Controller/WorkspaceUser.pm
+++ b/lib/Conch/Controller/WorkspaceUser.pm
@@ -70,10 +70,8 @@ sub add_user ($c) {
 	my $input = $c->validate_input('WorkspaceAddUser');
 	return if not $input;
 
-	# TODO: it would be nice to be sure of which type of data we were being passed here, so we
-	# don't have to look up by multiple columns.
 	my $rs = $c->db_user_accounts;
-	my $user = $rs->lookup_by_email($input->{user}) || $rs->lookup_by_name($input->{user});
+	my $user = $rs->lookup_by_email($input->{user});
 
 	return $c->status(404, { error => "user $input->{user} not found" })
 		unless $user;

--- a/lib/Conch/DB/ResultSet/UserAccount.pm
+++ b/lib/Conch/DB/ResultSet/UserAccount.pm
@@ -68,15 +68,6 @@ sub lookup_by_email {
     )->one_row;
 }
 
-=head2 lookup_by_name
-
-=cut
-
-sub lookup_by_name {
-    my ($self, $name) = @_;
-    $self->active->find({ name => $name });
-}
-
 1;
 __END__
 

--- a/sql/migrations/0063-user_account-name-not-unique.sql
+++ b/sql/migrations/0063-user_account-name-not-unique.sql
@@ -1,0 +1,6 @@
+SELECT run_migration(63, $$
+
+    drop index user_account_name_key;
+    create index user_account_name_key on user_account (name);
+
+$$);

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1409,7 +1409,7 @@ CREATE UNIQUE INDEX user_account_email_key ON public.user_account USING btree (e
 -- Name: user_account_name_key; Type: INDEX; Schema: public; Owner: conch
 --
 
-CREATE UNIQUE INDEX user_account_name_key ON public.user_account USING btree (name) WHERE (deactivated IS NULL);
+CREATE INDEX user_account_name_key ON public.user_account USING btree (name);
 
 
 --

--- a/t/integration/00_only_1_user_loaded.t
+++ b/t/integration/00_only_1_user_loaded.t
@@ -843,22 +843,6 @@ subtest 'modify another user' => sub {
 
 	$t->post_ok(
 		'/user?send_mail=0',
-		json => { name => 'conch', email => 'foo@conch.joyent.us' })
-		->status_is(409, 'cannot create user with a duplicate name')
-		->json_schema_is('UserError')
-		->json_is({
-				error => 'duplicate user found',
-				user => {
-					id => $conch_user->id,
-					email => 'conch@conch.joyent.us',
-					name => 'conch',
-					created => $conch_user->created,
-					deactivated => undef,
-				}
-			});
-
-	$t->post_ok(
-		'/user?send_mail=0',
 		json => { name => 'foo', email => 'conch@conch.joyent.us' })
 		->status_is(409, 'cannot create user with a duplicate email address')
 		->json_schema_is('UserError')
@@ -941,7 +925,7 @@ subtest 'modify another user' => sub {
 	$t2->get_ok('/me')->status_is(204);
 
 	my $t3 = Test::Conch->new(pg => $t->pg);	# we will only use this $mojo for basic auth
-	$t3->get_ok($t3->ua->server->url->userinfo('foo:123')->path('/me'))
+	$t3->get_ok($t3->ua->server->url->userinfo('foo@conch.joyent.us:123')->path('/me'))
 		->status_is(204, 'user can also use the app with basic auth');
 
 	$t->post_ok("/user/$new_user_id/revoke")
@@ -1012,7 +996,7 @@ subtest 'modify another user' => sub {
 		->status_is(401, 'cannot log in with the old password')
 		->json_is({ 'error' => 'unauthorized' });
 
-	$t3->get_ok($t3->ua->server->url->userinfo('foo:' . $insecure_password)->path('/me'))
+	$t3->get_ok($t3->ua->server->url->userinfo('foo@conch.joyent.us:' . $insecure_password)->path('/me'))
 		->status_is(401, 'user cannot use new password with basic auth')
 		->location_is('/user/me/password')
 		->json_is({ error => 'unauthorized' });
@@ -1075,7 +1059,7 @@ subtest 'modify another user' => sub {
 		->status_is(204, 'user authenticate with JWT again after his password is changed');
 	is($t2->tx->res->body, '', '...with no extra response messages');
 
-	$t3->get_ok($t3->ua->server->url->userinfo('foo:' . $secure_password)->path('/me'))
+	$t3->get_ok($t3->ua->server->url->userinfo('foo@conch.joyent.us:' . $secure_password)->path('/me'))
 		->status_is(204, 'after user fixes his password, he can use basic auth again');
 
 


### PR DESCRIPTION
no longer using name as an input identifier or authentication.
Note this will break any current users of basic auth whose 'name' has been changed to not equal 
their 'email', but there are few of these users, and we don't expect basic auth to be much in
use anymore.

closes #496.