### PR TITLE
properly share db connections

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -63,6 +63,7 @@ on 'test' => sub {
     requires 'Test::Fatal';
     requires 'Test::Deep';
     requires 'Path::Tiny';
+    requires 'Test::Memory::Cycle';
 };
 
 # note: DBD::Pg will fail to install on macos 10.13.x because Apple is

--- a/cpanfile
+++ b/cpanfile
@@ -26,7 +26,7 @@ requires 'Mojo::Pg';
 requires 'Mojo::Server::PSGI';
 requires 'Mojo::JWT';
 requires 'Mojolicious::Plugin::Bcrypt';
-requires 'Mojolicious::Plugin::Util::RandomString';
+requires 'Mojolicious::Plugin::Util::RandomString', '0.07'; # memory leak: https://rt.cpan.org/Ticket/Display.html?id=125981
 requires 'Mojolicious::Plugin::NYTProf';
 requires 'Mozilla::CA'; # not used directly, but IO::Socket::SSL sometimes demands it
 requires 'IO::Socket::SSL';

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -1336,6 +1336,14 @@ DISTRIBUTIONS
       perl 5.008004
       strict 0
       warnings 0
+  Devel-Cycle-1.12
+    pathname: L/LD/LDS/Devel-Cycle-1.12.tar.gz
+    provides:
+      Devel::Cycle 1.12
+    requirements:
+      ExtUtils::MakeMaker 0
+      Scalar::Util 0
+      Test::More 0
   Devel-GlobalDestruction-0.14
     pathname: H/HA/HAARG/Devel-GlobalDestruction-0.14.tar.gz
     provides:
@@ -2151,14 +2159,15 @@ DISTRIBUTIONS
       Test::More 0
       Time::HiRes 1.9719
       perl 5.010001
-  Mojolicious-Plugin-Util-RandomString-0.06
-    pathname: A/AK/AKRON/Mojolicious-Plugin-Util-RandomString-0.06.tar.gz
+  Mojolicious-Plugin-Util-RandomString-0.07
+    pathname: A/AK/AKRON/Mojolicious-Plugin-Util-RandomString-0.07.tar.gz
     provides:
-      Mojolicious::Plugin::Util::RandomString 0.06
+      Mojolicious::Plugin::Util::RandomString 0.07
     requirements:
       ExtUtils::MakeMaker 0
       Mojolicious 3.93
       Session::Token 1.502
+      Test::Memory::Cycle 1.06
       Test::More 0
       perl 5.010001
   Moo-2.003004
@@ -2266,6 +2275,13 @@ DISTRIBUTIONS
       XSLoader 0
       strict 0
       warnings 0
+  PadWalker-2.3
+    pathname: R/RO/ROBIN/PadWalker-2.3.tar.gz
+    provides:
+      PadWalker 2.3
+    requirements:
+      ExtUtils::MakeMaker 0
+      perl 5.008001
   Params-Classify-0.015
     pathname: Z/ZE/ZEFRAM/Params-Classify-0.015.tar.gz
     provides:
@@ -2747,6 +2763,19 @@ DISTRIBUTIONS
       Try::Tiny 0.07
       strict 0
       warnings 0
+  Test-Memory-Cycle-1.06
+    pathname: P/PE/PETDANCE/Test-Memory-Cycle-1.06.tar.gz
+    provides:
+      Test::Memory::Cycle 1.06
+    requirements:
+      Devel::Cycle 1.07
+      ExtUtils::MakeMaker 0
+      Getopt::Long 0
+      PadWalker 0
+      Test::Builder 0
+      Test::Builder::Tester 0
+      Test::More 0
+      Test::Simple 0.62
   Test-Number-Delta-1.06
     pathname: D/DA/DAGOLDEN/Test-Number-Delta-1.06.tar.gz
     provides:

--- a/lib/Conch/Plugin/Logging.pm
+++ b/lib/Conch/Plugin/Logging.pm
@@ -110,7 +110,7 @@ sub register ($self, $app, $conf) {
 			}
 		}
 
-		if ($app->feature('audit')) {
+		if ($c->feature('audit')) {
 			$log->{req}->{body} = $c->req->body;
 			unless ($c->req->url =~ /login/) {
 				$log->{res}->{body} = $c->res->body;

--- a/lib/Test/Conch.pm
+++ b/lib/Test/Conch.pm
@@ -100,6 +100,14 @@ sub new {
     return $self;
 }
 
+sub DESTROY {
+    my $self = shift;
+
+    # ensure that a new Test::Conch instance creates a brand new Mojo::Pg connection (with a
+    # possibly-different dsn) rather than using the old one to a now-dead postgres instance
+    Conch::Pg->DESTROY;
+}
+
 =head2 location_is
 
 Stolen from Test::Mojo's examples. I don't know why this isn't just part of the interface!

--- a/t/database.t
+++ b/t/database.t
@@ -35,6 +35,11 @@ subtest 'read-only database handle' => sub {
         'cannot create a user using the read-only db handle',
     );
 
+    # clear the transaction, because we have AutoCommit => 0 for this connection.
+    # (as an alternative, we can turn the ReadOnly flag off, and use the read-only
+    # credentials to connect to the server.. but it is better to have this safety here.)
+    $t->app->ro_schema->txn_rollback;
+
     is(
         exception {
             $t->app->db_ro_user_accounts->find($user1->id);
@@ -48,6 +53,30 @@ subtest 'read-only database handle' => sub {
     });
 };
 
+subtest 'transactions' => sub {
+    my $t = Test::Conch->new;
+
+    my $user_count = $t->app->db_user_accounts->count;
+
+    like(
+        exception {
+            $t->app->schema->txn_do(sub {
+                # get a "new" connection from the app here, rather than using the same $schema...
+                $t->app->db_user_accounts->create({
+                    name => 'another new user',
+                    email => 'test2@conch.joyent.us',
+                    password => 'whargarbl',
+                });
+                is($t->app->db_user_accounts->count, $user_count + 1, 'another user was created');
+                die 'oops, belay that order';
+            });
+        },
+        qr/oops, belay that order/,
+        'caught exception from inside the transaction',
+    );
+
+    is($t->app->db_user_accounts->count, $user_count, 'the new user was rolled back');
+};
 
 done_testing;
 # vim: set ts=4 sts=4 sw=4 et :

--- a/t/database.t
+++ b/t/database.t
@@ -3,7 +3,8 @@ use warnings;
 use Test::More;
 use Test::Conch;
 use Test::Fatal;
-use Test::Warnings;
+use Test::Warnings ':all';
+use Test::Memory::Cycle;
 
 subtest 'read-only database handle' => sub {
     my $t = Test::Conch->new;
@@ -41,6 +42,10 @@ subtest 'read-only database handle' => sub {
         undef,
         'no exception querying for a user using the read-only db handle',
     );
+
+    warnings(sub {
+        memory_cycle_ok($t, 'no leaks in the Test::Conch object');
+    });
 };
 
 

--- a/t/integration/00_only_1_user_loaded.t
+++ b/t/integration/00_only_1_user_loaded.t
@@ -5,9 +5,10 @@ use utf8;
 use Test::More;
 use Data::UUID;
 use Path::Tiny;
-use Test::Warnings;
+use Test::Warnings ':all';
 use Test::Conch;
 use Test::Deep;
+use Test::Memory::Cycle;
 
 my $uuid = Data::UUID->new;
 
@@ -1116,6 +1117,14 @@ subtest 'modify another user' => sub {
 	my $second_new_user = $t->app->db_user_accounts->find($second_new_user_id);
 	is($second_new_user->email, $new_user->email, '...but the email addresses are the same');
 	is($second_new_user->name, $new_user->name, '...but the names are the same');
+
+	warnings(sub {
+		memory_cycle_ok($t2, 'no leaks in the Test::Conch object');
+	});
 };
+
+warnings(sub {
+	memory_cycle_ok($t, 'no leaks in the Test::Conch object');
+});
 
 done_testing();


### PR DESCRIPTION
A single DBIx::Class::Schema object performs its own connection management (e.g. reconnecting
as needed, managing savepoints and performing rollbacks), so the same object must be used
consistently for this all to work. Therefore we must cache the object in the application and
hand out the same object from the handler method, rather than creating new ones on every call
to the handler.