### PR TITLE
do not let Conch::Pg tear down our db connection

### DIFF
--- a/lib/Conch/Pg.pm
+++ b/lib/Conch/Pg.pm
@@ -38,6 +38,8 @@ sub new {
 	my $self = {};
 
 	$self->{pg} = Mojo::Pg->new($pg_uri);
+	$self->{pg}->options->{InactiveDestroy} = 1; # we are sharing with DBIC
+
 	bless($self, $class);
 
 	$self->_init_StrongSingleton();


### PR DESCRIPTION
This resolves spurious stderr output during global destruction, due to DBIx::Class and Mojo::Pg
both competing to tear down the db handle at the same time.