### PR TITLE
allow setting a device asset_tag to null

### DIFF
--- a/json-schema/input.yaml
+++ b/json-schema/input.yaml
@@ -658,7 +658,9 @@ definitions:
       - asset_tag
     properties:
       asset_tag:
-        $ref: /definitions/device_asset_tag
+        oneOf:
+          - $ref: /definitions/device_asset_tag
+          - type: 'null'
   DeviceTritonUuid:
     type: object
     additionalProperties: false

--- a/json-schema/input.yaml
+++ b/json-schema/input.yaml
@@ -258,9 +258,13 @@ definitions:
       role:
         $ref: /definitions/uuid
       serial_number:
-        type: string
+        oneOf:
+          - type: 'null'
+          - type: string
       asset_tag:
-        type: string
+        oneOf:
+          - type: 'null'
+          - type: string
   RackAssignmentUpdates:
     type: array
     uniqueItems: true

--- a/lib/Conch/Controller/Device.pm
+++ b/lib/Conch/Controller/Device.pm
@@ -306,7 +306,7 @@ sub set_asset_tag ($c) {
 	my $device = $c->stash('device_rs')->single;
 
 	$device->update({ asset_tag => $input->{asset_tag}, updated => \'NOW()' });
-	$c->log->debug("Set the asset tag for device ".$device->id." to $input->{asset_tag}");
+	$c->log->debug('Set the asset tag for device '.$device->id.' to '.($input->{asset_tag} // 'null'));
 
 	$c->status(303);
 	$c->redirect_to($c->url_for('/device/' . $device->id));

--- a/lib/Test/Conch.pm
+++ b/lib/Test/Conch.pm
@@ -329,6 +329,18 @@ sub load_fixture ($self, @fixture_names) {
     $self->fixtures->load(@fixture_names);
 }
 
+=head2 reload_fixture
+
+Loads the fixture again. Will die if it already exists (you should use L</load_fixture> unless
+you are sure it has since been deleted).
+
+=cut
+
+sub reload_fixture ($self, @fixture_names) {
+    delete $self->fixtures->_cache->@{@fixture_names};
+    $self->fixtures->load(@fixture_names);
+}
+
 =head2 add_fixture
 
 Add one or more fixture definition(s), and populate the database with it.

--- a/t/integration/crud/devices.t
+++ b/t/integration/crud/devices.t
@@ -274,7 +274,10 @@ subtest 'mutate device attributes' => sub {
     $t->post_ok('/device/TEST/asset_tag', json => { asset_tag => 'asset_tag' })
         ->status_is(303)
         ->location_is('/device/TEST');
-    $detailed_device->{asset_tag} = 'asset_tag';
+
+    $t->post_ok('/device/TEST/asset_tag', json => { asset_tag => undef })
+        ->status_is(303)
+        ->location_is('/device/TEST');
 
     $t->post_ok('/device/TEST/validated')
         ->status_is(303)


### PR DESCRIPTION
closes #668.

also fixes the rack update endpoint to allow nullifying its asset_tag and serial_number (as permitted by the database schema).