### PR TITLE
re-add Mozilla::CA to resolve build issues on some platforms

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -28,6 +28,7 @@ requires 'Mojo::JWT';
 requires 'Mojolicious::Plugin::Bcrypt';
 requires 'Mojolicious::Plugin::Util::RandomString';
 requires 'Mojolicious::Plugin::NYTProf';
+requires 'Mozilla::CA'; # not used directly, but IO::Socket::SSL sometimes demands it
 requires 'IO::Socket::SSL';
 
 requires 'Moo';

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -2191,6 +2191,14 @@ DISTRIBUTIONS
       Sub::Defer 2.003001
       Sub::Quote 2.003001
       perl 5.006
+  Mozilla-CA-20180117
+    pathname: A/AB/ABH/Mozilla-CA-20180117.tar.gz
+    provides:
+      Mozilla::CA 20180117
+    requirements:
+      ExtUtils::MakeMaker 0
+      Test 0
+      perl 5.006
   Net-SSLeay-1.85
     pathname: M/MI/MIKEM/Net-SSLeay-1.85.tar.gz
     provides:


### PR DESCRIPTION
IO::Socket::SSL adds a dynamic prereq on Mozilla::CA if Net::SSLeay is not installed, so
whether this dependency happens depends on the order of installation which we cannot control.