### PR TITLE
a collection of small fixes

### DIFF
--- a/json-schema/input.yaml
+++ b/json-schema/input.yaml
@@ -1,5 +1,8 @@
 ---
 definitions:
+  non_empty_string:
+    type: string
+    minLength: 1
   uuid:
     type: string
     pattern: "^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"
@@ -540,9 +543,9 @@ definitions:
       - password
     properties:
       user:
-        type: string
+        $ref: /definitions/non_empty_string
       password:
-        type: string
+        $ref: /definitions/non_empty_string
   UserPassword:
     type: object
     additionalProperties: false
@@ -613,11 +616,11 @@ definitions:
       - name
     properties:
       name:
-        type: string
+        $ref: /definitions/non_empty_string
       description:
         anyOf:
           - type: 'null'
-          - type: string
+          - $ref: /definitions/non_empty_string
   WorkspaceAddUser:
     type: object
     additionalProperties: false
@@ -652,6 +655,7 @@ definitions:
         $ref: /definitions/uuid
   WorkspaceRoomReplace:
     type: array
+    uniqueItems: true
     items:
       description: datacenter room ids
       $ref: /definitions/uuid

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -64,8 +64,8 @@ definitions:
         anyOf:
           - $ref: /definitions/device_asset_tag
           - type: 'null'
-        description: this field is deprecated and will no longer be present.
       boot_phase:
+        description: this field is deprecated and will no longer be present.
         anyOf:
           - type: string
           - type: 'null'
@@ -76,6 +76,11 @@ definitions:
         $ref: /definitions/uuid
       health:
         type: string
+        enum:
+          - PASS
+          - FAIL
+          - UNKNOWN
+          - ERROR
       hostname:
         anyOf:
           - type: string
@@ -129,6 +134,7 @@ definitions:
           - type: 'null'
       nics: # NOTE: see also DeviceNic
         type: array
+        uniqueItems: true
         items:
           type: object
           additionalProperties: false
@@ -173,6 +179,7 @@ definitions:
           - type: 'null'
   Devices:
     type: array
+    uniqueItems: true
     items:
       $ref: "#/definitions/Device"
   Device:
@@ -194,13 +201,14 @@ definitions:
       - updated
       - uptime_since
       - validated
+      - triton_setup
     properties:
       asset_tag:
         anyOf:
           - $ref: /definitions/device_asset_tag
           - type: 'null'
-        deprecated: this field is deprecated and will no longer be present.
       boot_phase:
+        description: this field is deprecated and will no longer be present.
         anyOf:
           - type: string
           - type: 'null'
@@ -211,6 +219,11 @@ definitions:
         $ref: /definitions/uuid
       health:
         type: string
+        enum:
+          - PASS
+          - FAIL
+          - UNKNOWN
+          - ERROR
       hostname:
         anyOf:
           - type: string
@@ -263,6 +276,7 @@ definitions:
 
   DeviceNics:
     type: array
+    uniqueItems: true
     items:
       $ref: /definitions/DeviceNic
   DeviceNic:
@@ -407,6 +421,7 @@ definitions:
             description: Hardware product vendor name
   HardwareProducts:
     type: array
+    uniqueItems: true
     items:
       $ref: "#/definitions/HardwareProduct"
   HardwareProduct:
@@ -610,6 +625,7 @@ definitions:
     patternProperties:
       ^[\w-]+$:   # key is a room az name
         type: array
+        uniqueItems: true
         items:
           type: object
           additionalProperties: false
@@ -657,6 +673,7 @@ definitions:
         type: string
       slots:
         type: array
+        uniqueItems: true
         items:
           type: object
           additionalProperties: false
@@ -737,6 +754,7 @@ definitions:
         format: date-time
   ValidationPlans:
     type: array
+    uniqueItems: true
     items:
       $ref: "#/definitions/ValidationPlan"
   ValidationPlan:
@@ -804,6 +822,7 @@ definitions:
         $ref: /definitions/uuid
   ValidationResults:
     type: array
+    uniqueItems: true
     items:
       $ref: /definitions/ValidationResult
   ValidationState:
@@ -842,6 +861,7 @@ definitions:
         $ref: /definitions/uuid
   ValidationStatesWithResults:
     type: array
+    uniqueItems: true
     items:
       $ref: "#/definitions/ValidationStateWithResults"
   ValidationStateWithResults:
@@ -871,6 +891,7 @@ definitions:
         $ref: /definitions/device_id
       results:
         type: array
+        uniqueItems: true
         items:
           $ref: "#/definitions/ValidationResult"
       status:
@@ -885,6 +906,7 @@ definitions:
         $ref: /definitions/uuid
   WorkspaceRelays:
     type: array
+    uniqueItems: true
     items:
       $ref: "#/definitions/WorkspaceRelay"
   WorkspaceRelay:
@@ -912,6 +934,7 @@ definitions:
         description: >
           Array of devices that have reported through this relay device
         type: array
+        uniqueItems: true
         items:
           $ref: "#/definitions/Device"
       id:
@@ -933,12 +956,16 @@ definitions:
           room_name:
             type: string
       ssh_port:
-        type: number
+        anyOf:
+          - type: integer
+          - type: 'null'
       updated:
         type: string
         format: date-time
       version:
-        type: string
+        anyOf:
+          - type: string
+          - type: 'null'
   WorkspaceAndRole:
     type: object
     additionalProperties: false
@@ -972,10 +999,12 @@ definitions:
         $ref: /definitions/uuid
   WorkspacesAndRoles:
     type: array
+    uniqueItems: true
     items:
       $ref: /definitions/WorkspaceAndRole
   WorkspaceUsers:
     type: array
+    uniqueItems: true
     items:
       type: object
       additionalProperties: false
@@ -999,6 +1028,7 @@ definitions:
           $ref: /definitions/uuid
   DatacenterRoomsDetailed:
     type: array
+    uniqueItems: true
     items:
       $ref: /definitions/DatacenterRoomDetailed
   DatacenterRoomDetailed:
@@ -1034,6 +1064,7 @@ definitions:
         format: date-time
   Rooms:
     type: array
+    uniqueItems: true
     items:
       $ref: "#/definitions/Room"
   Room:
@@ -1059,6 +1090,7 @@ definitions:
           - type: 'null'
   Relays:
     type: array
+    uniqueItems: true
     items:
       $ref: "#/definitions/Relay"
   Relay:
@@ -1088,7 +1120,7 @@ definitions:
           - type: 'null'
       ssh_port:
         anyOf:
-          - type: number
+          - type: integer
           - type: 'null'
       updated:
         type: string
@@ -1177,6 +1209,7 @@ definitions:
         anyOf:
           - type: 'null'
           - type: array
+            uniqueItems: true
             items:
               $ref: /definitions/uuid
   WorkflowStatus:
@@ -1202,6 +1235,7 @@ definitions:
         $ref: /definitions/uuid
   Workflows:
     type: array
+    uniqueItems: true
     items:
       $ref: "#/definitions/Workflow"
   WorkflowStepStatus:
@@ -1247,6 +1281,7 @@ definitions:
         $ref: /definitions/uuid
   Racks:
     type: array
+    uniqueItems: true
     items:
       $ref: "#/definitions/Rack"
   Rack:
@@ -1308,10 +1343,12 @@ definitions:
         format: date-time
   RackRoles:
     type: array
+    uniqueItems: true
     items:
       $ref: "#/definitions/RackRole"
   RackLayouts:
     type: array
+    uniqueItems: true
     items:
       $ref: "#/definitions/RackLayout"
   RackLayout:
@@ -1412,10 +1449,12 @@ definitions:
         type: boolean
       workspaces:
         type: array
+        uniqueItems: true
         items:
           $ref: /definitions/WorkspaceAndRole
   UsersDetailed:
     type: array
+    uniqueItems: true
     items:
        $ref: /definitions/UserDetailed
   HardwareVendor:
@@ -1439,6 +1478,7 @@ definitions:
         format: date-time
   HardwareVendors:
     type: array
+    uniqueItems: true
     items:
       $ref: /definitions/HardwareVendor
   DeviceTotals:
@@ -1453,6 +1493,7 @@ definitions:
     patternProperties:
       .:
         type: array
+        uniqueItems: true
         items:
           type: object
           additionalProperties: false

--- a/lib/Conch.pm
+++ b/lib/Conch.pm
@@ -148,8 +148,6 @@ sub startup {
 		}
 	);
 
-	# note: we have a leak originating in this plugin.
-	# see https://rt.cpan.org/Ticket/Display.html?id=125981
 	$self->plugin('Util::RandomString' => {
 		alphabet => '2345679bdfhmnprtFGHJLMNPRT*#!@^-_+=',
 		length => 30

--- a/lib/Conch/Controller/DeviceReport.pm
+++ b/lib/Conch/Controller/DeviceReport.pm
@@ -137,6 +137,7 @@ sub process ($c) {
 		uptime_since        => $uptime,
 		hostname            => $unserialized_report->{os}{hostname},
 		updated             => \'NOW()',
+		deactivated         => undef,
 	});
 
 	$c->log->debug("Creating device report");

--- a/lib/Conch/Controller/User.pm
+++ b/lib/Conch/Controller/User.pm
@@ -313,7 +313,7 @@ sub update ($c) {
 	return if not $input;
 
 	my $user = $c->stash('target_user');
-	$c->log->debug('updating user '.$user->email.': '.$c->req->body);
+	$c->log->debug('updating user '.$user->email.': '.$c->req->text);
 	$user->update($input);
 
 	$user->discard_changes({ prefetch => { user_workspace_roles => 'workspace' } });

--- a/lib/Conch/DB/ResultSet/Workspace.pm
+++ b/lib/Conch/DB/ResultSet/Workspace.pm
@@ -35,7 +35,7 @@ sub workspaces_beneath {
     my ($self, $workspace_id) = @_;
 
     Carp::croak('missing workspace_id') if not defined $workspace_id;
-    Carp::croak('resultset should not have conditions') if $self->{attrs}{cond};
+    Carp::croak('resultset should not have conditions') if $self->{cond};
 
     my $query = q{
 WITH RECURSIVE workspace_children (id) AS (
@@ -66,7 +66,7 @@ sub and_workspaces_beneath {
     my ($self, $workspace_id) = @_;
 
     Carp::croak('missing workspace_id') if not defined $workspace_id;
-    Carp::croak('resultset should not have conditions') if $self->{attrs}{cond};
+    Carp::croak('resultset should not have conditions') if $self->{cond};
 
     my ($workspace_id_clause, @binds) = $self->_workspaces_subquery($workspace_id);
 
@@ -100,7 +100,7 @@ sub workspaces_above {
     my ($self, $workspace_id) = @_;
 
     Carp::croak('missing workspace_id') if not defined $workspace_id;
-    Carp::croak('resultset should not have conditions') if $self->{attrs}{cond};
+    Carp::croak('resultset should not have conditions') if $self->{cond};
 
     my $query = qq{
 WITH RECURSIVE workspace_parents (id, parent_workspace_id) AS (
@@ -132,7 +132,7 @@ sub and_workspaces_above {
     my ($self, $workspace_id) = @_;
 
     Carp::croak('missing workspace_id') if not defined $workspace_id;
-    Carp::croak('resultset should not have conditions') if $self->{attrs}{cond};
+    Carp::croak('resultset should not have conditions') if $self->{cond};
 
     my ($workspace_id_clause, @binds) = $self->_workspaces_subquery($workspace_id);
 
@@ -191,7 +191,7 @@ sub role_via_for_user {
 
     Carp::croak('missing workspace_id') if not defined $workspace_id;
     Carp::croak('missing user_id') if not defined $user_id;
-    Carp::croak('resultset should not have conditions') if $self->{attrs}{cond};
+    Carp::croak('resultset should not have conditions') if $self->{cond};
 
     # because we check for duplicate role entries when creating user_workspace_role rows,
     # we "should" only have *one* row with the highest permission in the entire heirarchy...

--- a/lib/Conch/Plugin/Logging.pm
+++ b/lib/Conch/Plugin/Logging.pm
@@ -70,7 +70,7 @@ sub register ($self, $app, $conf) {
 			$c->stash('user')->email . " (".$c->stash('user')->id.")" :
 			'NOT AUTHED';
 
-		my $req_headers = $c->tx->req->headers->to_hash;
+		my $req_headers = $c->tx->req->headers->to_hash(1);
 		for (qw(Authorization Cookie jwt_token jwt_sig)) {
 			delete $req_headers->{$_};
 		}
@@ -98,7 +98,7 @@ sub register ($self, $app, $conf) {
 			},
 		};
 
-		my $res_headers = $c->tx->res->headers->to_hash;
+		my $res_headers = $c->tx->res->headers->to_hash(1);
 		for (qw(Set-Cookie)) {
 			delete $res_headers->{$_};
 		}

--- a/lib/Conch/Plugin/Logging.pm
+++ b/lib/Conch/Plugin/Logging.pm
@@ -107,19 +107,14 @@ sub register ($self, $app, $conf) {
 			headers => $res_headers,
 		};
 
-		if($c->tx->res->code) {
-			$log->{res}->{statusCode} = $c->tx->res->code;
-
-			if($c->tx->res->code >= 400) {
-				$log->{res}->{body} = $c->res->body;
-			}
+		if ($c->res->code) {
+			$log->{res}{statusCode} = $c->res->code;
+			$log->{res}{body} = $c->res->text if $c->res->code >= 400;
 		}
 
 		if ($c->feature('audit')) {
-			$log->{req}->{body} = $c->req->body;
-			unless ($c->req->url =~ /login/) {
-				$log->{res}->{body} = $c->res->body;
-			}
+			$log->{req}{body} = $c->req->text;
+			$log->{res}{body} //= $c->res->text if $c->req->url !~ /login/;
 		}
 
 		if(my $e = $c->stash('exception')) {

--- a/lib/Conch/Plugin/Rollbar.pm
+++ b/lib/Conch/Plugin/Rollbar.pm
@@ -86,7 +86,8 @@ sub _record_exception ($c, $exception, @) {
 				method  => $c->req->method,
 				headers	=> $headers,
 				query_string => $c->req->query_params->to_string,
-				body	=> $c->req->body,
+				charset => $c->req->content->charset || $c->req->default_charset,
+				body	=> $c->req->text,
 			},
 			server => {
 				host => hostname(),

--- a/lib/Conch/Route/Validation.pm
+++ b/lib/Conch/Route/Validation.pm
@@ -54,9 +54,6 @@ sub routes {
         # POST /validation_plan/#validation_plan_id/validation
         $with_plan->post('/validation')->to('#add_validation');
 
-        # GET /validation_plan/#validation_plan_id/validation/#validation_id
-        $with_plan->get('/validation/#validation_id')->to('#get_validation');
-
         # DELETE /validation_plan/#validation_plan_id/validation/#validation_id
         $with_plan->delete('/validation/#validation_id')->to('#remove_validation');
     }

--- a/lib/Conch/Route/Workspace.pm
+++ b/lib/Conch/Route/Workspace.pm
@@ -18,14 +18,21 @@ Sets up the routes for /workspace:
     GET     /workspace/:workspace_id
     GET     /workspace/:workspace_id/child
     POST    /workspace/:workspace_id/child
+
     GET     /workspace/:workspace_id/device
     GET     /workspace/:workspace_id/device/active
+
     GET     /workspace/:workspace_id/rack
     POST    /workspace/:workspace_id/rack
     GET     /workspace/:workspace_id/rack/:rack_id
     DELETE  /workspace/:workspace_id/rack/:rack_id
+    POST    /workspace/:workspace_id/rack/:rack_id/layout
+
     GET     /workspace/:workspace_id/room
     PUT     /workspace/:workspace_id/room
+
+    GET     /workspace/:workspace_id/relay
+
     GET     /workspace/:workspace_id/user
     POST    /workspace/:workspace_id/user
     DELETE  /workspace/:workspace_id/user/#target_user_id


### PR DESCRIPTION
* fix error checking in workspace resultset methods
* always use (decoded) text, not (encoded) body when fetching request content
* log all headers, not just the first of each type
* when receiving a report for a deactivated device, reactivate it
* better json schemas for input and response validation
* remove mention of now-plugged leak
* document unmentioned routes
* remove unimplemented route