### PR TITLE
DB config and connection improvements

### DIFF
--- a/conch.conf.dist
+++ b/conch.conf.dist
@@ -10,8 +10,10 @@
 		normal_expiry => 86400, # 1 day
 	},
 
-	# URI format is postgresql://[user[:password]@][netloc][:port][/dbname][?param1=value1&...]
-	pg => 'postgresql://conch@/conch?client_encoding=UTF-8',
+    database => {
+        # URI format is postgresql://[user[:password]@][netloc][:port][/dbname][?param1=value1&...]
+        uri => 'postgresql://conch@/conch?client_encoding=UTF-8',
+    },
 
 	# Rollbar access token. Must be a token with write permissions
 	# rollbar_access_token => '00000000000000000000000000000000',
@@ -86,8 +88,10 @@
 		post_hook => 'around_dispatch',
 	},
 
-    # directory where all logs will be placed.
-    # if not absolute, will be relative to the root of the application.
-    # log_dir => 'log',
+    # logging => {
+    #     # directory where all logs will be placed.
+    #     # if not absolute, will be relative to the root of the application.
+    #     dir => 'log',
+    # },
 
 }

--- a/conch.conf.dist
+++ b/conch.conf.dist
@@ -11,8 +11,16 @@
 	},
 
     database => {
-        # URI format is postgresql://[user[:password]@][netloc][:port][/dbname][?param1=value1&...]
-        uri => 'postgresql://conch@/conch?client_encoding=UTF-8',
+        # dsn is as defined in https://metacpan.org/pod/DBI#connect
+        # and https://metacpan.org/pod/DBD::Pg#connect:
+        # dbi:DriverName:dbname=database_name[;host=hostname[;port=port]]
+        dsn => 'dbi:Pg:dbname=conch;host=localhost',
+        username => 'conch',
+        password => 'conch',
+        options => {
+            'client_encoding' => 'UTF-8',
+        },
+
     },
 
 	# Rollbar access token. Must be a token with write permissions

--- a/conch.conf.dist
+++ b/conch.conf.dist
@@ -17,6 +17,8 @@
         dsn => 'dbi:Pg:dbname=conch;host=localhost',
         username => 'conch',
         password => 'conch',
+        # ro_username, ro_password are used for ro connection when available.
+
         options => {
             'client_encoding' => 'UTF-8',
         },

--- a/lib/Conch.pm
+++ b/lib/Conch.pm
@@ -149,13 +149,13 @@ sub startup {
 		length => 30
 	});
 
-	$self->plugin('Conch::Plugin::GitVersion');
-	$self->plugin('Conch::Plugin::JsonValidator');
-	$self->plugin("Conch::Plugin::AuthHelpers");
-	$self->plugin('Conch::Plugin::Mail');
+	$self->plugin('Conch::Plugin::GitVersion', $self->config);
+	$self->plugin('Conch::Plugin::JsonValidator', $self->config);
+	$self->plugin('Conch::Plugin::AuthHelpers', $self->config);
+	$self->plugin('Conch::Plugin::Mail', $self->config);
 
 	$self->plugin(NYTProf => $self->config) if $self->feature('nytprof');
-	$self->plugin('Conch::Plugin::Rollbar') if $self->feature('rollbar');
+	$self->plugin('Conch::Plugin::Rollbar', $self->config) if $self->feature('rollbar');
 
 	push @{$self->commands->namespaces}, 'Conch::Command';
 

--- a/lib/Conch/Pg.pm
+++ b/lib/Conch/Pg.pm
@@ -28,16 +28,23 @@ use Mojo::Pg;
 
 =head2 new
 
-Create a new object. Pass in a postgres URI the first time the class is used.
-Afterwards, parameters are not necessary and will be ignored.
+Create a new object. Pass in a hashref of connection options (or a postgres URI) the first time
+the class is used.  Afterwards, parameters are not necessary and will be ignored.
 
 =cut
 
 sub new {
-	my ($class, $pg_uri) = @_;
+	my ($class, $pg_options) = @_;
 	my $self = {};
 
-	$self->{pg} = Mojo::Pg->new($pg_uri);
+	if (ref $pg_options eq 'HASH') {
+		$self->{pg} = Mojo::Pg->new;
+		$self->{pg}->$_($pg_options->{$_}) foreach keys %$pg_options;
+	}
+	else {
+		# use old-style pguri
+		$self->{pg} = Mojo::Pg->new($pg_options);
+	}
 	$self->{pg}->options->{InactiveDestroy} = 1; # we are sharing with DBIC
 
 	bless($self, $class);

--- a/lib/Conch/Plugin/AuthHelpers.pm
+++ b/lib/Conch/Plugin/AuthHelpers.pm
@@ -16,7 +16,7 @@ Contains all convenience handlers for authentication
 
 =cut
 
-sub register ($self, $app, $conf) {
+sub register ($self, $app, $config) {
 
 =head2 is_system_admin
 

--- a/lib/Conch/Plugin/Database.pm
+++ b/lib/Conch/Plugin/Database.pm
@@ -33,6 +33,12 @@ sub register ($self, $app, $config) {
         die $message;
     }
 
+    my ($ro_username, $ro_password) = $database_config->@{qw(ro_username ro_password)};
+    if (not $ro_username or not $ro_password) {
+        $app->log->info('read-only database credentials not provided; falling back to main credentials');
+        ($ro_username, $ro_password) = ($username, $password);
+    }
+
     my $options = {
         AutoCommit          => 1,
         AutoInactiveDestroy => 1,
@@ -95,7 +101,7 @@ cleared with C<< ->txn_rollback >>; see L<DBD::Pg/"ReadOnly-(boolean)">.
         # see L<DBIx::Class::Storage::DBI/DBIx::Class and AutoCommit>
         local $ENV{DBIC_UNSAFE_AUTOCOMMIT_OK} = 1;
         $_ro_schema = Conch::DB->connect(
-            $dsn, $username, $password,
+            $dsn, $ro_username, $ro_password,
             +{
                 $options->%*,
                 ReadOnly    => 1,

--- a/lib/Conch/Plugin/Database.pm
+++ b/lib/Conch/Plugin/Database.pm
@@ -53,8 +53,10 @@ that persists for the lifetime of the application.
 
 =cut
 
+    my $_rw_schema;
     $app->helper(schema => sub {
-        state $_rw_schema = Conch::DB->connect(
+        return $_rw_schema if $_rw_schema;
+        $_rw_schema = Conch::DB->connect(
             $dsn, $username, $password, $options,
         );
     });
@@ -77,10 +79,12 @@ cleared with C<< ->txn_rollback >>; see L<DBD::Pg/"ReadOnly-(boolean)">.
 
 =cut
 
+    my $_ro_schema;
     $app->helper(ro_schema => sub {
+        return $_ro_schema if $_ro_schema;
         # see L<DBIx::Class::Storage::DBI/DBIx::Class and AutoCommit>
         local $ENV{DBIC_UNSAFE_AUTOCOMMIT_OK} = 1;
-        state $_ro_schema = Conch::DB->connect(
+        $_ro_schema = Conch::DB->connect(
             $dsn, $username, $password,
             +{
                 $options->%*,

--- a/lib/Conch/Plugin/Database.pm
+++ b/lib/Conch/Plugin/Database.pm
@@ -24,9 +24,17 @@ Sets up the database and provides convenient accessors to it.
 
 sub register ($self, $app, $config) {
 
+    my $database_config = $config->{database};
+
+    if (not $database_config->{uri}) {
+        my $message = 'Your conch.conf is out of date. Please update it following the format in conch.conf.dist';
+        $app->log->fatal($message);
+        die $message;
+    }
+
     # Conch::Pg = legacy database access; will be removed soon.
     # for now we use Mojo::Pg to parse the pg connection uri.
-    my $mojo_pg = Conch::Pg->new($config->{pg})->{pg};
+    my $mojo_pg = Conch::Pg->new($database_config->{uri})->{pg};
     my ($dsn, $username, $password, $options) = map { $mojo_pg->$_ } qw(dsn username password options);
 
 

--- a/lib/Conch/Plugin/Database.pm
+++ b/lib/Conch/Plugin/Database.pm
@@ -78,18 +78,14 @@ cleared with C<< ->txn_rollback >>; see L<DBD::Pg/"ReadOnly-(boolean)">.
 =cut
 
     $app->helper(ro_schema => sub {
+        # see L<DBIx::Class::Storage::DBI/DBIx::Class and AutoCommit>
+        local $ENV{DBIC_UNSAFE_AUTOCOMMIT_OK} = 1;
         state $_ro_schema = Conch::DB->connect(
-            # we wrap up the DBI connection attributes in a subref so
-            # DBIx::Class doesn't warn about AutoCommit => 0 being a bad idea.
-            sub {
-                DBI->connect(
-                    $dsn, $username, $password,
-                    {
-                        $options->%*,
-                        ReadOnly        => 1,
-                        AutoCommit      => 0,
-                    },
-                );
+            $dsn, $username, $password,
+            +{
+                $options->%*,
+                ReadOnly    => 1,
+                AutoCommit  => 0,
             },
         );
     });

--- a/lib/Conch/Plugin/Database.pm
+++ b/lib/Conch/Plugin/Database.pm
@@ -39,6 +39,12 @@ sub register ($self, $app, $config) {
         ($ro_username, $ro_password) = ($username, $password);
     }
 
+    # allow overrides from the environment
+    $username = $ENV{POSTGRES_USER} // $username;
+    $password = $ENV{POSTGRES_PASSWORD} // $password;
+    $ro_username = $ENV{POSTGRES_USER} // $ro_username;
+    $ro_password = $ENV{POSTGRES_PASSWORD} // $ro_password;
+
     my $options = {
         AutoCommit          => 1,
         AutoInactiveDestroy => 1,
@@ -49,7 +55,12 @@ sub register ($self, $app, $config) {
     };
 
     # Conch::Pg = legacy database access; will be removed soon.
-    Conch::Pg->new({ $database_config->%{qw(dsn username password)}, options => $options });
+    Conch::Pg->new({
+        $database_config->%{qw(dsn username password)},
+        $ENV{POSTGRES_USER} ? ( username => $ENV{POSTGRES_USER} ) : (),
+        $ENV{POSTGRES_PASSWORD} ? ( password => $ENV{POSTGRES_PASSWORD} ) : (),
+        options => $options,
+    });
 
 
 =head2 schema

--- a/lib/Conch/Plugin/GitVersion.pm
+++ b/lib/Conch/Plugin/GitVersion.pm
@@ -22,7 +22,7 @@ Register C<version_tag> and C<version_hash>.
 
 =cut
 
-sub register ($self, $app, $conf) {
+sub register ($self, $app, $config) {
 
     my ($git_tag, $git_tag_stderr, undef) = capture {
         system(qw(git describe --always --long));

--- a/lib/Conch/Plugin/JsonValidator.pm
+++ b/lib/Conch/Plugin/JsonValidator.pm
@@ -54,7 +54,7 @@ Load the plugin into Mojo. Called by Mojo directly
 
 =cut
 
-sub register ($self, $app, $conf) {
+sub register ($self, $app, $config) {
 
     my $validator = JSON::Validator->new();
     $validator->schema(INPUT_SCHEMA_FILE);

--- a/lib/Conch/Plugin/Logging.pm
+++ b/lib/Conch/Plugin/Logging.pm
@@ -22,7 +22,8 @@ process exceptions.
 
 sub register ($self, $app, $config) {
 
-	my $log_dir = $config->{log_dir} // 'log';
+	my $plugin_config = $config->{logging} // {};
+	my $log_dir = $plugin_config->{dir} // 'log';
 
 	my %log_args = (
 		level => 'debug',

--- a/lib/Conch/Plugin/Rollbar.pm
+++ b/lib/Conch/Plugin/Rollbar.pm
@@ -24,7 +24,7 @@ Adds `send_exception_to_rollbar` to Mojolicious app
 
 =cut
 
-sub register ($self, $app, @) {
+sub register ($self, $app, $config) {
 	$app->helper(send_exception_to_rollbar => \&_record_exception);
 }
 

--- a/lib/Test/Conch.pm
+++ b/lib/Test/Conch.pm
@@ -47,7 +47,7 @@ the same database.
 
 =cut
 
-has 'pg';   # this is generally a Test::PostgreSQL object
+has 'pg';   # Test::PostgreSQL object
 
 =head2 validator
 
@@ -100,7 +100,11 @@ sub new {
 
     my $self = Test::Mojo->new(
         Conch => {
-            database => { uri => $pg->uri },    # TODO: pass dsn instead of uri
+            database => {
+                dsn => $pg->dsn,
+                username => $pg->dbowner,
+            },
+
             secrets => ["********"],
         }
     );
@@ -145,7 +149,7 @@ sub init_db ($class) {
     die $Test::PostgreSQL::errstr if not $pgsql;
 
     my $schema = Conch::DB->connect(
-        $pgsql->dsn, 'postgres', '',
+        $pgsql->dsn, $pgsql->dbowner, undef,
         {
             # same as from Mojo::Pg->new($uri)->options
             AutoCommit          => 1,
@@ -183,7 +187,7 @@ sub ro_schema ($class, $pgsql) {
         # DBIx::Class doesn't warn about AutoCommit => 0 being a bad idea.
         sub {
             DBI->connect(
-                $pgsql->dsn, 'postgres', '',
+                $pgsql->dsn, $pgsql->dbowner, undef,
                 {
                     AutoCommit          => 0,
                     AutoInactiveDestroy => 1,

--- a/lib/Test/Conch.pm
+++ b/lib/Test/Conch.pm
@@ -132,6 +132,11 @@ sub DESTROY ($self) {
     # ensure that a new Test::Conch instance creates a brand new Mojo::Pg connection (with a
     # possibly-different dsn) rather than using the old one to a now-dead postgres instance
     Conch::Pg->DESTROY;
+
+    # explicitly disconnect before terminating the server, to avoid exceptions like:
+    # "DBI Exception: DBD::Pg::st DESTROY failed: FATAL:  terminating connection due to administrator command"
+    do { $_->disconnect if $_->connected }
+        foreach $self->app->rw_schema->storage, $self->app->ro_schema->storage;
 }
 
 =head2 init_db

--- a/lib/Test/Conch.pm
+++ b/lib/Test/Conch.pm
@@ -182,21 +182,17 @@ Returns a read-only connection to a Test::PostgreSQL instance.
 =cut
 
 sub ro_schema ($class, $pgsql) {
+    # see L<DBIx::Class::Storage::DBI/DBIx::Class and AutoCommit>
+    local $ENV{DBIC_UNSAFE_AUTOCOMMIT_OK} = 1;
     Conch::DB->connect(
-        # we wrap up the DBI connection attributes in a subref so
-        # DBIx::Class doesn't warn about AutoCommit => 0 being a bad idea.
-        sub {
-            DBI->connect(
-                $pgsql->dsn, $pgsql->dbowner, undef,
-                {
-                    AutoCommit          => 0,
-                    AutoInactiveDestroy => 1,
-                    PrintError          => 0,
-                    PrintWarn           => 0,
-                    RaiseError          => 1,
-                    ReadOnly            => 1,
-                },
-            );
+        $pgsql->dsn, $pgsql->dbowner, undef,
+        +{
+            AutoCommit          => 0,
+            AutoInactiveDestroy => 1,
+            PrintError          => 0,
+            PrintWarn           => 0,
+            RaiseError          => 1,
+            ReadOnly            => 1,
         },
     );
 }

--- a/lib/Test/Conch.pm
+++ b/lib/Test/Conch.pm
@@ -100,8 +100,8 @@ sub new {
 
     my $self = Test::Mojo->new(
         Conch => {
-            pg      => $pg->uri,    # TODO: pass dsn instead of uri
-            secrets => ["********"]
+            database => { uri => $pg->uri },    # TODO: pass dsn instead of uri
+            secrets => ["********"],
         }
     );
 

--- a/t/database.t
+++ b/t/database.t
@@ -71,11 +71,6 @@ subtest 'read-only database handle' => sub {
         'cannot create a user using the read-only db handle',
     );
 
-    # clear the transaction, because we have AutoCommit => 0 for this connection.
-    # (as an alternative, we can turn the ReadOnly flag off, and use the read-only
-    # credentials to connect to the server.. but it is better to have this safety here.)
-    $t->app->ro_schema->txn_rollback;
-
     is(
         exception {
             $t->app->db_ro_user_accounts->find($user1->id);


### PR DESCRIPTION
- removes dependency on Mojo::Pg for parsing db credentials
- fixes race conditions and inappropriate connection sharing in tests
- allow for using separate read-only credentials (closes #440)
- allow environment overrides for db credentials (closes #618)

Requires simultaneous deployment of https://github.com/joyent/buildops-infra/pull/74