### PR TITLE
fix problems with rollbar payloads

### DIFF
--- a/lib/Conch/Plugin/Logging.pm
+++ b/lib/Conch/Plugin/Logging.pm
@@ -45,15 +45,14 @@ sub register ($self, $app, $conf) {
 
 	if ($app->feature('rollbar')) {
 		$app->hook(
-			before_render => sub {
-				my ( $c, $args ) = @_;
+			before_render => sub ($c, $args) {
 				my $template = $args->{template};
-				return if not $template;
-				if ( $template =~ /exception/ ) {
-					my $exception = $c->stash('exception') // $args->{exception};
-					$exception->verbose(1);
 
-					$app->send_exception_to_rollbar($exception);
+				if (my $exception = $c->stash('exception')
+						or ($template and $template =~ /exception/)) {
+					$exception //= $args->{exception};
+					$exception->verbose(1);
+					$c->send_exception_to_rollbar($exception);
 				}
 			}
 		);


### PR DESCRIPTION
- request info was not collected, due to using $app not $c
- using $app in the handler also created a memory leak
- fix broken extraction of stack frame data
- use "platform" as documented
- generate a custom signature to prevent unrelated exceptions from being grouped together
- added request headers, query params, POST body, stash variables
- added request id (for correlating with logs), uuid

closes #394.