### PR TITLE
Serve Schemas from the API

### DIFF
--- a/lib/Conch/Controller/Schema.pm
+++ b/lib/Conch/Controller/Schema.pm
@@ -1,0 +1,72 @@
+package Conch::Controller::Schema;
+
+use Mojo::Base 'Mojolicious::Controller', -signatures;
+
+use Data::Visitor::Tiny qw(visit);
+use Conch::Plugin::JsonValidator;
+use Mojo::Util qw(camelize);
+
+=pod
+
+=head1 NAME
+
+Conch::Controller::Schema
+
+=head1 METHODS
+
+=head2 get
+
+Get the json-schema in JSON format.
+
+=cut
+
+sub get ($c) {
+	my $type = $c->stash('request_or_response');
+	my $name = camelize $c->stash('name');
+
+	my $validator = JSON::Validator->new();
+
+	if ( lc($type) eq 'response' ) {
+		$validator->schema(Conch::Plugin::JsonValidator::OUTPUT_SCHEMA_FILE);
+
+	}
+	elsif ( lc($type) eq 'request' ) {
+		$validator->schema(Conch::Plugin::JsonValidator::INPUT_SCHEMA_FILE);
+	}
+
+	my $schema = $validator->get("/definitions/$name");
+
+	my sub inline_ref ( $ref, $schema ) {
+		my ($other) = $ref =~ m|#?/definitions/(\w+)$|;
+		$schema->{definitions}{$other} = $validator->get($ref);
+	}
+
+	visit $schema => sub ( $key, $ref, @ ) {
+		inline_ref( $_ => $schema ) if $key eq '$ref';
+		if ( !defined $_ && $key eq "type" ) {
+			$$ref = "null";
+		}
+	};
+	$schema->{title} //= $name;
+	$schema->{'$schema'} = 'http://json-schema.org/draft-07/schema#';
+	$schema->{'$id'}     = "urn:$name.schema.json";
+
+	return $c->status( 200, $schema );
+}
+
+1;
+__END__
+
+=pod
+
+=head1 LICENSING
+
+Copyright Joyent, Inc.
+
+This Source Code Form is subject to the terms of the Mozilla Public License,
+v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+one at http://mozilla.org/MPL/2.0/.
+
+=cut
+
+# vim: set ts=4 sts=4 sw=4 et :

--- a/lib/Conch/Route.pm
+++ b/lib/Conch/Route.pm
@@ -71,6 +71,10 @@ sub all_routes (
     $root->post('/logout')->to('login#session_logout');
     $root->post('/reset_password')->to('login#reset_password');
 
+    # GET /schema/:input_or_response/:schema_name
+    $root->get( '/schema/:request_or_response/:name' =>
+				[ request_or_response => [qw(request response)] ] )->to('schema#get');
+
     # GET /workspace/:workspace/device-totals
     $root->get('/workspace/:workspace/device-totals')->to('workspace_device#device_totals');
 

--- a/misc/validate
+++ b/misc/validate
@@ -2,30 +2,39 @@
 use 5.12.1;
 use warnings;
 
-use Dir::Self;
 use Getopt::Long;
 use JSON::Validator;
 use Mojo::File qw(path);
 use Mojo::JSON qw(decode_json);
 use Pod::Usage;
 
-my $schema_file = __DIR__ . '/../json-schema/input.yaml';
-my $name        = 'DeviceReport';
+my $schema_url = 'https://conch.joyent.us/schema/request';
+my $name       = 'DeviceReport';
 
 GetOptions(
-	'file|f:s'   => \$schema_file,
-	'schema|s:s' => \$name,
-	'report|r:s' => \my $report,
-	'help|h'     => \my $help,
+	'base_url|u:s'    => \$schema_url,
+	'schema_file|f:s' => \my $schema_file,
+	'schema|s:s'      => \$name,
+	'report|r:s'      => \my $report,
+	'help|h'          => \my $help,
 );
 
 pod2usage(1) if $help;
 
 my $validator = JSON::Validator->new;
-$validator->schema($schema_file);
+
+if ($schema_file){
+    my $schema = path($schema_file)->to_abs;
+    $validator->load_and_validate_schema($schema);
+} else {
+    $validator->load_and_validate_schema("$schema_url/$name");
+}
+
 $validator->coerce(1);
 
-$report = defined $report ? path($report)->slurp : do { local $/; <> };
+$report = decode_json(
+	defined $report ? path($report)->slurp : do { local $/; <> }
+);
 
 my $schema = $validator->get($name);
 if ( my @errors = $validator->validate( $report, $schema ) ) {
@@ -43,15 +52,15 @@ validate - validate a device report (or other json document) against conch json 
 
 =head1 SYNOPSIS
 
-    validate [-s SCHEMA] [-f FILE] [-h] REPORT
+    validate [-u URL ] [-s SCHEMA] [-f FILE] [-h] REPORT
 
 =head1 OPTIONS
 
 =over 4
 
-=item <-f FILE>
+=item <-u URL>
 
-A file containing the schmema to validate against. Defaults to C<json-schema/input.yaml>.
+A URL for the JSON Schema to validate against. Defaults to C<https://conch.joyent.us/schema/request/>
 
 =item <-s SCHEMA>
 
@@ -60,6 +69,10 @@ Name of the embedded schema to validate against. Defaults to C<DeviceReport>.
 =item <-r REPORT>
 
 File name of the report data to validate against. Defaults to STDIN.
+
+=item <-f FILE>
+
+A file containing the schmema to validate against.
 
 =item <-h>
 

--- a/t/schema.t
+++ b/t/schema.t
@@ -1,0 +1,54 @@
+use strict;
+
+use Test::Conch;
+use Test::More;
+use Test::Warnings;
+use JSON::Validator;
+use Mojo::JSON qw(decode_json);
+use Mojo::File qw(path);
+
+my $json_schema =
+	JSON::Validator->new->schema('http://json-schema.org/draft-04/schema#')
+	->schema->data;
+
+my $t = Test::Conch->new;
+
+$t->get_ok('/schema/response/Login')->status_is(200)
+	->json_schema_is($json_schema)->json_is( '/type' => 'object' )
+	->json_is( '/properties/jwt_token/type' => 'string' );
+
+$t->get_ok('/schema/request/Login')->status_is(200)
+	->json_schema_is($json_schema)->json_is( '/type' => 'object' )
+	->json_is( '/properties/user/$ref'     => '/definitions/non_empty_string' )
+	->json_is( '/properties/password/$ref' => '/definitions/non_empty_string' )
+	->json_cmp_deeply('/definitions/non_empty_string' => { type => 'string', minLength => 1 } );
+
+
+$t->get_ok('/schema/request/device_report')->status_is(200)
+	->json_schema_is($json_schema);
+
+# ensure that one of the schemas can validate some data
+{
+	my $report =
+		decode_json path('t/integration/resource/passing-device-report.json')
+		->slurp;
+	my $schema = $t->get_ok('/schema/request/device_report')->tx->res->json;
+	my $jv     = JSON::Validator->new()->load_and_validate_schema($schema);
+	my @errors = $jv->validate($report);
+	is scalar @errors, 0, 'no errors';
+}
+
+$t->get_ok('/schema/request/device_report')
+        ->status_is(200)
+        ->json_schema_is($json_schema);
+
+# ensure that one of the schemas can validate some data
+{
+    my $report = decode_json path('t/integration/resource/passing-device-report.json')->slurp;
+    my $schema = $t->get_ok('/schema/request/device_report')->tx->res->json;
+    my $jv = JSON::Validator->new()->load_and_validate_schema($schema);
+    my @errors = $jv->validate($report);
+    is scalar @errors, 0, 'no errors';
+}
+
+done_testing;


### PR DESCRIPTION
Our API messages are all based around JSON Schemas. This exposes those schemas to clients and other consumers so they can validate the messaging themselves. 

Request schemas are exposed via:

    http://conch.joyent.us/schema/request/:schema_name

Response schemas are exposed via 

    http://conch.joyent.us/schema/response/:schema_name

There is currently no way to list the possible values of `:schema_name`, that's reserved for future work.

Also the `misc/validate` script has been updated to pull from the production URLs by default.