### PR TITLE
add "phase" column to device

### DIFF
--- a/json-schema/common.yaml
+++ b/json-schema/common.yaml
@@ -22,6 +22,13 @@ definitions:
   device_asset_tag:
     type: string
     pattern: ^\S+$
+  device_phase:
+    type: string
+    enum:
+      - integration
+      - production
+      - diagnostics
+      - decommissioned
   int_or_stringy_int:
     description: an integer that may be presented as a json string
     # note that when JSON::Validator has 'coerce' mode on, both of these rules will match.

--- a/json-schema/input.yaml
+++ b/json-schema/input.yaml
@@ -11,6 +11,8 @@ definitions:
     $ref: common.yaml#/definitions/device_id
   device_asset_tag:
     $ref: common.yaml#/definitions/device_asset_tag
+  device_phase:
+    $ref: common.yaml#/definitions/device_phase
   ipaddr:
     $ref: common.yaml#/definitions/ipaddr
   macaddr:
@@ -515,6 +517,14 @@ definitions:
     properties:
       triton_uuid:
         $ref: /definitions/uuid
+  DevicePhase:
+    type: object
+    additionaProperties: false
+    required:
+      - phase
+    properties:
+      phase:
+        $ref: /definitions/device_phase
   WorkspaceRoomReplace:
     type: array
     uniqueItems: true

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -9,6 +9,8 @@ definitions:
     $ref: common.yaml#/definitions/device_id
   device_asset_tag:
     $ref: common.yaml#/definitions/device_asset_tag
+  device_phase:
+    $ref: common.yaml#/definitions/device_phase
   ipaddr:
     $ref: common.yaml#/definitions/ipaddr
   macaddr:
@@ -64,6 +66,7 @@ definitions:
       - updated
       - uptime_since
       - validated
+      - phase
       - location
       - nics
       - disks
@@ -131,6 +134,8 @@ definitions:
           - type: string
             format: date-time
           - type: 'null'
+      phase:
+        $ref: /definitions/device_phase
       location:
         oneOf:
           - $ref: "#/definitions/DeviceLocation"
@@ -283,6 +288,7 @@ definitions:
       - uptime_since
       - validated
       - triton_setup
+      - phase
       - rack_id
       - rack_unit_start
     properties:
@@ -346,6 +352,8 @@ definitions:
           - type: string
             format: date-time
           - type: 'null'
+      phase:
+        $ref: /definitions/device_phase
       rack_id:
         oneOf:
           - $ref: /definitions/uuid
@@ -472,6 +480,17 @@ definitions:
             properties:
               mac:
                 $ref: /definitions/macaddr
+  DevicePhase:
+    type: object
+    additionalProperties: false
+    required:
+      - id
+      - phase
+    properties:
+      id:
+        $ref: /definitions/device_id
+      phase:
+        $ref: /definitions/device_phase
   WorkspaceDevicePXEs:
     type: array
     uniqueItems: true

--- a/lib/Conch/Controller/Device.pm
+++ b/lib/Conch/Controller/Device.pm
@@ -379,6 +379,31 @@ sub set_validated($c) {
 	$c->redirect_to($c->url_for("/device/$device_id"));
 }
 
+=head2 get_phase
+
+Gets just the device's phase.  Response uses the DevicePhase json schema.
+
+=cut
+
+sub get_phase ($c) {
+    return $c->status(200, $c->stash('device_rs')->columns([qw(id phase)])->hri->single);
+}
+
+=head2 set_phase
+
+=cut
+
+sub set_phase ($c) {
+    my $input = $c->validate_input('DevicePhase');
+    return if not $input;
+
+    $c->stash('device_rs')->update({ phase => $input->{phase}, updated => \'now()' });
+    $c->log->debug('Set the phase for device '.$c->stash('device_id').' to '.$input->{phase});
+
+    $c->status(303);
+    $c->redirect_to($c->url_for('/device/'.$c->stash('device_id')));
+}
+
 1;
 __END__
 

--- a/lib/Conch/DB/Result/Device.pm
+++ b/lib/Conch/DB/Result/Device.pm
@@ -122,6 +122,13 @@ __PACKAGE__->table("device");
   data_type: 'text'
   is_nullable: 1
 
+=head2 phase
+
+  data_type: 'enum'
+  default_value: 'integration'
+  extra: {custom_type_name => "device_phase_enum",list => ["integration","production","diagnostics","decommissioned"]}
+  is_nullable: 0
+
 =cut
 
 __PACKAGE__->add_columns(
@@ -176,6 +183,16 @@ __PACKAGE__->add_columns(
   { data_type => "timestamp with time zone", is_nullable => 1 },
   "hostname",
   { data_type => "text", is_nullable => 1 },
+  "phase",
+  {
+    data_type => "enum",
+    default_value => "integration",
+    extra => {
+      custom_type_name => "device_phase_enum",
+      list => ["integration", "production", "diagnostics", "decommissioned"],
+    },
+    is_nullable => 0,
+  },
 );
 
 =head1 PRIMARY KEY
@@ -357,8 +374,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2019-03-12 13:33:32
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:M2j4oOof/SgTrd7S/tcVqQ
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2019-04-04 11:36:05
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:VmWasWcAAR+F8+QYjmPCTQ
 
 __PACKAGE__->has_many(
   "active_device_disks",

--- a/lib/Conch/Route/Device.pm
+++ b/lib/Conch/Route/Device.pm
@@ -65,6 +65,9 @@ sub routes {
         # GET /device/:device_id/pxe
         $with_device->get('/pxe')->to('device#get_pxe');
 
+        # GET /device/:device_id/phase
+        $with_device->get('/phase')->to('device#get_phase');
+
         # POST /device/:device_id/graduate
         $with_device->post('/graduate')->to('device#graduate');
         # POST /device/:device_id/triton_setup
@@ -77,6 +80,8 @@ sub routes {
         $with_device->post('/asset_tag')->to('device#set_asset_tag');
         # POST /device/:device_id/validated
         $with_device->post('/validated')->to('device#set_validated');
+        # POST /device/:device_id/phase
+        $with_device->post('/phase')->to('device#set_phase');
 
         {
             my $with_device_location = $with_device->any('/location');

--- a/sql/migrations/0088-device-phase.sql
+++ b/sql/migrations/0088-device-phase.sql
@@ -1,0 +1,6 @@
+SELECT run_migration(88, $$
+
+    create type device_phase_enum as enum ('integration','production','diagnostics','decommissioned');
+    alter table device add column phase device_phase_enum default 'integration' not null;
+
+$$);

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -72,6 +72,20 @@ CREATE TYPE public.device_health_enum AS ENUM (
 ALTER TYPE public.device_health_enum OWNER TO conch;
 
 --
+-- Name: device_phase_enum; Type: TYPE; Schema: public; Owner: conch
+--
+
+CREATE TYPE public.device_phase_enum AS ENUM (
+    'integration',
+    'production',
+    'diagnostics',
+    'decommissioned'
+);
+
+
+ALTER TYPE public.device_phase_enum OWNER TO conch;
+
+--
 -- Name: user_workspace_role_enum; Type: TYPE; Schema: public; Owner: conch
 --
 
@@ -196,7 +210,8 @@ CREATE TABLE public.device (
     triton_uuid uuid,
     asset_tag text,
     triton_setup timestamp with time zone,
-    hostname text
+    hostname text,
+    phase public.device_phase_enum DEFAULT 'integration'::public.device_phase_enum NOT NULL
 );
 
 


### PR DESCRIPTION
new endpoints:
    GET /device/:id/phase
    POST /device/:id/phase

the default phase for all existing and new devices is "integration".

closes #621.