### PR TITLE
skip creating the conch database when initializing the db

### DIFF
--- a/lib/Conch/DB/Util.pm
+++ b/lib/Conch/DB/Util.pm
@@ -151,7 +151,10 @@ sub initialize_db ($schema) {
     $schema->storage->dbh_do(sub ($storage, $dbh, @args) {
         # generally we don't execute this command, as the user already exists (we logged in as it)
         # $dbh->$do('CREATE ROLE conch LOGIN');
-        $dbh->$do('CREATE DATABASE conch OWNER conch');
+        # nor do we generally need to do this, as we have "a" database already, and will just
+        # create tables in the default database
+        # $dbh->$do('CREATE DATABASE conch OWNER conch');
+
         say STDERR 'loading sql/schema.sql' if $debug;
         $dbh->do(path('sql/schema.sql')->slurp_utf8) or die 'SQL load failed in sql/schema.sql';
         $dbh->$do('RESET search_path');  # go back to "$user", public

--- a/lib/Test/Conch.pm
+++ b/lib/Test/Conch.pm
@@ -147,6 +147,7 @@ sub init_db ($class) {
     my $pgsql = Test::PostgreSQL->new(pg_config => 'client_encoding=UTF-8', dbowner => 'conch');
     die $Test::PostgreSQL::errstr if not $pgsql;
 
+    Test::More::note('connecting to ',$pgsql->dsn) if $ENV{DBIC_TRACE};
     my $schema = Conch::DB->connect(
         $pgsql->dsn, $pgsql->dbowner, undef,
         {
@@ -174,6 +175,7 @@ Returns a read-only connection to a Test::PostgreSQL instance.
 sub ro_schema ($class, $pgsql) {
     # see L<DBIx::Class::Storage::DBI/DBIx::Class and AutoCommit>
     local $ENV{DBIC_UNSAFE_AUTOCOMMIT_OK} = 1;
+    Test::More::note('connecting to ',$pgsql->dsn) if $ENV{DBIC_TRACE};
     Conch::DB->connect(
         $pgsql->dsn, $pgsql->dbowner, undef,
         +{


### PR DESCRIPTION
For testing it doesn't matter what database we use (Test::PostgreSQL defaults to 'test'), and
for standing up new instances, docker automatically creates a database named for POSTGRES_USER.
    
closes #697.