### PR TITLE
preserve non-login tokens by default when clearing user tokens

### DIFF
--- a/lib/Conch/Controller/User.pm
+++ b/lib/Conch/Controller/User.pm
@@ -465,6 +465,10 @@ sub create_token ($c) {
     my $input = $c->validate_input('NewUserToken');
     return if not $input;
 
+    # we use this naming convention to indicate login tokens
+    return $c->status(400, { error => 'name "'.$input->{name}.'" is reserved' })
+        if $input->{name} =~ /^login_jwt_/;
+
     return $c->status(400, { error => 'name "'.$input->{name}.'" is already in use' })
         if $c->db_user_session_tokens
             ->search({ user_id => $c->stash('user_id'), name => $input->{name} })->exists;

--- a/lib/Conch/DB/Result/UserSessionToken.pm
+++ b/lib/Conch/DB/Result/UserSessionToken.pm
@@ -142,6 +142,20 @@ __PACKAGE__->add_columns(
     '+expires' => { retrieve_on_insert => 1 },
 );
 
+use experimental 'signatures';
+
+=head1 METHODS
+
+=head2 is_login
+
+Boolean indicating whether this token was created via the main /login flow.
+
+=cut
+
+sub is_login ($self) {
+    $self->name =~ /^login_jwt_\d+$/;
+}
+
 1;
 __END__
 

--- a/lib/Conch/Route/User.pm
+++ b/lib/Conch/Route/User.pm
@@ -32,7 +32,7 @@ Sets up the routes for /user:
     POST    /user/#target_user_id
     DELETE  /user/#target_user_id?clear_tokens=<0|1>
     POST    /user/#target_user_id/revoke
-    DELETE  /user/#target_user_id/password?clear_tokens=<0|1>&send_password_reset_mail=<0|1>
+    DELETE  /user/#target_user_id/password?clear_tokens=<0|login_only|all>&send_password_reset_mail=<0|1>
     GET     /user
     POST    /user?send_mail=<0|1>
 
@@ -113,7 +113,7 @@ sub routes {
 
         # POST /user/#target_user_id/revoke
         $user_with_target->post('/revoke')->to('#revoke_user_tokens');
-        # DELETE /user/#target_user_id/password?clear_tokens=<0|1>&send_password_reset_mail=<0|1>
+        # DELETE /user/#target_user_id/password?clear_tokens=<0|login_only|all>&send_password_reset_mail=<0|1>
         $user_with_target->delete('/password')->to('#reset_user_password');
 
         # GET /user

--- a/lib/Conch/Route/User.pm
+++ b/lib/Conch/Route/User.pm
@@ -21,7 +21,7 @@ Sets up the routes for /user:
     GET     /user/me/settings/#key
     POST    /user/me/settings/#key
     DELETE  /user/me/settings/#key
-    POST    /user/me/password
+    POST    /user/me/password?clear_tokens=<0|1>
 
     GET     /user/me/token
     POST    /user/me/token
@@ -30,11 +30,11 @@ Sets up the routes for /user:
 
     GET     /user/#target_user_id
     POST    /user/#target_user_id
-    DELETE  /user/#target_user_id
+    DELETE  /user/#target_user_id?clear_tokens=<0|1>
     POST    /user/#target_user_id/revoke
-    DELETE  /user/#target_user_id/password
+    DELETE  /user/#target_user_id/password?clear_tokens=<0|1>&send_password_reset_mail=<0|1>
     GET     /user
-    POST    /user
+    POST    /user?send_mail=<0|1>
 
 =cut
 
@@ -76,14 +76,14 @@ sub routes {
         }
 
         # after changing password, (possibly) pass through to logging out too
-        # POST /user/me/password
+        # POST /user/me/password?clear_tokens=<0|1>
         $user_me->under('/password')->to('#change_own_password')
             ->post->to('login#session_logout');
 
         {
             my $user_me_token = $user_me->any('/token');
 
-            # GET /user/me/token (?with_expired=1)
+            # GET /user/me/token
             $user_me_token->get('/')->to('#get_tokens');
             # POST /user/me/token
             $user_me_token->post('/')->to('#create_token');
@@ -108,17 +108,17 @@ sub routes {
         $user_with_target->get('/')->to('#get');
         # POST /user/#target_user_id
         $user_with_target->post('/')->to('#update');
-        # DELETE /user/#target_user_id
+        # DELETE /user/#target_user_id?clear_tokens=<0|1>
         $user_with_target->delete('/')->to('#deactivate');
 
         # POST /user/#target_user_id/revoke
         $user_with_target->post('/revoke')->to('#revoke_user_tokens');
-        # DELETE /user/#target_user_id/password
+        # DELETE /user/#target_user_id/password?clear_tokens=<0|1>&send_password_reset_mail=<0|1>
         $user_with_target->delete('/password')->to('#reset_user_password');
 
         # GET /user
         $user->require_system_admin->get('/')->to('#list');
-        # POST /user
+        # POST /user?send_mail=<0|1>
         $user->require_system_admin->post('/')->to('#create');
     }
 }

--- a/lib/Conch/Route/User.pm
+++ b/lib/Conch/Route/User.pm
@@ -21,7 +21,7 @@ Sets up the routes for /user:
     GET     /user/me/settings/#key
     POST    /user/me/settings/#key
     DELETE  /user/me/settings/#key
-    POST    /user/me/password?clear_tokens=<0|1>
+    POST    /user/me/password?clear_tokens=<0|login_only|all>
 
     GET     /user/me/token
     POST    /user/me/token
@@ -76,7 +76,7 @@ sub routes {
         }
 
         # after changing password, (possibly) pass through to logging out too
-        # POST /user/me/password?clear_tokens=<0|1>
+        # POST /user/me/password?clear_tokens=<0|login_only|all>
         $user_me->under('/password')->to('#change_own_password')
             ->post->to('login#session_logout');
 

--- a/lib/Conch/Route/Workspace.pm
+++ b/lib/Conch/Route/Workspace.pm
@@ -33,7 +33,7 @@ Sets up the routes for /workspace:
     GET     /workspace/:workspace_id_or_name/relay/:relay_id/device
 
     GET     /workspace/:workspace_id_or_name/user
-    POST    /workspace/:workspace_id_or_name/user
+    POST    /workspace/:workspace_id_or_name/user?send_mail=<0|1>
     DELETE  /workspace/:workspace_id_or_name/user/#target_user_id
 
 Note that in all routes using C<:workspace_id_or_name>, the stash for C<workspace_id> will be
@@ -109,7 +109,7 @@ sub routes {
 
         # GET /workspace/:workspace_id_or_name/user
         $with_workspace->get('/user')->to('workspace_user#list');
-        # POST /workspace/:workspace_id_or_name/user
+        # POST /workspace/:workspace_id_or_name/user?send_mail=<0|1>
         $with_workspace->post('/user')->to('workspace_user#add_user');
         # DELETE /workspace/:workspace_id_or_name/user/#target_user_id
         $with_workspace->under('/user/#target_user_id')->to('user#find_user')

--- a/t/integration/00_only_1_user_loaded.t
+++ b/t/integration/00_only_1_user_loaded.t
@@ -1020,6 +1020,10 @@ subtest 'modify another user' => sub {
 
 	$t2->get_ok('/me')->status_is(204);
 
+    $t2->post_ok('/user/me/token', json => { name => 'my api token' })
+        ->status_is(201);
+    my $api_token = $t2->tx->res->json->{token};
+
 	my $t3 = Test::Conch->new(pg => $t->pg);	# we will only use this $mojo for basic auth
 	$t3->get_ok($t3->ua->server->url->userinfo('foo@conch.joyent.us:123')->path('/me'))
 		->status_is(204, 'user can also use the app with basic auth');
@@ -1031,7 +1035,10 @@ subtest 'modify another user' => sub {
 		->status_is(401, 'new user cannot authenticate with persistent session after session is cleared');
 
 	$t2->get_ok('/me', { Authorization => "Bearer $jwt_token.$jwt_sig" })
-		->status_is(401, 'new user cannot authenticate with JWT after tokens are revoked');
+		->status_is(401, 'new user cannot authenticate with JWT after the login token is revoked');
+
+    $t2->get_ok('/me', { Authorization => 'Bearer '.$api_token })
+        ->status_is(401, 'new user cannot use an api token either');
 
 	$t2->post_ok(
 		'/login' => json => {
@@ -1043,6 +1050,10 @@ subtest 'modify another user' => sub {
 	$jwt_sig   = $t2->tx->res->cookie('jwt_sig')->value;
 
 	$t2->get_ok('/me')->status_is(204, 'session token re-established');
+
+    $t2->post_ok('/user/me/token', json => { name => 'my api token' })
+        ->status_is(201, 'got a new api token');
+    $api_token = $t2->tx->res->json->{token};
 
 	$t2->reset_session;	# force JWT to be used to authenticate
 	$t2->get_ok('/me', { Authorization => "Bearer $jwt_token.$jwt_sig" })
@@ -1084,7 +1095,12 @@ subtest 'modify another user' => sub {
 
 	$t2->reset_session;	# force JWT to be used to authenticate
 	$t2->get_ok('/me', { Authorization => "Bearer $jwt_token.$jwt_sig" })
-		->status_is(401, 'user cannot authenticate with JWT after his password is changed');
+		->status_is(401, 'user cannot authenticate with login JWT after his password is changed');
+
+    $t2->get_ok('/user/me', { Authorization => 'Bearer '.$api_token })
+        ->status_is(200, 'but the api token still works after his password is changed')
+        ->json_schema_is('UserDetailed')
+        ->json_is('/email' => 'foo@conch.joyent.us');
 
 	$t2->post_ok(
 		'/login' => json => {
@@ -1094,7 +1110,7 @@ subtest 'modify another user' => sub {
 		->status_is(401, 'cannot log in with the old password');
 
 	$t3->get_ok($t3->ua->server->url->userinfo('foo@conch.joyent.us:' . $insecure_password)->path('/me'))
-		->status_is(401, 'user cannot use new password with basic auth')
+		->status_is(401, 'user cannot use new password with basic auth to go anywhere else')
 		->location_is('/user/me/password');
 
 	$t2->post_ok(

--- a/t/integration/00_only_1_user_loaded.t
+++ b/t/integration/00_only_1_user_loaded.t
@@ -1177,6 +1177,10 @@ subtest 'user tokens' => sub {
 
     my @existing_jwts = $t->tx->res->json->@*;
 
+    $t->post_ok('/user/me/token', json => { name => 'login_jwt_1234' })
+        ->status_is(400)
+        ->json_is({ error => 'name "login_jwt_1234" is reserved' });
+
     $t->post_ok('/user/me/token', json => { name => 'my first token' })
         ->status_is(201)
         ->json_schema_is('NewUserToken')
@@ -1218,6 +1222,10 @@ subtest 'user tokens' => sub {
             last_used => undef,
             expires => $expires,
         });
+
+    $t->post_ok('/user/me/token', json => { name => 'my first token' })
+        ->status_is(400)
+        ->json_is({ error => 'name "my first token" is already in use' });
 
     my $t2 = Test::Conch->new(pg => $t->pg);
     $t2->get_ok('/user/me', { Authorization => 'Bearer '.$token })


### PR DESCRIPTION
For `POST /user/me/password` and `DELETE /user/#target_user_id/password`, the `clear_tokens` query parameter becomes more nuanced: instead of a boolean, it can now be `?clear_tokens=0`, `?clear_tokens=login_only`, `?clear_tokens=all` (defaulting to login_only), to allow api tokens to still used even while the user is in the password reset flow.

`?clear_tokens=1` continues to work (equivalent to login_only), so clients do not *have* to make changes, but ideally at least the web UI should expose this option to the user as there are situations where all api tokens should be revoked as well.

closes #729.