### PR TITLE
fix LinksUp validation

### DIFF
--- a/lib/Conch/Command/update_validations_release_225.pm
+++ b/lib/Conch/Command/update_validations_release_225.pm
@@ -1,0 +1,80 @@
+package Conch::Command::update_validations_release_225;
+
+=pod
+
+=head1 NAME
+
+update_validations_release_225 - A one-time command to update validations to the Server validation plan for release 2.25.
+
+=head1 SYNOPSIS
+
+    bin/conch update_validations_release_225 [long options...]
+
+        --help  print usage message and exit
+
+=cut
+
+use Mojo::Base 'Mojolicious::Command', -signatures;
+use Getopt::Long::Descriptive;
+
+has description => 'add new validations to the Server validation plan';
+
+has usage => sub { shift->extract_usage };  # extracts from SYNOPSIS
+
+sub run ($self, @opts) {
+
+    local @ARGV = @opts;
+    my ($opt, $usage) = describe_options(
+        # the descriptions aren't actually used anymore (mojo uses the synopsis instead)... but
+        # the 'usage' text block can be accessed with $usage->text
+        'update_validations_release_225 %o',
+        [],
+        [ 'help',           'print usage message and exit', { shortcircuit => 1 } ],
+    );
+
+    $self->app->schema->txn_do(sub ($app) {
+        # deactivate old validations whose versions are incrementing
+        $app->db_validations->active->search({ name => 'links_up' })->deactivate;
+
+        $app->log->info('Adding new validation rows...');
+
+        # make sure all updates have been applied for existing validations, and create new
+        # validation rows
+        Conch::ValidationSystem->new(
+            log => $app->log,
+            schema => $app->schema,
+        )->load_validations;
+
+        $app->log->info('Adding new validations to Server plan...');
+
+        my $validation_plan = $app->db_validation_plans->find({ name => 'Conch v1 Legacy Plan: Server' });
+        die 'Failed to find validation plan in database' if not $validation_plan;
+
+        my @new_validations = $app->db_validations->active->search(
+            { name => { -in => [ qw(links_up) ] } });
+        die 'Failed to find new validations (got '.scalar(@new_validations).')' if @new_validations != 1;
+
+        $validation_plan->create_related('validation_plan_members',
+                { validation_plan_id => $validation_plan->id, validation_id => $_->id })
+            foreach @new_validations;
+
+        $app->log->info('Done adding new validations to Server plan');
+
+    }, $self->app);
+}
+
+1;
+__END__
+
+=pod
+
+=head1 LICENSING
+
+Copyright Joyent, Inc.
+
+This Source Code Form is subject to the terms of the Mozilla Public License,
+v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+one at http://mozilla.org/MPL/2.0/.
+
+=cut
+# vim: set ts=4 sts=4 sw=4 et :

--- a/lib/Conch/Validation/LinksUp.pm
+++ b/lib/Conch/Validation/LinksUp.pm
@@ -3,10 +3,10 @@ package Conch::Validation::LinksUp;
 use Mojo::Base 'Conch::Validation';
 
 use constant name        => 'links_up';
-use constant version     => 1;
+use constant version     => 2;
 use constant category    => 'NET';
 use constant description => q(
-Validate that there are at least 4 NICs in the 'up' state
+Validate that there are at least 4 NICs in the 'up' state, not counting ipmi1
 );
 
 sub validate {
@@ -17,7 +17,7 @@ sub validate {
 
 	my $links_up = 0;
 	while ( my ( $name, $nic ) = each $data->{interfaces}->%* ) {
-		next if $name eq 'impi1';
+		next if $name eq 'ipmi1';
 		$links_up++ if ($nic->{state} && $nic->{state} eq 'up');
 	}
 

--- a/t/validations/links_up_v1.t
+++ b/t/validations/links_up_v1.t
@@ -27,7 +27,7 @@ test_validation(
 					eth0 => { state => 'up' },
 					eth1 => { state => 'up' },
 					eth2 => { state => 'up' },
-					eth3 => { state => 'up' },
+					impi1 => { state => 'up' },
 				}
 			},
 			success_num => 1,
@@ -69,13 +69,13 @@ test_validation(
 			success_num => 1,
 		},
 		{
-			description => "Don't count impi1",
+			description => "Don't count ipmi1",
 			data        => {
 				interfaces => {
 					eth0  => { state => 'up' },
 					eth1  => { state => 'up' },
 					eth2  => { state => 'up' },
-					impi1 => { state => 'up' },
+					ipmi1 => { state => 'up' },
 				}
 			},
 			failure_num => 1,


### PR DESCRIPTION
it was filtering out interfaces named "impi1", rather than the correct "ipmi1".
closes #665.