### PR TITLE
ensure that postgres connects using client_encoding = UTF-8

### DIFF
--- a/conch.conf.dist
+++ b/conch.conf.dist
@@ -11,7 +11,7 @@
 	},
 
 	# URI format is postgresql://[user[:password]@][netloc][:port][/dbname][?param1=value1&...]
-	pg => 'postgresql://conch@/conch',
+	pg => 'postgresql://conch@/conch?client_encoding=UTF-8',
 
 	# Rollbar access token. Must be a token with write permissions
 	# rollbar_access_token => '00000000000000000000000000000000',

--- a/lib/Test/ConchTmpDB.pm
+++ b/lib/Test/ConchTmpDB.pm
@@ -30,7 +30,7 @@ TODO: move this to Test::Conch?
 sub mk_tmp_db {
 	my $class = shift // __PACKAGE__;
 
-	my $pgtmp = Test::PostgreSQL->new();
+	my $pgtmp = Test::PostgreSQL->new(pg_config => 'client_encoding=UTF-8');
 	die $Test::PostgreSQL::errstr if not $pgtmp;
 
 	my $schema = $class->schema($pgtmp);


### PR DESCRIPTION
locale settings on individual deployment machines may otherwise cause other encodings to be used.
see:
https://metacpan.org/pod/DBD::Pg#Encoding
https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-CLIENT-ENCODING

Deployment must be accompanied by joyent/buildops-infra#60.