### PR TITLE
when building a release in docker, use --no-cache

### DIFF
--- a/docker/buildbot-release.bash
+++ b/docker/buildbot-release.bash
@@ -5,7 +5,7 @@
 : ${BUILDNUMBER:=0}
 
 LABEL=$(echo "${LABEL}" | sed 's/\//_/g')
-PREFIX=${PREFIX} LABEL=${LABEL} docker/builder.sh --file Dockerfile .
+PREFIX=${PREFIX} LABEL=${LABEL} docker/builder.sh --no-cache --file Dockerfile .
 
 docker run \
 	--name ${PREFIX}_${BUILDNUMBER} \


### PR DESCRIPTION
Closes #645 