### PR TITLE
handle mac+iface_name combinations changing

### DIFF
--- a/lib/Conch/Controller/DeviceReport.pm
+++ b/lib/Conch/Controller/DeviceReport.pm
@@ -331,6 +331,14 @@ sub _record_device_configuration {
 
 				delete $inactive_macs{$mac};
 
+				# deactivate this iface_name where mac is different,
+				# so we can assign it the new mac.
+				$c->db_device_nics->active->search({
+					device_id => $device->id,
+					iface_name => $nic,
+					mac => { '!=' => $mac },
+				})->deactivate;
+
 				# if nic already exists on a different device, it will be relocated
 				$c->db_device_nics->update_or_create(
 					{


### PR DESCRIPTION
otherwise, when we try to update a device_id+mac entry with an iface_name that is already used
by another row, we get a constraint violation.