### PR TITLE
filter out top-level "report_id" field when searching for duplicate reports

### DIFF
--- a/lib/Conch/Controller/DeviceReport.pm
+++ b/lib/Conch/Controller/DeviceReport.pm
@@ -123,7 +123,7 @@ sub process ($c) {
 
 			# but we can try harder to find *something* to return, in most cases...
 			$validation_state = $c->db_device_reports
-				->search({ report => \[ '= ?::jsonb', $raw_report ] })
+				->matches_jsonb($raw_report)
 				->related_resultset('validation_states')
 				->order_by({ -desc => 'validation_states.created' })
 				->rows(1)

--- a/lib/Conch/DB/Result/Device.pm
+++ b/lib/Conch/DB/Result/Device.pm
@@ -438,7 +438,7 @@ sub latest_report_matches {
     $self->self_rs
         ->latest_device_report
         ->as_subselect_rs
-        ->search({ report => \[ '= ?::jsonb', $jsonb ] })
+        ->matches_jsonb($jsonb)
         ->exists;
 }
 

--- a/lib/Conch/DB/ResultSet/DeviceReport.pm
+++ b/lib/Conch/DB/ResultSet/DeviceReport.pm
@@ -1,0 +1,49 @@
+package Conch::DB::ResultSet::DeviceReport;
+use v5.26;
+use warnings;
+use parent 'Conch::DB::ResultSet';
+
+use experimental 'signatures';
+
+=head1 NAME
+
+Conch::DB::ResultSet::DeviceReport
+
+=head1 DESCRIPTION
+
+Interface to queries involving device reports.
+
+=head1 METHODS
+
+=head2 matches_jsonb
+
+Search for reports that match the the passed-in json blob.
+
+Current fields ignored in the comparisons:
+
+    * report_id
+
+=cut
+
+sub matches_jsonb ($self, $jsonb) {
+    my $ignore_fields = join(' - ', map { "'$_'" } qw(report_id));
+
+    my $me = $self->current_source_alias;
+    $self->search(\[ "($me.report - $ignore_fields) = (?::jsonb - $ignore_fields)", $jsonb ]);
+}
+
+1;
+__END__
+
+=pod
+
+=head1 LICENSING
+
+Copyright Joyent, Inc.
+
+This Source Code Form is subject to the terms of the Mozilla Public License,
+v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+one at http://mozilla.org/MPL/2.0/.
+
+=cut
+# vim: set ts=4 sts=4 sw=4 et :


### PR DESCRIPTION
This contains the changes in #605 as it builds on top of it, so that PR must go first.