### PR TITLE
Fix DIMMCount and CPUCount

### DIFF
--- a/json-schema/input.yaml
+++ b/json-schema/input.yaml
@@ -90,8 +90,6 @@ definitions:
     type: object
     required:
       - bios_version
-      - memory
-      - processor
       - product_name
       - serial_number
       - state
@@ -115,6 +113,8 @@ definitions:
               type: string
             memory-serial-number:
               type: string
+            memory-size:
+              $ref: /definitions/int_or_stringy_int
       disks:
         type: object
         patternProperties:
@@ -193,16 +193,6 @@ definitions:
           ^\S$:
             description: port
             # type: unknown and not used.
-      memory:
-        type: object
-        required:
-          - total
-          - count
-        properties:
-          total:
-            $ref: /definitions/int_or_stringy_int
-          count:
-            $ref: /definitions/int_or_stringy_int
       os:
         type: object
         required:
@@ -210,16 +200,6 @@ definitions:
         properties:
           hostname:
             type: string
-      processor:
-        type: object
-        required:
-          - type
-          - count
-        properties:
-          type:
-            type: string
-          count:
-            type: integer
       product_name:
         # TODO: required for switches, and also for non-switches when 'sku' is not present.
         type: string

--- a/lib/Conch/Validation/CpuCount.pm
+++ b/lib/Conch/Validation/CpuCount.pm
@@ -3,7 +3,7 @@ package Conch::Validation::CpuCount;
 use Mojo::Base 'Conch::Validation';
 
 has 'name'        => 'cpu_count';
-has 'version'     => 1;
+has 'version'     => 2;
 has 'category'    => 'CPU';
 has 'description' => q(
 Validate the reported number of CPUs match the hardware product profile
@@ -12,19 +12,15 @@ Validate the reported number of CPUs match the hardware product profile
 sub validate {
 	my ( $self, $data ) = @_;
 
-	unless(
-		$data->{processor} 
-		and ref $data->{processor} eq 'HASH'
-		and $data->{processor}->{count}
-	){
-		$self->die("Missing processor.count")
+	unless ($data->{cpus}) {
+		$self->die("Missing cpus property")
 	}
 
 	my $hw_profile = $self->hardware_product_profile;
 
 	$self->register_result(
 		expected => $hw_profile->cpu_num,
-		got      => $data->{processor}->{count},
+		got      => scalar $data->{cpus}->@*,
 	);
 
 }

--- a/lib/Conch/Validation/DimmCount.pm
+++ b/lib/Conch/Validation/DimmCount.pm
@@ -3,24 +3,20 @@ package Conch::Validation::DimmCount;
 use Mojo::Base 'Conch::Validation';
 
 has 'name'        => 'dimm_count';
-has 'version'     => 1;
+has 'version'     => 2;
 has 'category'    => 'RAM';
 has 'description' => 'Verify the number of DIMMs reported';
 
 sub validate {
 	my ( $self, $data ) = @_;
 
-	unless($data->{memory}) {
-		$self->die("Missing 'memory' property");
-	}
-
-	unless($data->{memory}->{count}) {
-		$self->die("Missing 'count' property on 'memory'");
+	unless($data->{dimms}) {
+		$self->die("Missing 'dimms' property");
 	}
 
 	my $hw_profile = $self->hardware_product_profile;
 
-	my $dimms_num  = $data->{memory}->{count};
+	my $dimms_num  = scalar $data->{dimms}->@*;
 	my $dimms_want = $hw_profile->dimms_num;
 
 	$self->register_result(

--- a/lib/Conch/Validation/RamTotal.pm
+++ b/lib/Conch/Validation/RamTotal.pm
@@ -1,9 +1,10 @@
 package Conch::Validation::RamTotal;
 
 use Mojo::Base 'Conch::Validation';
+use List::Util qw(sum);
 
 has 'name'        => 'ram_total';
-has 'version'     => 1;
+has 'version'     => 2;
 has 'category'    => 'RAM';
 has 'description' => q(
 Validate the reported RAM match the hardware product profile
@@ -12,17 +13,14 @@ Validate the reported RAM match the hardware product profile
 sub validate {
 	my ( $self, $data ) = @_;
 
-	unless($data->{memory}) {
-		$self->die("Missing 'memory' property");
+	unless(exists $data->{dimms} && $data->{dimms}->@*) {
+		$self->die("Missing 'dimms' property");
 	}
 
-	unless($data->{memory}->{total}) {
-		$self->die("Missing the 'total' property on 'memory'");
-	}
 
 	my $hw_profile = $self->hardware_product_profile;
 
-	my $ram_total = $data->{memory}->{total};
+	my $ram_total = sum map { $_->{'memory-size'} // 0 } $data->{dimms}->@*;
 	my $ram_want  = $hw_profile->ram_total;
 
 	$self->register_result(

--- a/t/validations/cpu_count_v1.t
+++ b/t/validations/cpu_count_v1.t
@@ -10,17 +10,17 @@ test_validation(
 	},
 	cases => [
 		{
-			description => 'Missing processor count hash',
-			data        => { processor => 'foo' },
+			description => 'Missing cpus',
+			data        => {},
 		},
 		{
 			description => 'Incorrect processor count',
-			data        => { processor => { count => 1 } },
+			data        => { cpus => [ { core_id => '0' } ] },
 			failure_num => 1,
 		},
 		{
 			description => 'Correct processor count',
-			data        => { processor => { count => 2 } },
+			data        => { cpus => [ { core_id => '0' }, { core_id => '1' } ] },
 			success_num => 1,
 		},
 	]

--- a/t/validations/dimm_count_v1.t
+++ b/t/validations/dimm_count_v1.t
@@ -7,21 +7,40 @@ test_validation(
 	'Conch::Validation::DimmCount',
 	hardware_product => {
 		name    => 'Test Product',
-		profile => { dimms_num => 8 }
+		profile => { dimms_num => 2 }
 	},
 	cases => [
 		{
 			description => 'No data yields no success',
 			data        => {},
+
 		},
 		{
 			description => 'Iconrrect DIMM count',
-			data        => { 'memory' => { count => 1 } },
+	        data => {
+				dimms => [
+					{
+						'memory-locator'       => "P1-DIMMA1",
+						'memory-serial-number' => '12345'
+					}
+				]
+			},
 			failure_num => 1
 		},
 		{
 			description => 'Correct DIMM count',
-			data        => { 'memory' => { count => 8 } },
+            data => {
+				dimms => [
+					{
+						'memory-locator'       => "P1-DIMMA1",
+						'memory-serial-number' => '12345'
+					},
+					{
+						'memory-locator'       => "P1-DIMMB1",
+						'memory-serial-number' => '67890'
+					}
+				]
+			},
 			success_num => 1
 		},
 	]

--- a/t/validations/ram_total_v1.t
+++ b/t/validations/ram_total_v1.t
@@ -16,16 +16,37 @@ test_validation(
 		},
 		{
 			description => 'No memory total yields no success',
-			data        => { memory => {} },
+			data        => { dimms => [] },
 		},
 		{
 			description => 'Wrong memory total fails',
-			data        => { memory => { total => 64 } },
+            data => {
+				dimms => [
+					{
+						'memory-locator'       => "P1-DIMMA1",
+						'memory-serial-number' => '12345',
+                        'memory-size'          => 64,
+					}
+				]
+			},
 			failure_num => 1
 		},
 		{
 			description => 'Correct memory total success',
-			data        => { memory => { total => 128 } },
+            data => {
+				dimms => [
+					{
+						'memory-locator'       => "P1-DIMMA1",
+						'memory-serial-number' => '12345',
+                        'memory-size'          => 64,
+					},
+					{
+						'memory-locator'       => "P1-DIMMB1",
+						'memory-serial-number' => '67890',
+                        'memory-size'          => 64,
+					}
+				]
+			},
 			success_num => 1
 		},
 	]


### PR DESCRIPTION
The Device Report sends up a `dimms` and a `cpus` properties that list the memory DIMMs and the CPUs respectively. These were intended to replace the older `memory` and `processor` properties. 

This PR updates the `DIMMCount` and `CPUCount` validations to use the newer properties instead of the older one. This entirely deprecates `processors` and leaves the only the `total` property being used from the object in the `memory` property (which currently has no analog in DIMMs).