### PR TITLE
fixes for 2.24

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -4,7 +4,7 @@ print "Installing dependencies for conch, using $^X at version $]\n";
 print "PERL5LIB=$ENV{PERL5LIB}\n\n";
 
 requires 'perl', '5.026';
-
+die "Your perl is too old! Requires 5.026, but this is $]" if "$]" < '5.026';
 
 # basics
 requires 'Cpanel::JSON::XS';

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -803,6 +803,7 @@ definitions:
       - description
       - created
       - updated
+      - deactivated
     properties:
       id:
         $ref: /definitions/uuid
@@ -818,6 +819,11 @@ definitions:
       updated:
         type: string
         format: date-time
+      deactivated:
+        oneOf:
+          - type: 'null'
+          - type: string
+            format: date-time
   ValidationPlans:
     type: array
     uniqueItems: true

--- a/lib/Conch/Controller/DeviceReport.pm
+++ b/lib/Conch/Controller/DeviceReport.pm
@@ -93,13 +93,14 @@ sub process ($c) {
     # considered to be a pass.
     my ($previous_report_id, $previous_report_status);
     if ($existing_device) {
-        ($previous_report_id, $previous_report_status) =
+        my $previous_report =
             $existing_device->self_rs->latest_device_report
                 ->columns('device_reports.id')
                 ->with_report_status
                 ->hri
-                ->single
-                ->@{qw(id status)};
+                ->single;
+        ($previous_report_id, $previous_report_status) = $previous_report->@{qw(id status)}
+            if $previous_report;
     }
 
 	# Update/create the device and create the device report

--- a/lib/Conch/DB/Result/Validation.pm
+++ b/lib/Conch/DB/Result/Validation.pm
@@ -190,7 +190,6 @@ __PACKAGE__->many_to_many(
 
 __PACKAGE__->add_columns(
     '+module' => { is_serializable => 0 },
-    '+deactivated' => { is_serializable => 0 },
 );
 
 1;


### PR DESCRIPTION
- validation endpoints return data for deactivated validations also (closes #673)
- an extra check in cpanfile for the benefit of older tools
- removed use of transaction in `insert_validation_states` script
- properly handle the case where an already-existing device receives its first report