### PR TITLE
Handle 'role' existing in the POST /rack/:id payload when there is no change

### DIFF
--- a/json-schema/input.yaml
+++ b/json-schema/input.yaml
@@ -256,7 +256,7 @@ definitions:
         type: string
       datacenter_room_id:
         $ref: /definitions/uuid
-      role:
+      role: # TODO: this really should be rack_role_id
         $ref: /definitions/uuid
       serial_number:
         oneOf:

--- a/lib/Conch/Controller/Rack.pm
+++ b/lib/Conch/Controller/Rack.pm
@@ -152,8 +152,9 @@ sub update ($c) {
     }
 
     # prohibit shrinking rack_size if there are layouts that extend beyond it
-    if (exists $input->{role} and $input->{role} ne $rack->rack_role_id) {
-        my $rack_role = $c->db_rack_roles->find($input->{role});
+    if (exists $input->{role}
+            and ($input->{rack_role_id} = delete $input->{role}) ne $rack->rack_role_id) {
+        my $rack_role = $c->db_rack_roles->find($input->{rack_role_id});
         if (not $rack_role) {
             return $c->status(400 => { error => 'Rack role does not exist' });
         }
@@ -166,8 +167,6 @@ sub update ($c) {
                 .$rack_role->rack_size.': ', join(', ', @out_of_range));
             return $c->status(400 => { error => 'cannot resize rack: found an assigned rack layout that extends beyond the new rack_size' });
         }
-
-        $input->{rack_role_id} = delete $input->{role};
     }
 
     $rack->set_columns($input);

--- a/t/integration/crud/racks.t
+++ b/t/integration/crud/racks.t
@@ -84,6 +84,12 @@ $t->post_ok("/rack/$new_rack_id", json => {
     })
     ->status_is(303);
 
+$t->post_ok("/rack/$new_rack_id", json => { role => $small_rack_role->id })
+    ->status_is(303);
+
+$t->post_ok("/rack/$new_rack_id", json => { role => $small_rack_role->id })
+    ->status_is(303);
+
 $t->get_ok($t->tx->res->headers->location)
     ->status_is(200)
     ->json_schema_is('Rack')


### PR DESCRIPTION
Previously, we were only deleting/renaming the 'role' field to 'rack_role_id'
for database update if the value changed.

resolves exception https://rollbar.com/joyent_buildops/conch/items/64/occurrences/71642392522/.