### PR TITLE
remove the image removal part of the buildbot process

### DIFF
--- a/docker/buildbot-prerelease.bash
+++ b/docker/buildbot-prerelease.bash
@@ -18,5 +18,3 @@ docker run \
 	--rm \
 	--name ${PREFIX}_${BUILDNUMBER} \
 	${PREFIX}/conch-api:${LABEL}
-
-docker rmi ${PREFIX}/conch-api:${LABEL}

--- a/docker/buildbot-release.bash
+++ b/docker/buildbot-release.bash
@@ -16,4 +16,3 @@ docker run \
 && \
 docker push ${PREFIX}/conch-api:${LABEL}
 
-docker rmi ${PREFIX}/conch-api:${LABEL}


### PR DESCRIPTION
The buildbot scripts attempt to clean up after themselves at the end by calling `docker rmi` to remove the images they just built. This is causing spurious buildbot failures particularly during the release process.

The full flow looks like:
- build for `release/v99.99.0` is submitted and starts running
- the tag for `v99.99.0` is pushed up right after and starts running
- these two builds use the same git hash and have the same results. this causes docker to reuse bits of the image for `release/v99.99.0` in the image for `v99.99.0`
- When the build finishes for `release/v99.99.0` the script tries to remove the image. Docker throws up an error because `v99.99.0` is using that image.
- The build for `v99.99.0` continues, finishes, and cleans up the image

The end result is that we have a failed buildbot run for `release/v99.99.0` and a passing run for `v99.99.0` even though they are the same code.

This cleanup can be done server-side using `docker system prune` and the like. This PR removes the `rmi` call in the conch scripts and relies on the buildbot server to clean things up. These processes are already in place there.