### PR TITLE
clean up device queries and permission checks

### DIFF
--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -101,7 +101,9 @@ definitions:
       state:
         type: string
       system_uuid:
-        $ref: /definitions/uuid
+        anyOf:
+          - type: 'null'
+          - $ref: /definitions/uuid
       triton_setup:
         anyOf:
           - type: string

--- a/lib/Conch/Controller/Device.pm
+++ b/lib/Conch/Controller/Device.pm
@@ -49,46 +49,36 @@ sub find_device ($c) {
         return $c->status(404, { error => 'Not found' });
     }
 
-    my $device_rs;
     if ($device_check->{has_location}) {
-        my $direct_workspace_ids_rs = $c->stash('user')
-            ->related_resultset('user_workspace_roles')
-            ->distinct
-            ->get_column('workspace_id');
+        # HEAD, GET requires 'ro'; everything else (for now) requires 'rw'
+        my $method = $c->req->method;
+        my $requires_permission =
+            (any { $method eq $_ } qw(HEAD GET)) ? 'ro'
+          : (any { $method eq $_ } qw(POST PUT DELETE)) ? 'rw'
+          : die "need handling for $method method";
 
-        # look for the device in all the user's workspaces
-        $c->log->debug("looking for device $device_id in user's workspaces");
-        my $user_workspace_device_rs = $c->db_workspaces
-            ->and_workspaces_beneath($direct_workspace_ids_rs)
-            ->associated_racks
-            ->related_resultset('device_locations')
-            ->related_resultset('device');
-
-        $device_rs = $c->db_devices->search(
-            {
-                -and => [
-                    'device.id' => $device_id,
-                    'device.id' => { -in => $user_workspace_device_rs->get_column('id')->as_query },
-                ],
-            },
-        );
+        if (not $c->db_devices->search({ 'device.id' => $device_id })
+                ->user_has_permission($c->stash('user_id'), $requires_permission)) {
+            $c->log->debug('User lacks permission to access device '.$device_id);
+            return $c->status(403, { error => 'Forbidden' });
+        }
     }
     else {
         # look for unlocated devices among those that have sent a device report proxied by a
         # relay using the user's credentials
         $c->log->debug("looking for device $device_id associated with relay reports");
 
-        $device_rs = $c->db_devices
+        my $device_rs = $c->db_devices
             ->search({ 'device.id' => $device_id })
             ->related_resultset('device_relay_connections')
             ->related_resultset('relay')
             ->related_resultset('user_relay_connections')
             ->search({ 'user_relay_connections.user_id' => $c->stash('user_id') });
-    }
 
-    if (not $device_rs->exists) {
-        $c->log->debug('User lacks permission to access device '.$device_id);
-        return $c->status(404, { error => 'Not found' });
+        if (not $device_rs->exists) {
+            $c->log->debug('User lacks permission to access device '.$device_id);
+            return $c->status(403, { error => 'Forbidden' });
+        }
     }
 
 	$c->log->debug('Found device ' . $device_id);
@@ -167,6 +157,9 @@ sub lookup_by_other_attribute ($c) {
 	return $c->status(400, { error =>
 			'ambiguous query: specified multiple keys (' . join(', ', keys %$params) . ')'
 		}) if keys %$params > 1;
+
+    # TODO: not checking if the user has permissions to view this device.
+    # need to get workspace(s) containing each device and filter them out.
 
 	my ($key) = keys %$params;
 	my $value = $params->{$key};

--- a/lib/Conch/Controller/Device.pm
+++ b/lib/Conch/Controller/Device.pm
@@ -120,10 +120,10 @@ sub get ($c) {
 
 	my $detailed_device = +{
 		$device->TO_JSON->%*,
-		latest_report_is_invalid => \($latest_report->invalid_report ? 1 : 0),
-		latest_report => $latest_report->report ? from_json($latest_report->report) : undef,
+		latest_report_is_invalid => \($latest_report && $latest_report->invalid_report ? 1 : 0),
+		latest_report => $latest_report && $latest_report->report ? from_json($latest_report->report) : undef,
 		# if not null, this is text - maybe json-encoded, maybe random junk
-		invalid_report => $latest_report->invalid_report,
+		invalid_report => $latest_report ? $latest_report->invalid_report : undef,
 		nics => [ map {
 			my $device_nic = $_;
 			$device_nic->deactivated ? () :

--- a/lib/Conch/Controller/Device.pm
+++ b/lib/Conch/Controller/Device.pm
@@ -76,22 +76,14 @@ sub find_device ($c) {
     else {
         # look for unlocated devices among those that have sent a device report proxied by a
         # relay using the user's credentials
-		$c->log->debug("looking for device $device_id associated with relay reports");
-		my $relay_report_device_rs = $c->db_user_accounts
-			->search({ 'user_account.id' => $c->stash('user_id') })
-			->related_resultset('user_relay_connections')
-			->related_resultset('relay')
-			->related_resultset('device_relay_connections')
-			->related_resultset('device');
+        $c->log->debug("looking for device $device_id associated with relay reports");
 
-		$device_rs = $c->db_devices->search(
-			{
-				-and => [
-					'device.id' => $device_id,
-					'device.id' => { -in => $relay_report_device_rs->get_column('id')->as_query },
-				],
-			},
-		);
+        $device_rs = $c->db_devices
+            ->search({ 'device.id' => $device_id })
+            ->related_resultset('device_relay_connections')
+            ->related_resultset('relay')
+            ->related_resultset('user_relay_connections')
+            ->search({ 'user_relay_connections.user_id' => $c->stash('user_id') });
     }
 
     if (not $device_rs->exists) {

--- a/lib/Conch/Controller/Device.pm
+++ b/lib/Conch/Controller/Device.pm
@@ -126,10 +126,11 @@ sub get ($c) {
 		invalid_report => $latest_report ? $latest_report->invalid_report : undef,
 		nics => [ map {
 			my $device_nic = $_;
+			my $device_neighbor = $device_nic->device_neighbor;
 			$device_nic->deactivated ? () :
 			+{
-				(map { $_ => $device_nic->$_ } qw(iface_name iface_type iface_vendor)),
-				(map { $_ => $device_nic->device_neighbor->$_ } qw(mac peer_mac peer_port peer_switch)),
+				(map { $_ => $device_nic->$_ } qw(mac iface_name iface_type iface_vendor)),
+				(map { $_ => $device_neighbor && $device_neighbor->$_ } qw(peer_mac peer_port peer_switch)),
 			}
 		} $device->device_nics ],
 		location => $location,

--- a/lib/Conch/Controller/Device.pm
+++ b/lib/Conch/Controller/Device.pm
@@ -30,7 +30,7 @@ sub find_device ($c) {
 	# check if the device even exists, and then we can skip the rest of the rigamarole.
 	if (not $c->db_devices->search({ id => $device_id })->exists) {
 		$c->log->debug("Failed to find device $device_id");
-		return $c->status(404, { error => "Device '$device_id' not found" });
+		return $c->status(404, { error => 'Not found' });
 	}
 
 	my $direct_workspace_ids_rs = $c->stash('user')
@@ -81,7 +81,7 @@ sub find_device ($c) {
 		# still not found? give up!
 		if (not $device_rs->exists) {
 			$c->log->debug("Failed to find device $device_id");
-			return $c->status(404, { error => "Device '$device_id' not found" });
+			return $c->status(404, { error => 'Not found' });
 		}
 	}
 

--- a/lib/Conch/Controller/DeviceSettings.pm
+++ b/lib/Conch/Controller/DeviceSettings.pm
@@ -35,9 +35,12 @@ sub set_all ($c) {
 	my $perm_needed =
 		@non_tags && $settings_rs->active->search({ name => \@non_tags })->exists ? 'admin' : 'rw';
 
-	if (not $c->stash('device_rs')->user_has_permission($c->stash('user_id'), $perm_needed)) {
-		$c->log->debug("failed permission check (required $perm_needed)");
-		return $c->status(403, { error => 'insufficient permissions' });
+	# 'rw' already checked by find_device
+	if ($perm_needed eq 'admin') {
+		if (not $c->stash('device_rs')->user_has_permission($c->stash('user_id'), $perm_needed)) {
+			$c->log->debug("failed permission check (required $perm_needed)");
+			return $c->status(403, { error => 'insufficient permissions' });
+		}
 	}
 
 	# deactivate existing settings with the same keys
@@ -76,9 +79,13 @@ sub set_single ($c) {
 
 	# overwriting existing non-tag keys requires 'admin'; otherwise only require 'rw'.
 	my $perm_needed = $existing_setting && $setting_key !~ /^tag\./ ? 'admin' : 'rw';
-	if (not $c->stash('device_rs')->user_has_permission($c->stash('user_id'), $perm_needed)) {
-		$c->log->debug("failed permission check (required $perm_needed)");
-		return $c->status(403, { error => 'insufficient permissions' });
+
+	# 'rw' already checked by find_device
+	if ($perm_needed eq 'admin') {
+		if (not $c->stash('device_rs')->user_has_permission($c->stash('user_id'), $perm_needed)) {
+			$c->log->debug("failed permission check (required $perm_needed)");
+			return $c->status(403, { error => 'insufficient permissions' });
+		}
 	}
 
 	$existing_setting->update({ deactivated => \'NOW()' }) if $existing_setting;
@@ -135,9 +142,12 @@ sub delete_single ($c) {
 
 	my $perm_needed = $setting_key !~ /^tag\./ ? 'admin' : 'rw';
 
-	if (not $c->stash('device_rs')->user_has_permission($c->stash('user_id'), $perm_needed)) {
-		$c->log->debug("failed permission check (required $perm_needed)");
-		return $c->status(403, { error => 'insufficient permissions' });
+	# 'rw' already checked by find_device
+	if ($perm_needed eq 'admin') {
+		if (not $c->stash('device_rs')->user_has_permission($c->stash('user_id'), $perm_needed)) {
+			$c->log->debug("failed permission check (required $perm_needed)");
+			return $c->status(403, { error => 'insufficient permissions' });
+		}
 	}
 
 	unless (

--- a/lib/Conch/DB/ResultSet/UserWorkspaceRole.pm
+++ b/lib/Conch/DB/ResultSet/UserWorkspaceRole.pm
@@ -17,21 +17,31 @@ Interface to queries involving user/workspace permissions.
 
 =head1 METHODS
 
+=head2 with_permission
+
+Constrains the resultset to those user_workspace_role rows that grant (at least) the specified
+permission level.
+
+=cut
+
+sub with_permission ($self, $permission) {
+    Carp::croak('permission must be one of: ro, rw, admin')
+        if none { $permission eq $_ } qw(ro rw admin);
+
+    $self->search({ role => { '>=' => \[ q{?::user_workspace_role_enum}, $permission ] } });
+}
+
 =head2 user_has_permission
 
-Returns a boolean indicating whether there exists a user_workspace_role row that grant the
-specified permission level.
+Returns a boolean indicating whether there exists a user_workspace_role row that grant (at
+least) the specified permission level.
 
 =cut
 
 sub user_has_permission ($self, $user_id, $permission) {
-    Carp::croak('permission must be one of: ro, rw, admin')
-        if none { $permission eq $_ } qw(ro rw admin);
-
-    $self->search({
-        user_id => $user_id,
-        role => { '>=' => \[ q{?::user_workspace_role_enum}, $permission ] },
-    })->exists;
+    $self->search({ user_id => $user_id })
+        ->with_permission($permission)
+        ->exists;
 }
 
 1;

--- a/lib/Test/Conch.pm
+++ b/lib/Test/Conch.pm
@@ -388,6 +388,23 @@ sub authenticate ($self, %args) {
     return $self;
 }
 
+=head2 txn_local
+
+Given a subref, execute the code inside a transaction that is rolled back at the end. Useful
+for testing with mutated data that should not affect other tests.  The subref is called as a
+subtest and is invoked with the test object as well as any additional provided arguments.
+
+=cut
+
+sub txn_local ($self, $test_name, $subref, @args) {
+    $self->app->schema->txn_begin;
+
+    local $Test::Builder::Level = $Test::Builder::Level + 1;
+    Test::More::subtest($test_name => $subref, $self, @args);
+
+    $self->app->schema->txn_rollback;
+}
+
 1;
 __END__
 

--- a/lib/Test/Conch/Fixtures.pm
+++ b/lib/Test/Conch/Fixtures.pm
@@ -281,6 +281,7 @@ my %canned_definitions = (
         },
         requires => {
             legacy_datacenter_region_1 => { our => 'datacenter_id', their => 'id' },
+            # TODO: indicate a dependency on 'global_workspace'
         },
     },
     legacy_datacenter_rack => {
@@ -387,6 +388,8 @@ sub generate_set {
                 },
                 requires => {
                     "datacenter_$num" => { our => 'datacenter_id', their => 'id' },
+                    # this is a hack: should be able to specify requirements without copying values.
+                    global_workspace => { our => 'vendor_name', their => 'name' },
                 },
             },
             "workspace_room_${num}a" => {

--- a/t/integration/04_test_datacenter_loaded.t
+++ b/t/integration/04_test_datacenter_loaded.t
@@ -377,10 +377,9 @@ subtest 'Assign device to a location' => sub {
 my $detailed_device;
 
 subtest 'Single device' => sub {
-
-	$t->get_ok('/device/nonexistant')
+	$t->get_ok('/device/nonexistent')
 		->status_is(404)
-		->json_like( '/error', qr/not found/ );
+		->json_is({ error => 'Not found' });
 
 	$t->get_ok('/device/TEST')
 		->status_is(200)
@@ -394,10 +393,6 @@ subtest 'Single device' => sub {
 
 	my $device_id = $detailed_device->{id};
 	my @macs = map { $_->{mac} } $detailed_device->{nics}->@*;
-
-	$t->get_ok('/device/nonexistant')
-		->status_is(404)
-		->json_like( '/error', qr/not found/ );
 
 	my $undetailed_device = { $detailed_device->%* };
 	delete $undetailed_device->@{qw(latest_report_is_invalid latest_report invalid_report location nics disks)};
@@ -422,8 +417,9 @@ subtest 'Single device' => sub {
 	};
 
 	subtest 'mutate device attributes' => sub {
-		$t->post_ok('/device/nonexistant/graduate')
-			->status_is(404);
+		$t->post_ok('/device/nonexistent/graduate')
+			->status_is(404)
+			->json_is({ error => 'Not found' });
 
 		$t->post_ok('/device/TEST/graduate')
 			->status_is(303)
@@ -487,7 +483,8 @@ subtest 'Single device' => sub {
 			->content_is('{}');
 
 		$t->get_ok('/device/TEST/settings/foo')
-			->status_is(404);
+			->status_is(404)
+			->json_is({ error => 'No such setting \'foo\'' });
 
 		$t->post_ok('/device/TEST/settings')
 			->status_is( 400, 'Requires body' )
@@ -523,11 +520,11 @@ subtest 'Single device' => sub {
 
 		$t->get_ok('/device/TEST/settings/fizzle')
 			->status_is(404)
-			->json_like( '/error', qr/fizzle/ );
+			->json_is({ error => 'No such setting \'fizzle\'' });
 
 		$t->delete_ok('/device/TEST/settings/fizzle')
 			->status_is(404)
-			->json_like( '/error', qr/fizzle/ );
+			->json_is({ error => 'No such setting \'fizzle\'' });
 
 		$t->post_ok( '/device/TEST/settings',
 			json => { 'tag.foo' => 'foo', 'tag.bar' => 'bar' } )->status_is(200);
@@ -541,8 +538,9 @@ subtest 'Single device' => sub {
 		$t->delete_ok('/device/TEST/settings/tag.bar')->status_is(204)
 			->content_is('');
 
-		$t->get_ok('/device/TEST/settings/tag.bar')->status_is(404)
-			->json_like( '/error', qr/tag\.bar/ );
+		$t->get_ok('/device/TEST/settings/tag.bar')
+			->status_is(404)
+			->json_is({ error => 'No such setting \'tag.bar\'' });
 
 		my $undetailed_device = { $detailed_device->%* };
 		delete $undetailed_device->@{qw(latest_report_is_invalid latest_report invalid_report location nics disks)};

--- a/t/integration/04_test_datacenter_loaded.t
+++ b/t/integration/04_test_datacenter_loaded.t
@@ -943,13 +943,13 @@ subtest 'Permissions' => sub {
 		subtest 'device settings' => sub {
 			$t->post_ok('/device/TEST/settings', json => { name => 'new value' })
 				->status_is(403)
-				->json_is({ error => 'insufficient permissions' });
+				->json_is({ error => 'Forbidden' });
 			$t->post_ok('/device/TEST/settings/foo', json => { foo => 'new_value' })
 				->status_is(403)
-				->json_is({ error => 'insufficient permissions' });
+				->json_is({ error => 'Forbidden' });
 			$t->delete_ok('/device/TEST/settings/foo')
 				->status_is(403)
-				->json_is({ error => 'insufficient permissions' });
+				->json_is({ error => 'Forbidden' });
 		};
 
 		$t->post_ok("/logout")->status_is(204);

--- a/t/integration/crud/devices.t
+++ b/t/integration/crud/devices.t
@@ -6,6 +6,7 @@ use Test::Warnings;
 use Path::Tiny;
 use Test::Deep;
 use Test::Conch;
+use Data::UUID;
 
 my $t = Test::Conch->new;
 $t->load_fixture_set('workspace_room_rack_layout', 0);
@@ -18,6 +19,7 @@ $t->load_validation_plans([{
 
 my $rack_id = $t->load_fixture('datacenter_rack_0a')->id;
 my $hardware_product_id = $t->load_fixture('hardware_product_compute')->id;
+my $user_workspace_role = $t->load_fixture('conch_user_global_workspace');
 
 $t->authenticate;
 
@@ -101,10 +103,83 @@ subtest 'located device' => sub {
         $t->app->db_workspace_datacenter_racks->delete;
         $t->app->db_workspace_datacenter_rooms->delete;
         $t->get_ok('/device/LOCATED_DEVICE')
-            ->status_is(404)
+            ->status_is(403)
             ->json_schema_is('Error')
-            ->json_is('', { error => 'Not found' }, 'device isn\'t in a workspace anymore');
+            ->json_is('', { error => 'Forbidden' }, 'device isn\'t in a workspace anymore');
     });
+
+    # TODO: permissions for PUT, DELETE queries
+
+    subtest 'permissions for POST queries' => sub {
+        my @queries = (
+            '/device/LOCATED_DEVICE/graduate',
+            '/device/LOCATED_DEVICE/triton_reboot',
+            [ '/device/LOCATED_DEVICE/triton_uuid', json => { triton_uuid => Data::UUID->new->create_str } ],
+            '/device/LOCATED_DEVICE/triton_setup',
+            '/device/LOCATED_DEVICE/validated',
+        );
+
+        foreach my $query (@queries) {
+            $t->post_ok(ref $query ? $query->@* : $query)
+                ->status_is(303)
+                ->location_is('/device/LOCATED_DEVICE');
+        }
+
+        $user_workspace_role->update({ role => 'ro' });
+
+        foreach my $query (@queries) {
+            $t->post_ok(ref $query ? $query->@* : $query)
+                ->status_is(403)
+                ->json_schema_is('Error')
+                ->json_is({ error => 'Forbidden' });
+        }
+    };
+
+    subtest 'permissions for GET queries' => sub {
+        $t->app->db_devices->search({ id => 'LOCATED_DEVICE' })->update({
+            hostname => 'Luci',
+        });
+        $t->app->db_device_settings->create({
+            device_id => 'LOCATED_DEVICE',
+            name => 'hello',
+            value => 'world',
+        });
+        $t->app->db_device_nics->create({
+            device_id => 'LOCATED_DEVICE',
+            iface_name => 'home',
+            iface_type => 'me',
+            iface_vendor => 'me',
+            mac => '00:00:00:00:00:00',
+            ipaddr => '127.0.0.1',
+        });
+
+        my @queries = (
+            '/device/LOCATED_DEVICE',
+            '/device/LOCATED_DEVICE/location',
+            '/device/LOCATED_DEVICE/settings',
+            '/device/LOCATED_DEVICE/settings/hello',
+            '/device/LOCATED_DEVICE/validation_state',
+            '/device/LOCATED_DEVICE/interface',
+            # TODO: filter search results for permissions
+            #'/device?hostname=Luci',
+            #'/device?mac=00:00:00:00:00:00',
+            #'/device?ipaddr=127.0.0.1',
+        );
+
+        foreach my $query (@queries) {
+            $t->get_ok($query)
+                ->status_is(200);
+        };
+
+        $t->app->db_user_workspace_roles->delete;
+
+        foreach my $query (@queries) {
+            $t->get_ok($query)
+                ->status_is(403)
+                ->json_schema_is('Error')
+                ->json_is({ error => 'Forbidden' });
+        }
+    };
 };
 
 subtest 'device network interfaces' => sub {

--- a/t/integration/crud/devices.t
+++ b/t/integration/crud/devices.t
@@ -21,6 +21,11 @@ my $hardware_product_id = $t->load_fixture('hardware_product_compute')->id;
 
 $t->authenticate;
 
+$t->get_ok('/device/nonexistent')
+    ->status_is(404)
+    ->json_schema_is('Error')
+    ->json_is({ error => 'Not found' });
+
 subtest 'unlocated device' => sub {
     $t->post_ok(
         '/relay/deadbeef/register',

--- a/t/integration/crud/devices.t
+++ b/t/integration/crud/devices.t
@@ -1,5 +1,5 @@
 use v5.26;
-use warnings;
+use Mojo::Base -strict, -signatures;
 
 use Test::More;
 use Test::Warnings;
@@ -96,6 +96,15 @@ subtest 'located device' => sub {
             nics => [],
             disks => [],
         });
+
+    $t->txn_local('remove device from its workspace', sub ($t) {
+        $t->app->db_workspace_datacenter_racks->delete;
+        $t->app->db_workspace_datacenter_rooms->delete;
+        $t->get_ok('/device/LOCATED_DEVICE')
+            ->status_is(404)
+            ->json_schema_is('Error')
+            ->json_is('', { error => 'Not found' }, 'device isn\'t in a workspace anymore');
+    });
 };
 
 subtest 'device network interfaces' => sub {

--- a/t/pod-spelling.t
+++ b/t/pod-spelling.t
@@ -61,6 +61,7 @@ schemas
 sku
 subref
 subselect
+subtest
 subworkspace
 timestamptz
 validator


### PR DESCRIPTION
Fixes some minor bugs that haven't shown their faces in production yet; improves some db queries to make it easier to fix #561, to allow device endpoints to check if the user has permission to operate on that device.