### PR TITLE
fix relocating a disk that was previously associated with a different device

### DIFF
--- a/lib/Conch/Controller/DeviceReport.pm
+++ b/lib/Conch/Controller/DeviceReport.pm
@@ -298,8 +298,9 @@ sub _record_device_configuration {
 				delete $inactive_serials{$disk};
 
 				# if disk already exists on a different device, it will be relocated
-				$device->related_resultset('device_disks')->update_or_create(
+				$c->db_device_disks->update_or_create(
 					{
+						device_id => $device->id,
 						serial_number => $disk,
 						$dr->{disks}{$disk}->%{qw(
 							slot
@@ -343,8 +344,9 @@ sub _record_device_configuration {
 				delete $inactive_macs{$mac};
 
 				# if nic already exists on a different device, it will be relocated
-				$device->related_resultset('device_nics')->update_or_create(
+				$c->db_device_nics->update_or_create(
 					{
+						device_id    => $device->id,
 						mac          => $mac,
 						iface_name   => $nic,
 						iface_driver => '',


### PR DESCRIPTION
When querying using ->related_resultset, the column(s) used in the join are part of the initial
select query (when checking for pre-existence). But we actually only want to search using the
primary key, device_disk.serial_number.

(and also fix the same issue that would occur for device_nic.)

addresses https://rollbar.com/joyent_buildops/conch/items/64/occurrences/63647743377/
(some occurrences in item 64 are actually a different error.)