### PR TITLE
more 2.24.4 fixes

### DIFF
--- a/lib/Conch/Command/update_validations_release_224.pm
+++ b/lib/Conch/Command/update_validations_release_224.pm
@@ -33,11 +33,8 @@ sub run ($self, @opts) {
     );
 
     $self->app->schema->txn_do(sub ($app) {
-        # deactivating old validations whose versions are incrementing
-        $app->db_validations->search({
-            version => 1,
-            name => { -in => [ qw(dimm_count) ] },
-        })->deactivate;
+        # deactivate old validations whose versions are incrementing
+        $app->db_validations->active->search({ name => 'dimm_count' })->deactivate;
 
         $app->log->info('Adding new validation rows...');
 

--- a/lib/Conch/Controller/DeviceReport.pm
+++ b/lib/Conch/Controller/DeviceReport.pm
@@ -188,12 +188,8 @@ sub process ($c) {
             ->delete > 0)
         {
             $c->log->debug('deleted previous device report id '.$previous_report_id);
-            # deleting device_report cascaded to validation_state and validation_state_member;
-            # now clean up orphaned results
-            $device->search_related('validation_results',
-                { 'validation_state_members.validation_state_id' => undef },
-                { join => 'validation_state_members' },
-            )->delete;
+            # deleting device_report cascaded to validation_state and validation_state_member,
+            # but we leave orphaned validation_result rows behind for performance reasons.
         }
     }
 


### PR DESCRIPTION
- fixes an error with deactivating old validations in the 2.24 deployment
- disables realtime deletion of orphaned validation_result records (too slow!)
- in offline script, delete device reports in batches of maxsize 100, to avoid the sql binding list from getting too large.