### PR TITLE
disk hba, enclosure fields are sometimes numeric in device report payloads

### DIFF
--- a/json-schema/input.yaml
+++ b/json-schema/input.yaml
@@ -143,9 +143,9 @@ definitions:
               temp:
                 $ref: /definitions/int_or_stringy_int
               enclosure:
-                type: string
+                $ref: /definitions/int_or_stringy_int
               hba:
-                type: string
+                $ref: /definitions/int_or_stringy_int
               # any additional fields are not currently used.
       device_type:
         type: string

--- a/t/integration/resource/passing-device-report.json
+++ b/t/integration/resource/passing-device-report.json
@@ -16,7 +16,8 @@
       "transport": "sas",
       "temp": "26",
       "slot": "5",
-      "hba": "2",
+      "hba": 2,
+      "enclosure": -1,
       "device": "sdg",
       "firmware": "DL2B"
     },


### PR DESCRIPTION
since 2a956901, such reports would fail validation.