### PR TITLE
pass through the main logger to validations, rather than building a new one

### DIFF
--- a/docs/validation/BaseValidation.md
+++ b/docs/validation/BaseValidation.md
@@ -54,7 +54,7 @@ expected results.
 
 ### Log
 
-Logger for use in, well, logging. Defaults to a Conch::Log instance
+Required.
 
 ### Validation\_Results
 

--- a/lib/Conch/Model/Validation.pm
+++ b/lib/Conch/Model/Validation.pm
@@ -19,14 +19,14 @@ use Conch::Model::ValidationResult;
 my $attrs = [qw( id name version description module created updated)];
 has $attrs;
 
-use Conch::Log;
-has 'log' => sub { return Conch::Log->new };
+has 'log' => sub { Carp::croak('missing logger') };
 
 =head2 new
 
 Create a new Validation.
 	
 	Conch::Model::Validation->new (
+		log         => $logger,      # main logger object from mojo app or controller
 		name        => 'example_validation',
 		version     => 1,
 		description => 'Example Validation',
@@ -38,7 +38,7 @@ All unspecified fields will be 'undef'.
 =cut
 
 sub new ( $class, %args ) {
-	$class->SUPER::new( %args{@$attrs} );
+	$class->SUPER::new( %args{@$attrs, 'log'} );
 }
 
 =head2 TO_JSON
@@ -187,6 +187,7 @@ sub build_device_validation ( $self, $device, $hardware_product,
 	};
 
 	my $validation = $module->new(
+		log              => $self->log,
 		device           => $device,
 		device_location  => $device_location,
 		device_settings  => $device_settings,
@@ -230,7 +231,6 @@ sub run_validation_for_device ( $self, $device, $data ) {
 		$self->build_device_validation( $device, $hw_product, $location,
 		$settings );
 
-	$validation->log($self->log);
 	$validation->run($data);
 	return $validation->validation_results;
 }

--- a/lib/Conch/Model/ValidationPlan.pm
+++ b/lib/Conch/Model/ValidationPlan.pm
@@ -15,8 +15,7 @@ use Conch::Pg;
 my $attrs = [qw( id name description created )];
 has $attrs;
 
-use Conch::Log;
-has 'log' => sub { return Conch::Log->new() };
+has 'log' => sub { Carp::croak('missing logger') };
 
 =head2 TO_JSON
 
@@ -210,13 +209,14 @@ sub run_validations ( $self, $device, $data ) {
 
 	my @results;
 	for my $validation ( $self->validations->@* ) {
+
+		$validation->log($self->log);
 		my $validator = $validation->build_device_validation(
 			$device,
 			$hw_product,
 			$location,
 			$settings
 		);
-		$validator->log($self->log);
 
 		$validator->run($data);
 		push @results, $validator->validation_results->@*;

--- a/lib/Conch/Validation.pm
+++ b/lib/Conch/Validation.pm
@@ -64,14 +64,13 @@ use JSON::Validator;
 use Try::Tiny;
 
 use Conch::ValidationError;
-use Conch::Log;
 
 has 'name';
 has 'version';
 has 'description';
 has 'category';
 
-has 'log' => sub { return Conch::Log->new() };
+has 'log' => sub { Carp::croak('missing logger') };
 
 =head2 validation_results
 
@@ -130,12 +129,13 @@ list of attributes and values (Attributes are 'message', 'name', 'category',
 sub new ( $class, %attrs ) {
 
 	bless {
-		_device                    => $attrs{device},
-		_device_location           => $attrs{device_location},
-		_hardware_product          => $attrs{hardware_product},
-		_device_settings           => $attrs{device_settings} || {},
-		_validation_result_builder => $attrs{result_builder} || sub { return {@_} },
-		validation_results         => []
+		_device                    => delete $attrs{device},
+		_device_location           => delete $attrs{device_location},
+		_hardware_product          => delete $attrs{hardware_product},
+		_device_settings           => delete $attrs{device_settings} || {},
+		_validation_result_builder => delete $attrs{result_builder} || sub { return {@_} },
+		validation_results         => [],
+		%attrs,
 	}, $class;
 
 }


### PR DESCRIPTION
As discussed, this makes it easier to swap the logger object out later.