### PR TITLE
validation CRUD stuff

### DIFF
--- a/lib/Conch/Controller/DeviceValidation.pm
+++ b/lib/Conch/Controller/DeviceValidation.pm
@@ -68,8 +68,11 @@ sub validate ($c) {
         return $c->status(404 => { error => "Validation $validation_id not found" });
     }
 
-    # note, we aren't validating this data against the DeviceReport schema, although we should.
-    my $data = $c->req->json;
+    my $data = $c->validate_input('DeviceReport');
+    if (not $data) {
+        $c->log->debug('Device report input failed validation');
+        return;
+    }
 
     my @validation_results = Conch::ValidationSystem->new(
         schema => $c->ro_schema,
@@ -104,8 +107,11 @@ sub run_validation_plan ($c) {
         return $c->status(404 => { error => "Validation plan $validation_plan_id not found" });
     }
 
-    # note, we aren't validating this data against the DeviceReport schema, although we should.
-    my $data = $c->req->json;
+    my $data = $c->validate_input('DeviceReport');
+    if (not $data) {
+        $c->log->debug('Device report input failed validation');
+        return;
+    }
 
     my @validation_results = Conch::ValidationSystem->new(
         schema => $c->ro_schema,

--- a/lib/Conch/Route/Validation.pm
+++ b/lib/Conch/Route/Validation.pm
@@ -15,12 +15,12 @@ Conch::Route::Validation
 Sets up the routes for /validation and /validation_plan:
 
     GET     /validation
-    POST    /validation_plan                                                DISABLED
+    POST    /validation_plan                                                        DISABLED
     GET     /validation_plan
-    GET     /validation_plan/:validation_plan_id
-    GET     /validation_plan/:validation_plan_id/validation
-    POST    /validation_plan/:validation_plan_id/validation                 DISABLED
-    DELETE  /validation_plan/:validation_plan_id/validation/:validation_id  DISABLED
+    GET     /validation_plan/:validation_plan_id_or_name
+    GET     /validation_plan/:validation_plan_id_or_name/validation
+    POST    /validation_plan/:validation_plan_id_or_name/validation                 DISABLED
+    DELETE  /validation_plan/:validation_plan_id_or_name/validation/:validation_id  DISABLED
 
 =cut
 
@@ -42,18 +42,18 @@ sub routes {
     $vp->get('/')->to('#list');
 
     {
-        my $with_plan = $vp->under('/:validation_plan_id')->to('#find_validation_plan');
+        my $with_plan = $vp->under('/:validation_plan_id_or_name')->to('#find_validation_plan');
 
-        # GET /validation_plan/:validation_plan_id
+        # GET /validation_plan/:validation_plan_id_or_name
         $with_plan->get('/')->to('#get');
 
-        # GET /validation_plan/:validation_plan_id/validation
+        # GET /validation_plan/:validation_plan_id_or_name/validation
         $with_plan->get('/validation')->to('#list_validations');
 
-        # POST /validation_plan/:validation_plan_id/validation (DISABLED)
+        # POST /validation_plan/:validation_plan_id_or_name/validation (DISABLED)
         $with_plan->post('/validation')->to('#add_validation');
 
-        # DELETE /validation_plan/:validation_plan_id/validation/:validation_id (DISABLED)
+        # DELETE /validation_plan/:validation_plan_id_or_name/validation/:validation_id (DISABLED)
         $with_plan->delete('/validation/:validation_id')->to('#remove_validation');
     }
 }

--- a/lib/Conch/Route/Validation.pm
+++ b/lib/Conch/Route/Validation.pm
@@ -15,6 +15,8 @@ Conch::Route::Validation
 Sets up the routes for /validation and /validation_plan:
 
     GET     /validation
+    GET     /validation/:validation_id_or_name
+
     POST    /validation_plan                                                        DISABLED
     GET     /validation_plan
     GET     /validation_plan/:validation_plan_id_or_name
@@ -28,8 +30,20 @@ sub routes {
     my $class = shift;
     my $r = shift;  # secured, under /
 
+    # all these /validation routes go to the Validation controller
+    my $v = $r->any('/validation');
+    $v->to({ controller => 'validation' });
+
     # GET /validation
-    $r->get('/validation')->to('validation#list');
+    $v->get('/')->to('#list');
+
+    {
+        my $with_validation = $v->under('/:validation_id_or_name')->to('#find_validation');
+
+        # GET /validation/:validation_id_or_name
+        $with_validation->get('/')->to('#get');
+    }
+
 
     # all these /validation_plan routes go to the ValidationPlan controller
     my $vp = $r->any('/validation_plan');

--- a/t/integration/04_test_datacenter_loaded.t
+++ b/t/integration/04_test_datacenter_loaded.t
@@ -670,7 +670,14 @@ subtest 'Validations' => sub {
     $validation_plan->find_or_create_related('validation_plan_members', { validation_id => $validation_id });
 
 	subtest 'test validating a device' => sub {
+		my $good_report = path('t/integration/resource/passing-device-report.json')->slurp_utf8;
+
 		$t->post_ok("/device/TEST/validation/$validation_id", json => {})
+			->status_is(400)
+			->json_schema_is('Error');
+
+		$t->post_ok("/device/TEST/validation/$validation_id",
+				{ 'Content-Type' => 'application/json' }, $good_report)
 			->status_is(200)
 			->json_schema_is('ValidationResults')
 			->json_cmp_deeply([ superhashof({
@@ -681,6 +688,11 @@ subtest 'Validations' => sub {
 		my $validation_results = $t->tx->res->json;
 
 		$t->post_ok("/device/TEST/validation_plan/$validation_plan_id", json => {})
+			->status_is(400)
+			->json_schema_is('Error');
+
+		$t->post_ok("/device/TEST/validation_plan/$validation_plan_id",
+				{ 'Content-Type' => 'application/json' }, $good_report)
 			->status_is(200)
 			->json_schema_is('ValidationResults')
 			->json_is($validation_results);

--- a/t/integration/04_test_datacenter_loaded.t
+++ b/t/integration/04_test_datacenter_loaded.t
@@ -660,91 +660,14 @@ subtest 'Workspace devices' => sub {
 };
 
 subtest 'Validations' => sub {
-	$t->get_ok('/validation')
-		->status_is(200)
-		->json_schema_is('Validations');
+    my $validation_id = $t->app->db_validations->get_column('id')->single;
 
-	my $validation_id = $t->tx->res->json->[0]->{id};
-	my @validations = $t->tx->res->json->@*;
-
-    $t->get_ok('/validation_plan')
-        ->status_is(200)
-        ->json_schema_is('ValidationPlans')
-        ->json_cmp_deeply([
-            {
-                id => ignore,
-                name => 'Conch v1 Legacy Plan: Server',
-                description => 'Test Plan',
-                created => ignore,
-            },
-        ]);
-
-    my $validation_plan_id = $t->tx->res->json->[0]->{id};
-    my @validation_plans = $t->tx->res->json->@*;
-
-  SKIP: {
-    # while we are skipping these tests,
-    # create a new validation plan containing our validation so subsequent tests still pass...
     my $validation_plan = $t->app->db_validation_plans->create({
         name => 'my_test_plan',
         description => 'another test plan',
     });
-    $validation_plan_id = $validation_plan->id;
+    my $validation_plan_id = $validation_plan->id;
     $validation_plan->find_or_create_related('validation_plan_members', { validation_id => $validation_id });
-
-    skip 'endpoints that mutate validation plans have been disabled', 21;
-	$t->post_ok('/validation_plan', json => { name => 'my_test_plan', description => 'another test plan' })
-		->status_is(303);
-
-	$t->get_ok($t->tx->res->headers->location)
-		->status_is(200)
-		->json_schema_is('ValidationPlan');
-
-	$validation_plan_id = $t->tx->res->json->{id};
-
-	$t->get_ok('/validation_plan')
-		->status_is(200)
-		->json_schema_is('ValidationPlans')
-		->json_cmp_deeply([
-			@validation_plans,
-			{
-				id => $validation_plan_id,
-				name => 'my_test_plan',
-				description => 'another test plan',
-				created => ignore,
-			},
-		]);
-
-	my @plans = $t->tx->res->json->@*;
-
-	$t->get_ok("/validation_plan/$validation_plan_id")
-		->status_is(200)
-		->json_schema_is('ValidationPlan')
-		->json_is($plans[1]);
-
-	$t->post_ok("/validation_plan/$validation_plan_id/validation",
-			json => { id => $validation_id })
-		->status_is(204);
-
-	$t->post_ok("/validation_plan/$validation_plan_id/validation",
-			json => { id => $validation_id })
-		->status_is(204, 'adding a validation to a plan twice is not an error');
-
-	$t->post_ok('/validation_plan',
-			json => { name => 'my_test_plan', description => 'test plan' })
-		->status_is(409)
-		->json_is({ error => "A Validation Plan already exists with the name 'my_test_plan'" });
-
-	$t->get_ok('/validation_plan')
-		->status_is(200)
-		->json_schema_is('ValidationPlans')
-		->json_is(\@plans);
-
-	$t->get_ok("/validation_plan/$validation_plan_id/validation")
-		->status_is(200)
-		->json_schema_is('Validations')
-		->json_is([ $validations[0] ]);
-  } # end SKIP
 
 	subtest 'test validating a device' => sub {
 		$t->post_ok("/device/TEST/validation/$validation_id", json => {})
@@ -763,15 +686,6 @@ subtest 'Validations' => sub {
 			->json_is($validation_results);
 	};
 
-  SKIP: {
-    skip 'endpoints that mutate validation plans have been disabled', 5;
-	$t->delete_ok("/validation_plan/$validation_plan_id/validation/$validation_id")
-		->status_is(204);
-
-	$t->get_ok("/validation_plan/$validation_plan_id/validation")
-		->status_is(200)
-		->json_is('', []);
-  } # end SKIP
 
 	my $device = $t->app->db_devices->find('TEST');
 	my $device_report = $t->app->db_device_reports->rows(1)->order_by({ -desc => 'created' })->single;

--- a/t/integration/crud/validations.t
+++ b/t/integration/crud/validations.t
@@ -1,0 +1,106 @@
+use v5.26;
+use Mojo::Base -strict, -signatures;
+
+use Test::More;
+use Test::Warnings;
+use Test::Deep;
+use Test::Conch;
+
+my $t = Test::Conch->new;
+$t->load_fixture('conch_user_global_workspace');
+$t->load_validation_plans([{
+    name        => 'Conch v1 Legacy Plan: Server',
+    description => 'Test Plan',
+    validations => [ 'Conch::Validation::DeviceProductName' ],
+}]);
+
+$t->authenticate;
+
+$t->get_ok('/validation')
+    ->status_is(200)
+    ->json_schema_is('Validations');
+
+my $validation_id = $t->tx->res->json->[0]->{id};
+my @validations = $t->tx->res->json->@*;
+
+$t->get_ok('/validation_plan')
+    ->status_is(200)
+    ->json_schema_is('ValidationPlans')
+    ->json_cmp_deeply([
+        {
+            id => ignore,
+            name => 'Conch v1 Legacy Plan: Server',
+            description => 'Test Plan',
+            created => ignore,
+        },
+    ]);
+
+my $validation_plan_id = $t->tx->res->json->[0]->{id};
+my @validation_plans = $t->tx->res->json->@*;
+
+
+SKIP: {
+    skip 'endpoints that mutate validation plans have been disabled', 26;
+    $t->post_ok('/validation_plan', json => { name => 'my_test_plan', description => 'another test plan' })
+        ->status_is(303);
+
+    $t->get_ok($t->tx->res->headers->location)
+        ->status_is(200)
+        ->json_schema_is('ValidationPlan');
+
+    $validation_plan_id = $t->tx->res->json->{id};
+
+    $t->get_ok('/validation_plan')
+        ->status_is(200)
+        ->json_schema_is('ValidationPlans')
+        ->json_cmp_deeply([
+            @validation_plans,
+            {
+                id => $validation_plan_id,
+                name => 'my_test_plan',
+                description => 'another test plan',
+                created => ignore,
+            },
+        ]);
+
+    @validation_plans = $t->tx->res->json->@*;
+
+    $t->get_ok("/validation_plan/$validation_plan_id")
+        ->status_is(200)
+        ->json_schema_is('ValidationPlan')
+        ->json_is($validation_plans[1]);
+
+    $t->post_ok("/validation_plan/$validation_plan_id/validation",
+            json => { id => $validation_id })
+        ->status_is(204);
+
+    $t->post_ok("/validation_plan/$validation_plan_id/validation",
+            json => { id => $validation_id })
+        ->status_is(204, 'adding a validation to a plan twice is not an error');
+
+    $t->post_ok('/validation_plan',
+            json => { name => 'my_test_plan', description => 'test plan' })
+        ->status_is(409)
+        ->json_is({ error => "A Validation Plan already exists with the name 'my_test_plan'" });
+
+    $t->get_ok('/validation_plan')
+        ->status_is(200)
+        ->json_schema_is('ValidationPlans')
+        ->json_is(\@validation_plans);
+
+    $t->get_ok("/validation_plan/$validation_plan_id/validation")
+        ->status_is(200)
+        ->json_schema_is('Validations')
+        ->json_is([ $validations[0] ]);
+
+    $t->delete_ok("/validation_plan/$validation_plan_id/validation/$validation_id")
+        ->status_is(204);
+
+    $t->get_ok("/validation_plan/$validation_plan_id/validation")
+        ->status_is(200)
+        ->json_is('', []);
+} # end SKIP
+
+
+done_testing;
+# vim: set ts=4 sts=4 sw=4 et :

--- a/t/integration/crud/validations.t
+++ b/t/integration/crud/validations.t
@@ -38,6 +38,26 @@ $t->get_ok('/validation_plan')
 my $validation_plan_id = $t->tx->res->json->[0]->{id};
 my @validation_plans = $t->tx->res->json->@*;
 
+$t->get_ok('/validation_plan/'.$validation_plans[0]->{id})
+    ->status_is(200)
+    ->json_schema_is('ValidationPlan')
+    ->json_is($validation_plans[0]);
+
+$t->get_ok('/validation_plan/Conch v1 Legacy Plan: Server')
+    ->status_is(200)
+    ->json_schema_is('ValidationPlan')
+    ->json_is($validation_plans[0]);
+
+$t->get_ok('/validation_plan/'.$validation_plans[0]->{id}.'/validation')
+    ->status_is(200)
+    ->json_schema_is('Validations')
+    ->json_is([ $validations[0] ]);
+
+$t->get_ok('/validation_plan/Conch v1 Legacy Plan: Server/validation')
+    ->status_is(200)
+    ->json_schema_is('Validations')
+    ->json_is([ $validations[0] ]);
+
 
 SKIP: {
     skip 'endpoints that mutate validation plans have been disabled', 26;

--- a/t/integration/crud/validations.t
+++ b/t/integration/crud/validations.t
@@ -58,6 +58,16 @@ $t->get_ok('/validation_plan/Conch v1 Legacy Plan: Server/validation')
     ->json_schema_is('Validations')
     ->json_is([ $validations[0] ]);
 
+$t->get_ok('/validation/'.$validation_id)
+    ->status_is(200)
+    ->json_schema_is('Validation')
+    ->json_is($validations[0]);
+
+$t->get_ok('/validation/'.$validations[0]->{name})
+    ->status_is(200)
+    ->json_schema_is('Validation')
+    ->json_is($validations[0]);
+
 
 SKIP: {
     skip 'endpoints that mutate validation plans have been disabled', 26;


### PR DESCRIPTION
- validate device reports against their schema for one-off device validation endpoints
that is, these endpoints:
    POST /device/:device_id/validation/:validation_id
    POST /device/:device_id/validation_plan/:validation_plan_id
closes #610.

- new endpoint: GET /validation/:validation_id_or_name
closes #608.

- allow querying validation_plans by name
closes #607.