### PR TITLE
misc fixes for 2.26

### DIFF
--- a/bin/conch-db
+++ b/bin/conch-db
@@ -39,7 +39,7 @@ create-global-workspace  create the GLOBAL workspace
 create-admin-user        create a user with admin privileges
 migrate                  run outstanding migrations on a Conch database (no effect with 'all')
 apply-dump-migration [n] generate new DBIC result classes, schema.sql after applying a migration(s)
-all                      alias for initialize create-valiations create-admin-user
+all                      alias for initialize create-validations create-admin-user
 
 The environment variables POSTGRES_DB, POSTGRES_HOST, POSTGRES_USER and POSTGRES_PASSWORD are
 used if set.  Otherwise, the config file will be used to find database credentials.

--- a/cpanfile
+++ b/cpanfile
@@ -7,7 +7,7 @@ requires 'perl', '5.026';
 die "Your perl is too old! Requires 5.026, but this is $]" if "$]" < '5.026';
 
 # basics
-requires 'Cpanel::JSON::XS';
+requires 'Cpanel::JSON::XS', '4.10';
 requires 'List::MoreUtils::XS';         # make List::MoreUtils faster
 requires 'Data::UUID';
 requires 'List::Compare';
@@ -16,7 +16,6 @@ requires 'Try::Tiny';
 requires 'Time::HiRes';
 requires 'Time::Moment', '>= 0.43'; # for PR#28, fixes use of stdbool.h (thanks Dale)
 requires 'JSON::Validator', '2.14';
-requires 'Pod::Markdown::Github';
 requires 'Data::Validate::IP';      # for json schema validation of 'ipv4', 'ipv6' types
 requires 'HTTP::Tiny';
 requires 'Safe::Isa';
@@ -57,6 +56,9 @@ requires 'Data::Printer', '0.99_019', dist => 'GARU/Data-Printer-0.99_019.tar.gz
 requires 'Devel::Confess';
 
 # misc scripts
+requires 'Pod::Usage';
+requires 'Pod::Markdown::Github';
+requires 'Getopt::Long';
 requires 'Data::Visitor::Tiny';
 
 # database and rendering

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -250,10 +250,10 @@ DISTRIBUTIONS
       perl 5.006
       strict 0
       warnings 0
-  Cpanel-JSON-XS-4.08
-    pathname: R/RU/RURBAN/Cpanel-JSON-XS-4.08.tar.gz
+  Cpanel-JSON-XS-4.10
+    pathname: R/RU/RURBAN/Cpanel-JSON-XS-4.10.tar.gz
     provides:
-      Cpanel::JSON::XS 4.08
+      Cpanel::JSON::XS 4.10
       Cpanel::JSON::XS::Type undef
     requirements:
       ExtUtils::MakeMaker 0

--- a/json-schema/input.yaml
+++ b/json-schema/input.yaml
@@ -211,7 +211,7 @@ definitions:
           - serial
         properties:
           serial:
-            type: string
+            $ref: /definitions/non_empty_string
       serial_number:
         $ref: /definitions/device_id
       state:

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -3,6 +3,9 @@ definitions:
   uuid:
     type: string
     pattern: "^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"
+  relay_id:
+    type: string
+    pattern: ^\S+$
   device_id:
     type: string
     pattern: ^\S+$
@@ -1337,7 +1340,7 @@ definitions:
         type: string
         format: date-time
       id:
-        type: string
+        $ref: /definitions/relay_id
       ipaddr:
         oneOf:
           - $ref: /definitions/ipaddr

--- a/lib/Conch.pm
+++ b/lib/Conch.pm
@@ -93,11 +93,6 @@ sub startup {
 
 
 	$self->hook(
-		# Preventative check against CSRF. Cross-origin requests can only
-		# specify application/x-www-form-urlencoded, multipart/form-data,
-		# and text/plain Content Types without triggering CORS checks in the browser.
-		# Appropriate CORS headers must still be added by the serving proxy
-		# to be effective against CSRF.
 		before_routes => sub ($c) {
 			my $headers = $c->req->headers;
 
@@ -113,27 +108,6 @@ sub startup {
 			}
 		}
 	);
-
-
-	# This sets CORS headers suitable for development. More restrictive headers
-	# *should* be added by a reverse-proxy for production deployments.
-	# This will set 'Access-Control-Allow-Origin' to the request Origin, which
-	# means it's vulnerable to CSRF attacks. However, for developing browser
-	# apps locally, this is a necessary evil.
-	if ($self->mode eq 'development') {
-		$self->hook(
-			after_dispatch => sub ($c) {
-				my $origin = $c->req->headers->origin || '*';
-				$c->res->headers->header( 'Access-Control-Allow-Origin' => $origin );
-				$c->res->headers->header(
-					'Access-Control-Allow-Methods' => 'GET, PUT, POST, DELETE, OPTIONS' );
-				$c->res->headers->header( 'Access-Control-Max-Age' => 3600 );
-				$c->res->headers->header( 'Access-Control-Allow-Headers' =>
-						'Content-Type, Authorization, X-Requested-With' );
-				$c->res->headers->header( 'Access-Control-Allow-Credentials' => 'true' );
-			}
-		);
-	}
 
 	$self->hook(
 		before_dispatch => sub ($c) {

--- a/lib/Conch.pm
+++ b/lib/Conch.pm
@@ -64,7 +64,9 @@ sub startup {
 	$self->helper(
 		status => sub ($c, $code, $payload = undef) {
 
+			$payload //= { error => 'Unauthorized' } if $code == 401;
 			$payload //= { error => "Forbidden" } if $code == 403;
+			$payload //= { error => 'Not Found' } if $code == 404;
 			$payload //= { error => "Unimplemented" } if $code == 501;
 
 			if (not $payload) {

--- a/lib/Conch/Controller/Datacenter.pm
+++ b/lib/Conch/Controller/Datacenter.pm
@@ -34,7 +34,7 @@ sub find_datacenter ($c) {
 
     if (not $datacenter) {
         $c->log->debug('Unable to find datacenter '.$datacenter_id);
-        return $c->status(404 => { error => 'Not found' });
+        return $c->status(404);
     }
 
     $c->log->debug('Found datacenter '.$datacenter_id);

--- a/lib/Conch/Controller/DatacenterRoom.pm
+++ b/lib/Conch/Controller/DatacenterRoom.pm
@@ -35,7 +35,7 @@ sub find_datacenter_room ($c) {
 
     if (not $room) {
         $c->log->debug('Could not find datacenter room');
-        return $c->status(404 => { error => 'Not found' });
+        return $c->status(404);
     }
 
     $c->log->debug('Found datacenter room');

--- a/lib/Conch/Controller/Device.pm
+++ b/lib/Conch/Controller/Device.pm
@@ -46,7 +46,7 @@ sub find_device ($c) {
     # if the device doesn't exist, we can bail out right now
     if (not $device_check->{exists}) {
         $c->log->debug("Failed to find device $device_id");
-        return $c->status(404, { error => 'Not found' });
+        return $c->status(404);
     }
 
     if ($c->is_system_admin) {
@@ -63,7 +63,7 @@ sub find_device ($c) {
         if (not $c->db_devices->search({ 'device.id' => $device_id })
                 ->user_has_permission($c->stash('user_id'), $requires_permission)) {
             $c->log->debug('User lacks permission to access device '.$device_id);
-            return $c->status(403, { error => 'Forbidden' });
+            return $c->status(403);
         }
     }
     else {
@@ -80,7 +80,7 @@ sub find_device ($c) {
 
         if (not $device_rs->exists) {
             $c->log->debug('User lacks permission to access device '.$device_id);
-            return $c->status(403, { error => 'Forbidden' });
+            return $c->status(403);
         }
     }
 
@@ -192,7 +192,7 @@ sub lookup_by_other_attribute ($c) {
 
 	if (not @devices) {
 		$c->log->debug("Failed to find devices matching $key=$value.");
-		return $c->status(404, { error => 'Devices not found' });
+		return $c->status(404);
 	}
 
 	$c->log->debug(scalar(@devices).' devices found');

--- a/lib/Conch/Controller/DeviceInterface.pm
+++ b/lib/Conch/Controller/DeviceInterface.pm
@@ -32,7 +32,7 @@ sub find_device_interface ($c) {
         ->search_related('device_nics', { iface_name => $interface_name });
     if (not $nic_rs->exists) {
         $c->log->debug("Failed to find interface $interface_name for device " . $c->stash('device_id'));
-        return $c->status(404, { error => "Interface '$interface_name' for device '" . $c->stash('device_id') . ' not found' });
+        return $c->status(404);
     }
 
     $c->stash('device_interface_rs', scalar $nic_rs);

--- a/lib/Conch/Controller/DeviceReport.pm
+++ b/lib/Conch/Controller/DeviceReport.pm
@@ -86,6 +86,12 @@ sub process ($c) {
 		});
 	}
 
+    if ($unserialized_report->{relay} and my $relay_serial = $unserialized_report->{relay}{serial}) {
+        # TODO: relay id should be a uuid
+        return $c->status(400, { error => 'relay serial '.$relay_serial.' is not registered' })
+            if not $c->db_relays->active->search({ id => $relay_serial })->exists;
+    }
+
 	my $existing_device = $c->db_devices->active->find($c->stash('device_id'));
 
     # capture information about the last report before we store the new one

--- a/lib/Conch/Controller/DeviceSettings.pm
+++ b/lib/Conch/Controller/DeviceSettings.pm
@@ -39,7 +39,7 @@ sub set_all ($c) {
 	if ($perm_needed eq 'admin') {
 		if (not $c->stash('device_rs')->user_has_permission($c->stash('user_id'), $perm_needed)) {
 			$c->log->debug("failed permission check (required $perm_needed)");
-			return $c->status(403, { error => 'insufficient permissions' });
+			return $c->status(403);
 		}
 	}
 
@@ -84,7 +84,7 @@ sub set_single ($c) {
 	if ($perm_needed eq 'admin') {
 		if (not $c->stash('device_rs')->user_has_permission($c->stash('user_id'), $perm_needed)) {
 			$c->log->debug("failed permission check (required $perm_needed)");
-			return $c->status(403, { error => 'insufficient permissions' });
+			return $c->status(403);
 		}
 	}
 
@@ -125,8 +125,7 @@ sub get_single ($c) {
 			{ order_by => { -desc => 'created' }, rows => 1 },
 		)->single;
 
-	return $c->status( 404, { error => "No such setting '$setting_key'" } )
-		unless $setting;
+	return $c->status(404) unless $setting;
 
 	$c->status(200, { $setting_key => $setting->value });
 }
@@ -146,7 +145,7 @@ sub delete_single ($c) {
 	if ($perm_needed eq 'admin') {
 		if (not $c->stash('device_rs')->user_has_permission($c->stash('user_id'), $perm_needed)) {
 			$c->log->debug("failed permission check (required $perm_needed)");
-			return $c->status(403, { error => 'insufficient permissions' });
+			return $c->status(403);
 		}
 	}
 
@@ -158,7 +157,8 @@ sub delete_single ($c) {
 			->search({ name => $setting_key })
 			->deactivate > 0
 	) {
-		return $c->status( 404, { error => "No such setting '$setting_key'" } );
+		$c->log->debug("No such setting '$setting_key'");
+		return $c->status(404);
 	}
 
 	return $c->status(204);

--- a/lib/Conch/Controller/DeviceValidation.pm
+++ b/lib/Conch/Controller/DeviceValidation.pm
@@ -65,7 +65,7 @@ sub validate ($c) {
     my $validation = $c->db_ro_validations->active->find($validation_id);
     if (not $validation) {
         $c->log->debug("Could not find validation $validation_id");
-        return $c->status(404 => { error => "Validation $validation_id not found" });
+        return $c->status(404);
     }
 
     my $data = $c->validate_input('DeviceReport');
@@ -104,7 +104,7 @@ sub run_validation_plan ($c) {
     my $validation_plan = $c->db_ro_validation_plans->active->find($validation_plan_id);
     if (not $validation_plan) {
         $c->log->debug("Could not find validation plan $validation_plan_id");
-        return $c->status(404 => { error => "Validation plan $validation_plan_id not found" });
+        return $c->status(404);
     }
 
     my $data = $c->validate_input('DeviceReport');

--- a/lib/Conch/Controller/HardwareProduct.pm
+++ b/lib/Conch/Controller/HardwareProduct.pm
@@ -56,14 +56,14 @@ sub find_hardware_product ($c) {
             ->search({ "hardware_product.$key" => $value });
     } else {
         $c->log->debug("Looking up a HardwareProduct by id ".$c->stash('hardware_product_id'));
-        return $c->status(404 => { error => 'Not found' }) if not is_uuid($c->stash('hardware_product_id'));
+        return $c->status(404) if not is_uuid($c->stash('hardware_product_id'));
         $hardware_product_rs = $hardware_product_rs
             ->search({ 'hardware_product.id' => $c->stash('hardware_product_id') });
     }
 
     if (not $hardware_product_rs->exists) {
         $c->log->debug('Could not locate a valid hardware product');
-        return $c->status(404 => { error => 'Not found' });
+        return $c->status(404);
     }
 
     $c->stash('hardware_product_rs' => scalar $hardware_product_rs);

--- a/lib/Conch/Controller/HardwareVendor.pm
+++ b/lib/Conch/Controller/HardwareVendor.pm
@@ -37,7 +37,7 @@ sub find_hardware_vendor ($c) {
 
     if (not $hardware_vendor) {
         $c->log->debug('Could not locate a valid hardware vendor');
-        return $c->status(404 => { error => 'Not found' });
+        return $c->status(404);
     }
 
     $c->log->debug('Found hardware vendor ' . $hardware_vendor->id);

--- a/lib/Conch/Controller/Login.pm
+++ b/lib/Conch/Controller/Login.pm
@@ -97,18 +97,18 @@ sub authenticate ($c) {
 
 		unless ($user) {
 			$c->log->debug('basic auth failed: user not found');
-			return $c->status(401, { error => 'unauthorized' });
+			return $c->status(401);
 		}
 
 		if (not $user->validate_password($password)) {
 			$c->log->debug('basic auth failed: incorrect password');
-			return $c->status(401, { error => 'unauthorized' });
+			return $c->status(401);
 		}
 
 		if ($user->force_password_change) {
 			$c->log->debug('basic auth failed: password correct, but force_password_change was set');
 			$c->res->headers->location($c->url_for('/user/me/password'));
-			return $c->status(401, { error => 'unauthorized' });
+			return $c->status(401);
 		}
 
 		# pass through to whatever action the user was trying to reach
@@ -147,7 +147,7 @@ sub authenticate ($c) {
 			and $c->db_user_session_tokens->search_for_user_token($jwt->{uid}, $jwt->{jti})->exists)
 		{
 			$c->log->debug('JWT auth failed');
-			return $c->status(401, { error => 'unauthorized' });
+			return $c->status(401);
 		}
 
 		$user_id = $jwt->{uid};
@@ -182,12 +182,12 @@ sub authenticate ($c) {
 							->update({ expires => \'least(expires, now() + interval \'10 minutes\')' }) if $jwt;
 
 						$c->res->headers->location($c->url_for('/user/me/password'));
-						return $c->status(401, { error => 'unauthorized' });
+						return $c->status(401);
 					}
 				}
 				else {
 					$c->log->debug('user\'s tokens were revoked - they must /login again');
-					return $c->status(401, { error => 'unauthorized' });
+					return $c->status(401);
 				}
 			}
 
@@ -198,7 +198,7 @@ sub authenticate ($c) {
 	}
 
 	$c->log->debug('auth failed: no credentials provided');
-	return $c->status(401, { error => 'unauthorized' });
+	return $c->status(401);
 }
 
 =head2 session_login

--- a/lib/Conch/Controller/Rack.pm
+++ b/lib/Conch/Controller/Rack.pm
@@ -28,7 +28,7 @@ sub find_rack ($c) {
 
     if (not $rack_rs->exists) {
         $c->log->debug('Could not find rack ',$c->stash('rack_id'));
-        return $c->status(404 => { error => 'Not found' });
+        return $c->status(404);
     }
 
     # HEAD, GET requires 'ro'; everything else (for now) requires 'rw'
@@ -40,7 +40,7 @@ sub find_rack ($c) {
 
     if (not $rack_rs->user_has_permission($c->stash('user_id'), $requires_permission)) {
         $c->log->debug('User lacks permission to access rack'.$c->stash('rack_id'));
-        return $c->status(403, { error => 'Forbidden' });
+        return $c->status(403);
     }
 
     $c->log->debug('Found rack '.$c->stash('rack_id'));

--- a/lib/Conch/Controller/RackLayout.pm
+++ b/lib/Conch/Controller/RackLayout.pm
@@ -29,7 +29,7 @@ sub find_rack_layout ($c) {
     my $layout = $c->db_rack_layouts->find($c->stash('layout_id'));
     if (not $layout) {
         $c->log->debug('Could not find rack layout '.$c->stash('layout_id'));
-        return $c->status(404 => { error => 'Not found' });
+        return $c->status(404);
     }
 
     $c->log->debug('Found rack layout '.$layout->id);

--- a/lib/Conch/Controller/RackRole.pm
+++ b/lib/Conch/Controller/RackRole.pm
@@ -27,7 +27,7 @@ sub find_rack_role ($c) {
         my ($key, $value) = ($1, $2);
         if ($key ne 'name') {
             $c->log->warn("Unknown identifier '$key'");
-            return $c->status(404 => { error => 'Not found' });
+            return $c->status(404);
         }
 
         $c->log->debug("Looking up rack role using identifier '$key'");
@@ -39,7 +39,7 @@ sub find_rack_role ($c) {
 
     if (not $rack_role) {
         $c->log->debug('Failed to find rack role');
-        return $c->status(404 => { error => 'Not found' });
+        return $c->status(404);
     }
 
     $c->log->debug('Found rack role '.$rack_role->id);

--- a/lib/Conch/Controller/Relay.pm
+++ b/lib/Conch/Controller/Relay.pm
@@ -46,7 +46,7 @@ sub register ($c) {
 
 =head2 list
 
-If the user is a system admin, retrieve a list of all relays in the database
+If the user is a system admin, retrieve a list of all active relays in the database
 
 Response uses the Relays json schema.
 
@@ -55,7 +55,7 @@ Response uses the Relays json schema.
 sub list ($c) {
     return $c->status(403) unless $c->is_system_admin;
 
-    $c->status(200, [ $c->db_relays->all ]);
+    $c->status(200, [ $c->db_relays->active->all ]);
 }
 
 1;

--- a/lib/Conch/Controller/Schema.pm
+++ b/lib/Conch/Controller/Schema.pm
@@ -26,10 +26,10 @@ sub get ($c) {
     my $validator = $type eq 'response' ? $c->get_response_validator
         : $type eq 'request' ? $c->get_input_validator
         : undef;
-    return $c->status(404, { error => 'Not found' }) if not $validator;
+    return $c->status(404) if not $validator;
 
     my $schema = $validator->get("/definitions/$name");
-    return $c->status(404, { error => 'Not found' }) if not $schema;
+    return $c->status(404) if not $schema;
 
     my sub inline_ref ( $ref, $schema ) {
         my ($other) = $ref =~ m|#?/definitions/(\w+)$|;

--- a/lib/Conch/Controller/User.pm
+++ b/lib/Conch/Controller/User.pm
@@ -152,8 +152,7 @@ sub get_setting ($c) {
 		{ order_by => { -desc => 'created' } },
 	)->one_row;
 
-	return $c->status( 404, { error => "No such setting '$key'" } )
-		unless $setting;
+	return $c->status(404) unless $setting;
 
 	$c->status( 200, { $key => from_json($setting->value) } );
 }
@@ -173,8 +172,7 @@ sub delete_setting ($c) {
 
 	my $count = $user->search_related('user_settings', { name => $key })->active->deactivate;
 
-	return $c->status( 404, { error => "No such setting '$key'" } )
-		unless $count;
+	return $c->status(404) unless $count;
 
 	return $c->status(204);
 }
@@ -290,7 +288,7 @@ sub find_user ($c) {
 	$c->log->debug('looking up user '.$user_param);
 	my $user = $user_rs->lookup_by_id_or_email($user_param);
 
-	return $c->status(404, { error => "user $user_param not found" }) if not $user;
+	return $c->status(404) if not $user;
 
 	$c->stash('target_user', $user);
 	return 1;

--- a/lib/Conch/Controller/Validation.pm
+++ b/lib/Conch/Controller/Validation.pm
@@ -46,7 +46,7 @@ sub find_validation($c) {
 
     if (not $validation_rs->exists) {
         $c->log->debug("Failed to find validation for '$identifier'");
-        return $c->status(404, { error => 'Not found' });
+        return $c->status(404);
     }
 
     $c->stash('validation_rs', scalar $validation_rs);

--- a/lib/Conch/Controller/ValidationPlan.pm
+++ b/lib/Conch/Controller/ValidationPlan.pm
@@ -76,7 +76,7 @@ sub find_validation_plan($c) {
 
     if (not $validation_plan) {
         $c->log->debug("Failed to find validation plan for '$identifier'");
-        return $c->status(404, { error => 'Not found' });
+        return $c->status(404);
     }
 
     $c->log->debug('Found validation plan '.$validation_plan->id);

--- a/lib/Conch/Controller/ValidationState.pm
+++ b/lib/Conch/Controller/ValidationState.pm
@@ -28,7 +28,7 @@ Response uses the ValidationStateWithResults json schema.
 =cut
 
 sub get ($c) {
-    return $c->status(404 => { error => 'Not found' })
+    return $c->status(404)
         if not is_uuid($c->stash('validation_state_id'));
 
     my ($validation_state) = $c->db_validation_states
@@ -38,7 +38,7 @@ sub get ($c) {
 
     if (not $validation_state) {
         $c->log->debug('Failed to find validation for \''.$c->stash('validation_state_id').'\'');
-        return $c->status(404, { error => 'Not found' });
+        return $c->status(404);
     }
 
     $c->log->debug('Found validation '.$validation_state->id);

--- a/lib/Conch/Controller/WorkspaceRack.pm
+++ b/lib/Conch/Controller/WorkspaceRack.pm
@@ -104,7 +104,7 @@ sub find_rack ($c) {
 
     if (not $rack_rs->exists) {
         $c->log->debug("Could not find rack $rack_id");
-        return $c->status(404, { error => "Rack $rack_id not found" });
+        return $c->status(404);
     }
 
     # store the simplified query to access the device, now that we've confirmed the user has

--- a/lib/Conch/Controller/WorkspaceUser.pm
+++ b/lib/Conch/Controller/WorkspaceUser.pm
@@ -67,8 +67,7 @@ sub add_user ($c) {
 
 	my $user = $c->db_user_accounts->active->lookup_by_id_or_email("email=$input->{user}");
 
-	return $c->status(404, { error => "user $input->{user} not found" })
-		unless $user;
+	return $c->status(404) unless $user;
 
 	# check if the user already has access to this workspace
 	if (my $existing_role_via = $c->db_workspaces

--- a/lib/Conch/Route.pm
+++ b/lib/Conch/Route.pm
@@ -39,7 +39,7 @@ sub all_routes (
         my ($r, $path) = @_;
         $r->any(sub {
             my $c = shift;
-            return $c->status(401, { error => 'unauthorized' })
+            return $c->status(401)
                 unless $c->stash('user') and $c->stash('user_id');
 
             return $c->status(403, { error => 'Must be system admin' })

--- a/lib/Conch/Route.pm
+++ b/lib/Conch/Route.pm
@@ -49,9 +49,6 @@ sub all_routes (
         })->under;
     });
 
-    # CORS preflight check
-    $root->options('*', sub{ shift->status(204) });
-
     $root->get( '/doc',
         sub { shift->reply->static('public/doc/index.html') } );
 

--- a/lib/Conch/Route.pm
+++ b/lib/Conch/Route.pm
@@ -49,14 +49,17 @@ sub all_routes (
         })->under;
     });
 
+    # GET /doc
     $root->get( '/doc',
         sub { shift->reply->static('public/doc/index.html') } );
 
+    # GET /ping
     $root->get(
         '/ping',
         sub { shift->status( 200, { status => 'ok' } ) },
     );
 
+    # GET /version
     $root->get(
         '/version' => sub {
             my $c = shift;
@@ -64,8 +67,13 @@ sub all_routes (
         }
     );
 
+    # POST /login
     $root->post('/login')->to('login#session_login');
+
+    # POST /logout
     $root->post('/logout')->to('login#session_logout');
+
+    # POST /reset_password
     $root->post('/reset_password')->to('login#reset_password');
 
     # GET /schema/:input_or_response/:schema_name

--- a/lib/Test/Conch.pm
+++ b/lib/Test/Conch.pm
@@ -116,8 +116,9 @@ sub new {
         sub ($file, $) {
             return if not -f $file;
             return if $file !~ /\.pm$/; # skip swap files
-            $self->app->log->info("loading $file");
-            eval "require './$file'" or die $@;
+            my $module = 'Conch::Controller::'. ($file->basename =~ s/\.pm$//r);
+            $self->app->log->info("loading $module");
+            eval "require $module" or die $@;
         },
         { recurse => 1 },
     );

--- a/t/integration/00_only_1_user_loaded.t
+++ b/t/integration/00_only_1_user_loaded.t
@@ -22,8 +22,8 @@ $t->get_ok('/ping')
 	->header_isnt('Request-Id' => undef)
 	->header_isnt('X-Request-ID' => undef);
 
-$t->get_ok('/me')->status_is(401)->json_is({ error => 'unauthorized' });
-$t->get_ok('/login')->status_is(401)->json_is({ error => 'unauthorized' });
+$t->get_ok('/me')->status_is(401);
+$t->get_ok('/login')->status_is(401);
 
 my $now = Conch::Time->now;
 
@@ -47,8 +47,7 @@ subtest 'User' => sub {
 		->json_is('', {});
 
 	$t->get_ok('/user/me/settings/BAD')
-		->status_is(404)
-		->json_is('', { error => "No such setting 'BAD'" });
+		->status_is(404);
 
 	$t->post_ok(
 		'/user/me/settings/TEST' => json => { 'NOTTEST' => 'test' })
@@ -97,8 +96,7 @@ subtest 'User' => sub {
 		->status_is(200)
 		->json_is('', {});
 	$t->get_ok('/user/me/settings/TEST')
-		->status_is(404)
-		->json_is('', { error => "No such setting 'TEST'" });
+		->status_is(404);
 
 	$t->post_ok('/user/me/settings/dot.setting' => json => { 'dot.setting' => 'set' })
 		->status_is(200)
@@ -834,8 +832,7 @@ subtest 'Log out' => sub {
 	$t->post_ok("/logout")
 		->status_is(204);
 	$t->get_ok("/workspace")
-		->status_is(401)
-		->json_is({ error => 'unauthorized' });
+		->status_is(401);
 };
 
 subtest 'JWT authentication' => sub {
@@ -990,12 +987,10 @@ subtest 'modify another user' => sub {
 		->status_is(204, 'revoked all tokens for the new user');
 
 	$t2->get_ok('/me')
-		->status_is(401, 'new user cannot authenticate with persistent session after session is cleared')
-		->json_is({ error => 'unauthorized' });
+		->status_is(401, 'new user cannot authenticate with persistent session after session is cleared');
 
 	$t2->get_ok('/me', { Authorization => "Bearer $jwt_token.$jwt_sig" })
-		->status_is(401, 'new user cannot authenticate with JWT after tokens are revoked')
-		->json_is({ error => 'unauthorized' });
+		->status_is(401, 'new user cannot authenticate with JWT after tokens are revoked');
 
 	$t2->post_ok(
 		'/login' => json => {
@@ -1032,8 +1027,7 @@ subtest 'modify another user' => sub {
 		->json_is({ error => 'invalid identifier format for email=foobar' });
 
 	$t->delete_ok('/user/email=foobar@conch.joyent.us/password?send_password_reset_mail=0')
-		->status_is(404, 'attempted to reset the password for a non-existent user')
-		->json_is({ error => 'user email=foobar@conch.joyent.us not found' });
+		->status_is(404, 'attempted to reset the password for a non-existent user');
 
 	$t->delete_ok(
 		"/user/$new_user_id/password?send_password_reset_mail=0")
@@ -1045,26 +1039,22 @@ subtest 'modify another user' => sub {
 	my $insecure_password = $_new_password;
 
 	$t2->get_ok('/me')
-		->status_is(401, 'user can no longer use his saved session after his password is changed')
-		->json_is({ error => 'unauthorized' });
+		->status_is(401, 'user can no longer use his saved session after his password is changed');
 
 	$t2->reset_session;	# force JWT to be used to authenticate
 	$t2->get_ok('/me', { Authorization => "Bearer $jwt_token.$jwt_sig" })
-		->status_is(401, 'user cannot authenticate with JWT after his password is changed')
-		->json_is({ error => 'unauthorized' });
+		->status_is(401, 'user cannot authenticate with JWT after his password is changed');
 
 	$t2->post_ok(
 		'/login' => json => {
 			user     => 'foo@conch.joyent.us',
 			password => 'foo',
 		})
-		->status_is(401, 'cannot log in with the old password')
-		->json_is({ 'error' => 'unauthorized' });
+		->status_is(401, 'cannot log in with the old password');
 
 	$t3->get_ok($t3->ua->server->url->userinfo('foo@conch.joyent.us:' . $insecure_password)->path('/me'))
 		->status_is(401, 'user cannot use new password with basic auth')
-		->location_is('/user/me/password')
-		->json_is({ error => 'unauthorized' });
+		->location_is('/user/me/password');
 
 	$t2->post_ok(
 		'/login' => json => {
@@ -1079,22 +1069,19 @@ subtest 'modify another user' => sub {
 
 	$t2->get_ok('/me')
 		->status_is(401, 'user can\'t use his session to do anything else')
-		->location_is('/user/me/password')
-		->json_is({ error => 'unauthorized' });
+		->location_is('/user/me/password');
 
 	$t2->reset_session;	# force JWT to be used to authenticate
 	$t2->get_ok('/me', { Authorization => "Bearer $jwt_token.$jwt_sig" })
 		->status_is(401, 'user can\'t use his JWT to do anything else')
-		->location_is('/user/me/password')
-		->json_is({ error => 'unauthorized' });
+		->location_is('/user/me/password');
 
 	$t2->post_ok(
 		'/login' => json => {
 			user     => 'foo@conch.joyent.us',
 			password => $insecure_password,
 		})
-		->status_is(401, 'user cannot log in with the same insecure password again')
-		->json_is({ error => 'unauthorized' });
+		->status_is(401, 'user cannot log in with the same insecure password again');
 
 	$t2->post_ok(
 		'/user/me/password' => { Authorization => "Bearer $jwt_token.$jwt_sig" }
@@ -1129,16 +1116,14 @@ subtest 'modify another user' => sub {
 
 
 	$t->delete_ok('/user/email=foobar@joyent.conch.us')
-		->status_is(404, 'attempted to deactivate a non-existent user')
-		->json_is({ error => 'user email=foobar@joyent.conch.us not found' });
+		->status_is(404, 'attempted to deactivate a non-existent user');
 
 	$t->delete_ok("/user/$new_user_id")
 		->status_is(204, 'new user is deactivated');
 
 	# we haven't cleared the user's session yet...
 	$t2->get_ok('/me')
-		->status_is(401, 'user cannot log in with saved browser session')
-		->json_is({ 'error' => 'unauthorized' });
+		->status_is(401, 'user cannot log in with saved browser session');
 
 	$t2->reset_session;	# force JWT to be used to authenticate
 	$t2->post_ok(
@@ -1146,8 +1131,7 @@ subtest 'modify another user' => sub {
 			user     => 'foo@conch.joyent.us',
 			password => $secure_password,
 		})
-		->status_is(401, 'user can no longer log in with credentials')
-		->json_is({ 'error' => 'unauthorized' });
+		->status_is(401, 'user can no longer log in with credentials');
 
 	$t->delete_ok("/user/$new_user_id")
 		->status_is(410, 'new user was already deactivated')

--- a/t/integration/04_test_datacenter_loaded.t
+++ b/t/integration/04_test_datacenter_loaded.t
@@ -713,15 +713,12 @@ subtest 'Permissions' => sub {
 			$t->post_ok('/device/TEST/settings', json => { key => 'value' })
 				->status_is(200, 'writing new key only requires rw');
 			$t->post_ok('/device/TEST/settings/key', json => { key => 'new value' })
-				->status_is(403)
-				->json_is({ error => 'insufficient permissions' });
+				->status_is(403);
 			$t->delete_ok('/device/TEST/settings/foo')
-				->status_is(403)
-				->json_is({ error => 'insufficient permissions' });
+				->status_is(403);
 
 			$t->post_ok('/device/TEST/settings', json => { key => 'new value', 'tag.bar' => 'bar' })
-				->status_is(403)
-				->json_is({ error => 'insufficient permissions' });
+				->status_is(403);
 			$t->post_ok('/device/TEST/settings', json => { 'tag.foo' => 'foo', 'tag.bar' => 'bar' })
 				->status_is(200);
 
@@ -731,8 +728,8 @@ subtest 'Permissions' => sub {
 				->json_is('/tag.bar', 'newbar', 'Setting was updated');
 			$t->delete_ok('/device/TEST/settings/tag.bar')->status_is(204)
 				->content_is('');
-			$t->get_ok('/device/TEST/settings/tag.bar')->status_is(404)
-				->json_is({ error => 'No such setting \'tag.bar\'' });
+			$t->get_ok('/device/TEST/settings/tag.bar')
+				->status_is(404);
 		};
 
 		$t->post_ok("/logout")->status_is(204);

--- a/t/integration/06_secured_endpoints.t
+++ b/t/integration/06_secured_endpoints.t
@@ -12,37 +12,26 @@ my $uuid = Data::UUID->new;
 
 my $t = Test::Conch->new;
 
-$t->get_ok("/me")->status_is(401)->json_is( '/error' => 'unauthorized' );
-$t->get_ok("/login")->status_is(401)->json_is( '/error' => 'unauthorized' );
+$t->get_ok('/me')->status_is(401);
 
-$t->get_ok("/workspace")->status_is(401)->json_is( '/error' => 'unauthorized' );
-$t->get_ok( "/workspace/" . $uuid->create_str )->status_is(401)
-	->json_is( '/error' => 'unauthorized' );
+$t->get_ok('/login')->status_is(401);
 
-$t->get_ok("/device/TEST")->status_is(401)
-	->json_is( '/error' => 'unauthorized' );
-$t->post_ok("/device/TEST", json => { a => 'b' })->status_is(401)
-	->json_is( '/error' => 'unauthorized' );
+$t->get_ok('/workspace')->status_is(401);
+$t->get_ok('/workspace/'.$uuid->create_str)->status_is(401);
 
-$t->post_ok("/relay/TEST/register", json => { a => 'b' })->status_is(401)
-	->json_is( '/error' => 'unauthorized' );
+$t->get_ok('/device/TEST')->status_is(401);
+$t->post_ok('/device/TEST', json => { a => 'b' })->status_is(401);
 
-$t->get_ok("/user/me/settings")->status_is(401)
-	->json_is( '/error' => 'unauthorized' );
-$t->post_ok("/user/me/settings", json => { a => 'b' })->status_is(401)
-	->json_is( '/error' => 'unauthorized' );
-$t->get_ok("/user/me/settings/test")->status_is(401)
-	->json_is( '/error' => 'unauthorized' );
-$t->post_ok("/user/me/settings/test", json => { a => 'b' })->status_is(401)
-	->json_is( '/error' => 'unauthorized' );
-$t->get_ok("/user/me/settings/test.dot")->status_is(401)
-	->json_is( '/error' => 'unauthorized' );
-$t->post_ok("/user/me/settings/test.dot", json => { 'test.dot' => 'b' })
-	->status_is(401)->json_is( '/error' => 'unauthorized' );
+$t->post_ok('/relay/TEST/register', json => { a => 'b' })->status_is(401);
 
-$t->get_ok("/hardware_product")->status_is(401)
-	->json_is( '/error' => 'unauthorized' );
-$t->get_ok("/hardware_product/" . $uuid->create_str)->status_is(401)
-	->json_is( '/error' => 'unauthorized' );
+$t->get_ok('/user/me/settings')->status_is(401);
+$t->post_ok('/user/me/settings', json => { a => 'b' })->status_is(401);
+$t->get_ok('/user/me/settings/test')->status_is(401);
+$t->post_ok('/user/me/settings/test', json => { a => 'b' })->status_is(401);
+$t->get_ok('/user/me/settings/test.dot')->status_is(401);
+$t->post_ok('/user/me/settings/test.dot', json => { 'test.dot' => 'b' })->status_is(401);
+
+$t->get_ok('/hardware_product')->status_is(401);
+$t->get_ok('/hardware_product/'.$uuid->create_str)->status_is(401);
 
 done_testing();

--- a/t/integration/crud/devices.t
+++ b/t/integration/crud/devices.t
@@ -28,9 +28,7 @@ my $admin_user = $t->load_fixture('conch_user_global_workspace')->user_account;
 $t->authenticate(user => $ro_user->email);
 
 $t->get_ok('/device/nonexistent')
-    ->status_is(404)
-    ->json_schema_is('Error')
-    ->json_is({ error => 'Not found' });
+    ->status_is(404);
 
 
 subtest 'unlocated device, no registered relay' => sub {
@@ -299,8 +297,7 @@ subtest 'get by device attributes' => sub {
 
 subtest 'mutate device attributes' => sub {
     $t->post_ok('/device/nonexistent/graduate')
-        ->status_is(404)
-        ->json_is({ error => 'Not found' });
+        ->status_is(404);
 
     $t->post_ok('/device/TEST/graduate')
         ->status_is(303)
@@ -378,8 +375,7 @@ subtest 'Device settings' => sub {
         ->content_is('{}');
 
     $t->get_ok('/device/LOCATED_DEVICE/settings/foo')
-        ->status_is(404)
-        ->json_is({ error => 'No such setting \'foo\'' });
+        ->status_is(404);
 
     $t->post_ok('/device/LOCATED_DEVICE/settings')
         ->status_is(400, 'Requires body')
@@ -412,12 +408,10 @@ subtest 'Device settings' => sub {
         ->content_is('');
 
     $t->get_ok('/device/LOCATED_DEVICE/settings/fizzle')
-        ->status_is(404)
-        ->json_is({ error => 'No such setting \'fizzle\'' });
+        ->status_is(404);
 
     $t->delete_ok('/device/LOCATED_DEVICE/settings/fizzle')
-        ->status_is(404)
-        ->json_is({ error => 'No such setting \'fizzle\'' });
+        ->status_is(404);
 
     $t->post_ok('/device/LOCATED_DEVICE/settings', json => { 'tag.foo' => 'foo', 'tag.bar' => 'bar' })
         ->status_is(200);
@@ -434,8 +428,7 @@ subtest 'Device settings' => sub {
         ->content_is('');
 
     $t->get_ok('/device/LOCATED_DEVICE/settings/tag.bar')
-        ->status_is(404)
-        ->json_is({ error => 'No such setting \'tag.bar\'' });
+        ->status_is(404);
 
     $t->get_ok('/device/LOCATED_DEVICE')
         ->status_is(200)

--- a/t/integration/crud/hardware_vendor.t
+++ b/t/integration/crud/hardware_vendor.t
@@ -21,14 +21,10 @@ $t->get_ok('/hardware_vendor')
 my $vendors = $t->tx->res->json;
 
 $t->get_ok('/hardware_vendor/'.$uuid->create_str)
-    ->status_is(404)
-    ->json_schema_is('Error')
-    ->json_is({ error => 'Not found' });
+    ->status_is(404);
 
 $t->get_ok('/hardware_vendor/foo')
-    ->status_is(404)
-    ->json_schema_is('Error')
-    ->json_is({ error => 'Not found' });
+    ->status_is(404);
 
 $t->get_ok('/hardware_vendor/'.$vendors->[0]{id})
     ->status_is(200)

--- a/t/integration/crud/workspace-rack.t
+++ b/t/integration/crud/workspace-rack.t
@@ -232,8 +232,7 @@ subtest 'Remove rack from workspace' => sub {
         ->status_is(204);
 
     $t->get_ok("/workspace/$sub_ws_id/rack/$rack_id")
-        ->status_is(404)
-        ->json_cmp_deeply({ error => re(qr/not found/) });
+        ->status_is(404);
 
     $t->post_ok("/workspace/$global_ws_id/rack", json => { id => $rack_id })
         ->status_is(400)

--- a/t/schema.t
+++ b/t/schema.t
@@ -14,8 +14,7 @@ my $json_schema =
 my $t = Test::Conch->new;
 
 $t->get_ok('/schema/request/hello')
-    ->status_is(404)
-    ->json_is({ error => 'Not found' });
+    ->status_is(404);
 
 $t->get_ok('/schema/response/Login')
     ->status_is(200)


### PR DESCRIPTION
externally-visible changes:

- be consistent in the payload for 404 responses
- gracefully handle the case when a report comes from an unregistered relay
- only return active relays from GET /relay
- remove unnecessary CORS handling
