### PR TITLE
add a new feature flag that caused the API to log to stderr, not the log directory

### DIFF
--- a/conch.conf.dist
+++ b/conch.conf.dist
@@ -24,6 +24,7 @@
 		audit          => 0,
 		rollbar        => 0,
 		nytprof        => 0,
+		log_to_stderr  => 0,
 
 		# Stop issuing 'conch' cookies. This does not prevent existing conch
 		# cookies from being validated (as long as the secrets are the same).

--- a/lib/Conch/Role/MojoLog.pm
+++ b/lib/Conch/Role/MojoLog.pm
@@ -34,11 +34,15 @@ has log => sub {
 	my $home = $c->app->home;
 	my $mode = $c->app->mode;
 
-    return Conch::Log->new(
-        request_id => $c->req->request_id,
-		path       => $home->child('log', "$mode.log"),
+	my %args = (
+		request_id => $c->req->request_id,
 		level      => 'debug',
-    );
+	);
+	if (not $c->feature('log_to_stderr')) {
+		$args{path} = $home->child('log', "$mode.log"),
+	}
+
+    return Conch::Log->new(%args);
 };
 
 1;


### PR DESCRIPTION
This feature is most useful for Docker, where logging to STDERR allows me to catch those logs easily and feed them into Docker's logging infrastructure.

