### PR TITLE
in /login, ensure old login JWTs are removed

### DIFF
--- a/lib/Conch/Controller/Login.pm
+++ b/lib/Conch/Controller/Login.pm
@@ -244,6 +244,9 @@ sub session_login ($c) {
 		$c->session( 'user' => $user->id );
 	}
 
+    # expire and delete any old session login JWTs for this user (there should only be one!)
+    $user->user_session_tokens->login_only->unexpired->expire;
+
 	# clear out all expired session tokens
 	$c->db_user_session_tokens->expired->delete;
 

--- a/lib/Conch/DB/ResultSet/UserSessionToken.pm
+++ b/lib/Conch/DB/ResultSet/UserSessionToken.pm
@@ -60,6 +60,16 @@ sub search_for_user_token ($self, $user_id, $token) {
     });
 }
 
+=head2 login_only
+
+Chainable resultset to search for login tokens (created via the main /login flow).
+
+=cut
+
+sub login_only ($self) {
+    $self->search({ name => { '-similar to' => 'login_jwt_[0-9]+' } });
+}
+
 =head2 expire
 
 Update all matching rows by setting expires = now(). (Returns the number of rows updated.)

--- a/lib/Test/Conch.pm
+++ b/lib/Test/Conch.pm
@@ -401,13 +401,8 @@ sub authenticate ($self, %args) {
 
     local $Test::Builder::Level = $Test::Builder::Level + 1;
     $self->post_ok('/login', json => { %args{qw(user password)} })
-        ->status_is(200, $args{message});
-
-    if ($self->tx->res->code != 200) {
-        my $message = 'Login failed for '.$args{user};
-        Test::More::BAIL_OUT($message) if $args{bailout};
-        Test::More::plan(skip_all => $message) if not $args{bailout};
-    }
+        ->status_is(200, $args{message} // 'logged in as '.$args{user})
+            or $args{bailout} and Test::More::BAIL_OUT('Failed to log in as '.$args{user});
 
     return $self;
 }


### PR DESCRIPTION
This prevents inadvertent collisions in the "name" field, as encountered in some tests.