### PR TITLE
fix argument handling for commands

### DIFF
--- a/lib/Conch/Command/check_layouts.pm
+++ b/lib/Conch/Command/check_layouts.pm
@@ -21,9 +21,9 @@ has description => 'Check for occupancy conflicts in existing rack layouts';
 
 has usage => sub { shift->extract_usage };  # extracts from SYNOPSIS
 
-sub run ($self) {
+sub run ($self, @opts) {
 
-    local @ARGV = @_;
+    local @ARGV = @opts;
     my ($opt, $usage) = describe_options(
         # the descriptions aren't actually used anymore (mojo uses the synopsis instead)... but
         # the 'usage' text block can be accessed with $usage->text

--- a/lib/Conch/Command/clean_permissions.pm
+++ b/lib/Conch/Command/clean_permissions.pm
@@ -16,17 +16,16 @@ clean_permissions - clean up unnecessary user_workspace_role entries
 
 =cut
 
-use Mojo::Base 'Mojolicious::Command';
+use Mojo::Base 'Mojolicious::Command', -signatures;
 use Getopt::Long::Descriptive;
 
 has description => 'Clean up unnecessary permissions';
 
 has usage => sub { shift->extract_usage };  # extracts from SYNOPSIS
 
-sub run {
-    my $self = shift;
+sub run ($self, @opts) {
 
-    local @ARGV = @_;
+    local @ARGV = @opts;
     my ($opt, $usage) = describe_options(
         # the descriptions aren't actually used anymore (mojo uses the synopsis instead)... but
         # the 'usage' text block can be accessed with $usage->text

--- a/lib/Conch/Command/create_user.pm
+++ b/lib/Conch/Command/create_user.pm
@@ -18,7 +18,7 @@ create_user - create a new user, optionally sending an email
 =cut
 
 use open ':std', ':encoding(UTF-8)'; # force stdin, stdout, stderr into utf8
-use Mojo::Base 'Mojolicious::Command';
+use Mojo::Base 'Mojolicious::Command', -signatures;
 use Getopt::Long::Descriptive;
 use Encode ();
 
@@ -26,10 +26,9 @@ has description => 'Create a new user';
 
 has usage => sub { shift->extract_usage };  # extracts from SYNOPSIS
 
-sub run {
-    my $self = shift;
+sub run ($self, @opts) {
 
-    local @ARGV = @_;
+    local @ARGV = @opts;
 
     # decode command line arguments
     @ARGV = map { Encode::decode('UTF-8', $_) } @ARGV if grep /\P{ASCII}/, @ARGV;

--- a/lib/Conch/Command/update_validation_states.pm
+++ b/lib/Conch/Command/update_validation_states.pm
@@ -21,9 +21,9 @@ has description => 'Set validation_state.device_report_id in all historical reco
 
 has usage => sub { shift->extract_usage };  # extracts from SYNOPSIS
 
-sub run ($self) {
+sub run ($self, @opts) {
 
-    local @ARGV = @_;
+    local @ARGV = @opts;
     my ($opt, $usage) = describe_options(
         # the descriptions aren't actually used anymore (mojo uses the synopsis instead)... but
         # the 'usage' text block can be accessed with $usage->text

--- a/lib/Conch/Command/update_validations.pm
+++ b/lib/Conch/Command/update_validations.pm
@@ -22,10 +22,9 @@ has description => 'update database validation entries to match Conch::Validatio
 
 has usage => sub { shift->extract_usage };  # extracts from SYNOPSIS
 
-sub run {
-    my $self = shift;
+sub run ($self, @opts) {
 
-    local @ARGV = @_;
+    local @ARGV = @opts;
     my ($opt, $usage) = describe_options(
         # the descriptions aren't actually used anymore (mojo uses the synopsis instead)... but
         # the 'usage' text block can be accessed with $usage->text

--- a/lib/Conch/Command/workspaces.pm
+++ b/lib/Conch/Command/workspaces.pm
@@ -21,9 +21,9 @@ has description => 'View all workspaces in their heirarchical order';
 
 has usage => sub { shift->extract_usage };  # extracts from SYNOPSIS
 
-sub run ($self) {
+sub run ($self, @opts) {
 
-    local @ARGV = @_;
+    local @ARGV = @opts;
     my ($opt, $usage) = describe_options(
         # the descriptions aren't actually used anymore (mojo uses the synopsis instead)... but
         # the 'usage' text block can be accessed with $usage->text


### PR DESCRIPTION
incorrect signatures would result in death when passing an option e.g. --help