### PR TITLE
sysadmin token endpoints

### DIFF
--- a/lib/Conch/Controller/User.pm
+++ b/lib/Conch/Controller/User.pm
@@ -539,6 +539,8 @@ Deactivates a token from future use.
 =cut
 
 sub expire_token ($c) {
+    $c->log->warn('user '.$c->stash('user')->name.' expired user session token "'
+        .$c->stash('token_name').'" for user '.$c->stash('target_user')->name);
     $c->stash('token_rs')->expire;
     return $c->status(204);
 }

--- a/lib/Conch/Controller/User.pm
+++ b/lib/Conch/Controller/User.pm
@@ -32,7 +32,7 @@ sub revoke_user_tokens ($c) {
 	my $user = $c->stash('target_user');
 
 	$c->log->debug('revoking session tokens for user ' . $user->name . ', forcing them to /login again');
-	$user->delete_related('user_session_tokens');
+    $user->user_session_tokens->unexpired->expire;
 	$user->update({ refuse_session_auth => 1 });
 
 	$c->status(204);

--- a/lib/Conch/DB/AsEpoch.pm
+++ b/lib/Conch/DB/AsEpoch.pm
@@ -22,8 +22,10 @@ This code is postgres-specific.
 =head2 as_epoch
 
 Adds to a resultset a selection list for a timestamp column as a unix epoch time.
+If the column already existed in the selection list (presumably using the default time format),
+it is replaced.
 
-In this example, a 'created' column will be added to the result, containing a value in unix
+In this example, a 'created' column will be included in the result, containing a value in unix
 epoch time format (number of seconds since 1970-01-01 00:00:00 UTC).
 
     $rs = $rs->as_epoch('created');

--- a/lib/Conch/DB/Result/UserSessionToken.pm
+++ b/lib/Conch/DB/Result/UserSessionToken.pm
@@ -153,7 +153,7 @@ Boolean indicating whether this token was created via the main /login flow.
 =cut
 
 sub is_login ($self) {
-    $self->name =~ /^login_jwt_\d+$/;
+    $self->name =~ /^login_jwt_[\d_]+$/;
 }
 
 1;

--- a/lib/Conch/DB/ResultSet/UserSessionToken.pm
+++ b/lib/Conch/DB/ResultSet/UserSessionToken.pm
@@ -70,6 +70,17 @@ sub login_only ($self) {
     $self->search({ name => { '-similar to' => 'login_jwt_[0-9_]+' } });
 }
 
+=head2 api_only
+
+Chainable resultset to search for api tokens (NOT created via the main /login flow).
+
+=cut
+
+sub api_only ($self) {
+    my $me = $self->current_source_alias;
+    $self->search({ $me.'.name' => { '-not similar to' => 'login_jwt_[0-9_]+' } });
+}
+
 =head2 expire
 
 Update all matching rows by setting expires = now(). (Returns the number of rows updated.)

--- a/lib/Conch/DB/ResultSet/UserSessionToken.pm
+++ b/lib/Conch/DB/ResultSet/UserSessionToken.pm
@@ -67,7 +67,8 @@ Chainable resultset to search for login tokens (created via the main /login flow
 =cut
 
 sub login_only ($self) {
-    $self->search({ name => { '-similar to' => 'login_jwt_[0-9_]+' } });
+    my $me = $self->current_source_alias;
+    $self->search({ $me.'.name' => { '-similar to' => 'login_jwt_[0-9_]+' } });
 }
 
 =head2 api_only

--- a/lib/Conch/DB/ResultSet/UserSessionToken.pm
+++ b/lib/Conch/DB/ResultSet/UserSessionToken.pm
@@ -67,7 +67,7 @@ Chainable resultset to search for login tokens (created via the main /login flow
 =cut
 
 sub login_only ($self) {
-    $self->search({ name => { '-similar to' => 'login_jwt_[0-9]+' } });
+    $self->search({ name => { '-similar to' => 'login_jwt_[0-9_]+' } });
 }
 
 =head2 expire

--- a/lib/Conch/Route/User.pm
+++ b/lib/Conch/Route/User.pm
@@ -1,6 +1,6 @@
 package Conch::Route::User;
 
-use Mojo::Base -strict;
+use Mojo::Base -strict, -signatures;
 
 =pod
 
@@ -48,18 +48,19 @@ sub routes {
 
     # interfaces for user updating their own account...
     {
-        # all these routes are under /user/
-        my $user_me = $user->any('/me');
+        # all /user/me routes operate with the target user set to ourselves
+        my $user_me = $user->under('/me')
+            ->to(cb => sub ($c) { $c->stash('target_user', $c->stash('user')); return 1 });
 
         # GET /user/me
-        $user_me->get('/')->to('#get_me');
+        $user_me->get('/')->to('#get');
 
         # POST /user/me/revoke
-        $user_me->post('/revoke')->to('#revoke_own_tokens');
+        $user_me->post('/revoke')->to('#revoke_user_tokens');
 
         # POST /user/me/password?clear_tokens=<login_only|0|all>
         # (after changing password, (possibly) pass through to logging out too)
-        $user_me->under('/password')->to('#change_own_password')
+        $user->under('/me/password')->to('#change_own_password')
             ->post('/')->to('login#session_logout');
 
         {
@@ -89,7 +90,7 @@ sub routes {
             # POST /user/me/token
             $user_me_token->post('/')->to('#create_token');
             # DELETE /user/me/token (same as POST /user/me/revoke)
-            $user_me_token->delete('/')->to('#revoke_own_tokens');
+            $user_me_token->delete('/')->to('#revoke_user_tokens');
 
             my $with_token = $user_me_token->under('/:token_name')->to('#find_token');
 

--- a/lib/Conch/Route/User.pm
+++ b/lib/Conch/Route/User.pm
@@ -34,6 +34,12 @@ Sets up the routes for /user:
     DELETE  /user/#target_user_id_or_email?clear_tokens=<1|0>
     POST    /user/#target_user_id_or_email/revoke
     DELETE  /user/#target_user_id_or_email/password?clear_tokens=<login_only|0|all>&send_password_reset_mail=<1|0>
+
+    GET     /user/#target_user_id_or_email/token
+    DELETE  /user/#target_user_id_or_email/token (same as POST /user/#target_user_id_or_email/revoke)
+    GET     /user/#target_user_id_or_email/token/:token_name
+    DELETE  /user/#target_user_id_or_email/token/:token_name
+
     GET     /user
     POST    /user?send_mail=<1|0>
 
@@ -124,6 +130,23 @@ sub routes {
         $user->require_system_admin->get('/')->to('#list');
         # POST /user?send_mail=<1|0>
         $user->require_system_admin->post('/')->to('#create');
+
+        {
+            my $user_with_target_token = $user_with_target->any('/token');
+
+            # GET /user/#target_user_id_or_email/token
+            $user_with_target_token->get('/')->to('#get_tokens');
+            # DELETE /user/#target_user_id_or_email/token (same as POST /user/#target_user_id_or_email/revoke)
+            $user_with_target_token->delete('/')->to('#revoke_user_tokens');
+
+            my $with_token = $user_with_target_token->under('/:token_name')->to('#find_token');
+
+            # GET /user/#target_user_id_or_email/token/:token_name
+            $with_token->get('/')->to('#get_token');
+
+            # DELETE /user/#target_user_id_or_email/token/:token_name
+            $with_token->delete('/')->to('#expire_token');
+        }
     }
 }
 

--- a/lib/Conch/Route/User.pm
+++ b/lib/Conch/Route/User.pm
@@ -16,12 +16,12 @@ Sets up the routes for /user:
 
     GET     /user/me
     POST    /user/me/revoke
+    POST    /user/me/password?clear_tokens=<login_only|0|all>
     GET     /user/me/settings
     POST    /user/me/settings
     GET     /user/me/settings/#key
     POST    /user/me/settings/#key
     DELETE  /user/me/settings/#key
-    POST    /user/me/password?clear_tokens=<login_only|0|all>
 
     GET     /user/me/token
     POST    /user/me/token
@@ -57,6 +57,11 @@ sub routes {
         # POST /user/me/revoke
         $user_me->post('/revoke')->to('#revoke_own_tokens');
 
+        # POST /user/me/password?clear_tokens=<login_only|0|all>
+        # (after changing password, (possibly) pass through to logging out too)
+        $user_me->under('/password')->to('#change_own_password')
+            ->post('/')->to('login#session_logout');
+
         {
             my $user_me_settings = $user_me->any('/settings');
 
@@ -75,11 +80,6 @@ sub routes {
             # DELETE /user/me/settings/#key
             $user_me_settings_with_key->delete('/')->to('#delete_setting');
         }
-
-        # after changing password, (possibly) pass through to logging out too
-        # POST /user/me/password?clear_tokens=<login_only|0|all>
-        $user_me->under('/password')->to('#change_own_password')
-            ->post('/')->to('login#session_logout');
 
         {
             my $user_me_token = $user_me->any('/token');

--- a/lib/Conch/Route/User.pm
+++ b/lib/Conch/Route/User.pm
@@ -23,7 +23,7 @@ Sets up the routes for /user:
     POST    /user/me/settings/#key
     DELETE  /user/me/settings/#key
 
-    GET     /user/me/token
+    GET     /user/me/token?login=<0|1>&api=<1|0>
     POST    /user/me/token
     DELETE  /user/me/token?login_only=<0|1> or ?api_only=<0|1> (same as POST /user/me/revoke)
     GET     /user/me/token/:token_name
@@ -35,7 +35,7 @@ Sets up the routes for /user:
     POST    /user/#target_user_id_or_email/revoke?login_only=<0|1> or ?api_only=<0|1>
     DELETE  /user/#target_user_id_or_email/password?clear_tokens=<login_only|0|all>&send_password_reset_mail=<1|0>
 
-    GET     /user/#target_user_id_or_email/token
+    GET     /user/#target_user_id_or_email/token?login=<0|1>&api=<1|0>
     DELETE  /user/#target_user_id_or_email/token?login_only=<0|1> or ?api_only=<0|1> (same as POST /user/#target_user_id_or_email/revoke)
     GET     /user/#target_user_id_or_email/token/:token_name
     DELETE  /user/#target_user_id_or_email/token/:token_name
@@ -91,7 +91,7 @@ sub routes {
         {
             my $user_me_token = $user_me->any('/token');
 
-            # GET /user/me/token
+            # GET /user/me/token?login=<0|1>&api=<1|0>
             $user_me_token->get('/')->to('#get_tokens');
             # POST /user/me/token
             $user_me_token->post('/')->to('#create_token');
@@ -134,7 +134,7 @@ sub routes {
         {
             my $user_with_target_token = $user_with_target->any('/token');
 
-            # GET /user/#target_user_id_or_email/token
+            # GET /user/#target_user_id_or_email/token?login=<0|1>&api=<1|0>
             $user_with_target_token->get('/')->to('#get_tokens');
             # DELETE /user/#target_user_id_or_email/token?login_only=<0|1> or ?api_only=<0|1>
             # (same as POST /user/#target_user_id_or_email/revoke)

--- a/lib/Conch/Route/User.pm
+++ b/lib/Conch/Route/User.pm
@@ -21,7 +21,7 @@ Sets up the routes for /user:
     GET     /user/me/settings/#key
     POST    /user/me/settings/#key
     DELETE  /user/me/settings/#key
-    POST    /user/me/password?clear_tokens=<0|login_only|all>
+    POST    /user/me/password?clear_tokens=<login_only|0|all>
 
     GET     /user/me/token
     POST    /user/me/token
@@ -30,12 +30,11 @@ Sets up the routes for /user:
 
     GET     /user/#target_user_id_or_email
     POST    /user/#target_user_id_or_email
-    DELETE  /user/#target_user_id_or_email?clear_tokens=<0|1>
+    DELETE  /user/#target_user_id_or_email?clear_tokens=<1|0>
     POST    /user/#target_user_id_or_email/revoke
-    DELETE  /user/#target_user_id_or_email/password
-    DELETE  /user/#target_user_id_or_email/password?clear_tokens=<0|login_only|all>&send_password_reset_mail=<0|1>
+    DELETE  /user/#target_user_id_or_email/password?clear_tokens=<login_only|0|all>&send_password_reset_mail=<1|0>
     GET     /user
-    POST    /user?send_mail=<0|1>
+    POST    /user?send_mail=<1|0>
 
 =cut
 
@@ -77,7 +76,7 @@ sub routes {
         }
 
         # after changing password, (possibly) pass through to logging out too
-        # POST /user/me/password?clear_tokens=<0|login_only|all>
+        # POST /user/me/password?clear_tokens=<login_only|0|all>
         $user_me->under('/password')->to('#change_own_password')
             ->post('/')->to('login#session_logout');
 
@@ -109,17 +108,17 @@ sub routes {
         $user_with_target->get('/')->to('#get');
         # POST /user/#target_user_id_or_email
         $user_with_target->post('/')->to('#update');
-        # DELETE /user/#target_user_id_or_email?clear_tokens=<0|1>
+        # DELETE /user/#target_user_id_or_email?clear_tokens=<1|0>
         $user_with_target->delete('/')->to('#deactivate');
 
         # POST /user/#target_user_id_or_email/revoke
         $user_with_target->post('/revoke')->to('#revoke_user_tokens');
-        # DELETE /user/#target_user_id_or_email/password?clear_tokens=<0|login_only|all>&send_password_reset_mail=<0|1>
+        # DELETE /user/#target_user_id_or_email/password?clear_tokens=<login_only|0|all>&send_password_reset_mail=<1|0>
         $user_with_target->delete('/password')->to('#reset_user_password');
 
         # GET /user
         $user->require_system_admin->get('/')->to('#list');
-        # POST /user?send_mail=<0|1>
+        # POST /user?send_mail=<1|0>
         $user->require_system_admin->post('/')->to('#create');
     }
 }

--- a/lib/Conch/Route/User.pm
+++ b/lib/Conch/Route/User.pm
@@ -15,7 +15,7 @@ Conch::Route::User
 Sets up the routes for /user:
 
     GET     /user/me
-    POST    /user/me/revoke
+    POST    /user/me/revoke?login_only=<0|1> or ?api_only=<0|1>
     POST    /user/me/password?clear_tokens=<login_only|0|all>
     GET     /user/me/settings
     POST    /user/me/settings
@@ -25,18 +25,18 @@ Sets up the routes for /user:
 
     GET     /user/me/token
     POST    /user/me/token
-    DELETE  /user/me/token (same as POST /user/me/revoke)
+    DELETE  /user/me/token?login_only=<0|1> or ?api_only=<0|1> (same as POST /user/me/revoke)
     GET     /user/me/token/:token_name
     DELETE  /user/me/token/:token_name
 
     GET     /user/#target_user_id_or_email
     POST    /user/#target_user_id_or_email
     DELETE  /user/#target_user_id_or_email?clear_tokens=<1|0>
-    POST    /user/#target_user_id_or_email/revoke
+    POST    /user/#target_user_id_or_email/revoke?login_only=<0|1> or ?api_only=<0|1>
     DELETE  /user/#target_user_id_or_email/password?clear_tokens=<login_only|0|all>&send_password_reset_mail=<1|0>
 
     GET     /user/#target_user_id_or_email/token
-    DELETE  /user/#target_user_id_or_email/token (same as POST /user/#target_user_id_or_email/revoke)
+    DELETE  /user/#target_user_id_or_email/token?login_only=<0|1> or ?api_only=<0|1> (same as POST /user/#target_user_id_or_email/revoke)
     GET     /user/#target_user_id_or_email/token/:token_name
     DELETE  /user/#target_user_id_or_email/token/:token_name
 
@@ -61,7 +61,7 @@ sub routes {
         # GET /user/me
         $user_me->get('/')->to('#get');
 
-        # POST /user/me/revoke
+        # POST /user/me/revoke?login_only=<0|1> or ?api_only=<0|1>
         $user_me->post('/revoke')->to('#revoke_user_tokens');
 
         # POST /user/me/password?clear_tokens=<login_only|0|all>
@@ -95,7 +95,7 @@ sub routes {
             $user_me_token->get('/')->to('#get_tokens');
             # POST /user/me/token
             $user_me_token->post('/')->to('#create_token');
-            # DELETE /user/me/token (same as POST /user/me/revoke)
+            # DELETE /user/me/token?login_only=<0|1> or ?api_only=<0|1> (same as POST /user/me/revoke)
             $user_me_token->delete('/')->to('#revoke_user_tokens');
 
             my $with_token = $user_me_token->under('/:token_name')->to('#find_token');
@@ -121,7 +121,7 @@ sub routes {
         # DELETE /user/#target_user_id_or_email?clear_tokens=<1|0>
         $user_with_target->delete('/')->to('#deactivate');
 
-        # POST /user/#target_user_id_or_email/revoke
+        # POST /user/#target_user_id_or_email/revoke?login_only=<0|1> or ?api_only=<0|1>
         $user_with_target->post('/revoke')->to('#revoke_user_tokens');
         # DELETE /user/#target_user_id_or_email/password?clear_tokens=<login_only|0|all>&send_password_reset_mail=<1|0>
         $user_with_target->delete('/password')->to('#reset_user_password');
@@ -136,7 +136,8 @@ sub routes {
 
             # GET /user/#target_user_id_or_email/token
             $user_with_target_token->get('/')->to('#get_tokens');
-            # DELETE /user/#target_user_id_or_email/token (same as POST /user/#target_user_id_or_email/revoke)
+            # DELETE /user/#target_user_id_or_email/token?login_only=<0|1> or ?api_only=<0|1>
+            # (same as POST /user/#target_user_id_or_email/revoke)
             $user_with_target_token->delete('/')->to('#revoke_user_tokens');
 
             my $with_token = $user_with_target_token->under('/:token_name')->to('#find_token');

--- a/lib/Conch/Route/User.pm
+++ b/lib/Conch/Route/User.pm
@@ -25,6 +25,7 @@ Sets up the routes for /user:
 
     GET     /user/me/token
     POST    /user/me/token
+    DELETE  /user/me/token (same as POST /user/me/revoke)
     GET     /user/me/token/:token_name
     DELETE  /user/me/token/:token_name
 
@@ -87,6 +88,8 @@ sub routes {
             $user_me_token->get('/')->to('#get_tokens');
             # POST /user/me/token
             $user_me_token->post('/')->to('#create_token');
+            # DELETE /user/me/token (same as POST /user/me/revoke)
+            $user_me_token->delete('/')->to('#revoke_own_tokens');
 
             my $with_token = $user_me_token->under('/:token_name')->to('#find_token');
 

--- a/lib/Conch/Route/Workspace.pm
+++ b/lib/Conch/Route/Workspace.pm
@@ -33,7 +33,7 @@ Sets up the routes for /workspace:
     GET     /workspace/:workspace_id_or_name/relay/:relay_id/device
 
     GET     /workspace/:workspace_id_or_name/user
-    POST    /workspace/:workspace_id_or_name/user?send_mail=<0|1>
+    POST    /workspace/:workspace_id_or_name/user?send_mail=<1|0>
     DELETE  /workspace/:workspace_id_or_name/user/#target_user_id_or_email
 
 Note that in all routes using C<:workspace_id_or_name>, the stash for C<workspace_id> will be
@@ -109,7 +109,7 @@ sub routes {
 
         # GET /workspace/:workspace_id_or_name/user
         $with_workspace->get('/user')->to('workspace_user#list');
-        # POST /workspace/:workspace_id_or_name/user?send_mail=<0|1>
+        # POST /workspace/:workspace_id_or_name/user?send_mail=<1|0>
         $with_workspace->post('/user')->to('workspace_user#add_user');
         # DELETE /workspace/:workspace_id_or_name/user/#target_user_id_or_email
         $with_workspace->under('/user/#target_user_id_or_email')->to('user#find_user')

--- a/t/integration/00_only_1_user_loaded.t
+++ b/t/integration/00_only_1_user_loaded.t
@@ -838,6 +838,8 @@ subtest 'JWT authentication' => sub {
 	)->status_is( 204, "Revoke tokens for self" );
 	$t->get_ok( "/workspace", { Authorization => "Bearer $jwt_token_2" } )
 		->status_is( 401, "Cannot use after self revocation" );
+
+    $t->authenticate;
 };
 
 subtest 'modify another user' => sub {
@@ -1242,6 +1244,9 @@ subtest 'user tokens' => sub {
     $t2 = Test::Conch->new(pg => $t->pg);
     $t2->get_ok('/user/me', { Authorization => 'Bearer '.$token })
         ->status_is(401);
+
+    # session was wiped; need to re-auth.
+    $t->authenticate;
 };
 
 warnings(sub {

--- a/t/integration/00_only_1_user_loaded.t
+++ b/t/integration/00_only_1_user_loaded.t
@@ -10,6 +10,7 @@ use Test::Warnings ':all';
 use Test::Conch;
 use Test::Deep;
 use Test::Deep::NumberTolerant;
+use Time::HiRes 'time'; # time() now has µs precision
 use Test::Memory::Cycle;
 
 my $uuid = Data::UUID->new;
@@ -1138,7 +1139,7 @@ subtest 'modify another user' => sub {
 	});
 };
 
-subtest 'user tokens' => sub {
+subtest 'user tokens (our own)' => sub {
     $t->get_ok('/user/me/token')
         ->status_is(200)
         ->json_schema_is('UserTokens')
@@ -1247,6 +1248,140 @@ subtest 'user tokens' => sub {
 
     # session was wiped; need to re-auth.
     $t->authenticate;
+};
+
+subtest 'user tokens (someone else\'s)' => sub {
+    my ($email, $password) = ('foo@conch.joyent.us', 'neupassword');
+
+    $t->get_ok('/user/email='.$email.'/token')
+        ->status_is(200)
+        ->json_schema_is('UserTokens')
+        ->json_is([]);
+
+    # password was set to something random when the user was (re)created
+    $t->app->db_user_accounts->active->find({ email => $email })->update({ password => $password });
+
+    my $t_other_user = Test::Conch->new(pg => $t->pg);
+    $t_other_user->authenticate(user => $email, password => $password);
+
+    my @jwts = ($t_other_user->tx->res->json->{jwt_token}.'.'.$t_other_user->tx->res->cookie('jwt_sig')->value);
+
+    $t->get_ok('/user/email='.$email.'/token')
+        ->status_is(200)
+        ->json_schema_is('UserTokens')
+        ->json_cmp_deeply([
+            {
+                name => re(qr/^login_jwt_[\d_]+$/),
+                created => re(qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/),
+                last_used => ignore,
+                expires => re(qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/),
+            },
+        ]);
+    my @tokens = $t->tx->res->json->@*;
+
+    $t->get_ok('/user/email='.$email.'/token/'.$tokens[0]->{name})
+        ->status_is(200)
+        ->json_schema_is('UserToken')
+        ->json_is($tokens[0]);
+
+    # can't use the sysadmin endpoints, even to ask about ourself
+    $t_other_user->get_ok('/user/email='.$email.'/token')
+        ->status_is(403);
+    $t_other_user->get_ok('/user/email='.$email.'/token/foo')
+        ->status_is(403);
+    $t_other_user->delete_ok('/user/email='.$email.'/token')
+        ->status_is(403);
+    $t_other_user->delete_ok('/user/email='.$email.'/token/foo')
+        ->status_is(403);
+
+    # log in again, creating another JWT.
+    $t_other_user->authenticate(user => $email, password => $password);
+    push @jwts, $t_other_user->tx->res->json->{jwt_token}.'.'.$t_other_user->tx->res->cookie('jwt_sig')->value;
+
+    $t->get_ok('/user/email='.$email.'/token')
+        ->status_is(200)
+        ->json_schema_is('UserTokens')
+        ->json_cmp_deeply([
+            @tokens,
+            {
+                name => re(qr/^login_jwt_[\d_]+$/),
+                created => re(qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/),
+                last_used => ignore,
+                expires => re(qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/),
+            },
+        ]);
+    @tokens = $t->tx->res->json->@*;
+
+    $t->delete_ok('/user/email='.$email.'/token/'.$tokens[0]->{name})
+        ->status_is(204);
+
+    $t->get_ok('/user/email='.$email.'/token')
+        ->status_is(200)
+        ->json_schema_is('UserTokens')
+        ->json_is([ $tokens[1] ]);
+
+    $t->get_ok('/user/email='.$email.'/token/'.$tokens[0]->{name})
+        ->status_is(404);
+
+    $t_other_user->reset_session; # force JWT to be used to authenticate
+
+    $t_other_user->get_ok('/user/me/token', { Authorization => 'Bearer '.$jwts[0] })
+        ->status_is(401, 'first token is gone');
+
+    $t_other_user->get_ok('/user/me/token', { Authorization => 'Bearer '.$jwts[1] })
+        ->status_is(200, 'second token is still ok')
+        ->json_schema_is('UserTokens')
+        ->json_cmp_deeply([
+            {
+                $tokens[1]->%*,
+                last_used => re(qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/),
+            },
+        ]);
+
+    $t_other_user->get_ok('/user/me/token/'.$tokens[0]->{name}, { Authorization => 'Bearer '.$jwts[1] })
+        ->status_is(404);
+
+    $t->delete_ok('/user/email='.$email.'/token')
+        ->status_is(204);
+
+    cmp_deeply(
+        [ $t->app->db_user_accounts->active->search({ email => $email })
+                ->related_resultset('user_session_tokens')
+                ->columns(['name'])
+                ->as_epoch('expires')
+                ->hri ],
+        [
+            {
+                name => $tokens[1]->{name},
+                expires => within_tolerance(less_than => time),
+            },
+        ],
+        'first token has already been deleted; second token still remains, but is expired',
+    );
+
+    $t->delete_ok('/user/email='.$email.'/token/'.$tokens[0]->{name})
+        ->status_is(404);
+
+    $t->delete_ok('/user/email='.$email.'/token/'.$tokens[1]->{name})
+        ->status_is(404);
+
+    $t->get_ok('/user/email='.$email.'/token')
+        ->status_is(200)
+        ->json_schema_is('UserTokens')
+        ->json_is([]);
+
+    $t_other_user->get_ok('/user/me', { Authorization => 'Bearer '.$jwts[0] })
+        ->status_is(401, 'first token is gone');
+
+    $t_other_user->get_ok('/user/me', { Authorization => 'Bearer '.$jwts[1] })
+        ->status_is(401, 'second token is gone');
+
+    is(
+        $t->app->db_user_accounts->active->search({ email => $email })
+            ->related_resultset('user_session_tokens')->count,
+        0,
+        'both tokens are now deleted',
+    );
 };
 
 warnings(sub {

--- a/t/integration/00_only_1_user_loaded.t
+++ b/t/integration/00_only_1_user_loaded.t
@@ -819,10 +819,15 @@ subtest 'JWT authentication' => sub {
 		->status_is( 200, "Can authenticate with new token" );
 	$t->get_ok( "/workspace", { Authorization => "Bearer $jwt_token.$jwt_sig" } )
 		->status_is( 401, "Cannot use old token" );
-	$t->post_ok( '/refresh_token',
-		{ Authorization => "Bearer $jwt_token.$jwt_sig" } )
-		->status_is( 401, "Cannot reuse token with old JWT" );
 
+    $t->get_ok('/me', { Authorization => "Bearer $jwt_token.$jwt_sig" } )
+        ->status_is( 401, "Cannot reuse old JWT" );
+
+    $t->post_ok('/user/email='.$t->CONCH_EMAIL.'/revoke?api_only=1',
+            { Authorization => "Bearer $new_jwt_token" })
+        ->status_is(204, 'Revoke api tokens for user');
+    $t->get_ok('/workspace', { Authorization => "Bearer $new_jwt_token" } )
+        ->status_is(200, 'user can still use the login token');
 	$t->post_ok('/user/email='.$t->CONCH_EMAIL.'/revoke',
 			{ Authorization => "Bearer $new_jwt_token" })
 		->status_is(204, 'Revoke all tokens for user');
@@ -950,17 +955,23 @@ subtest 'modify another user' => sub {
 	$t3->get_ok($t3->ua->server->url->userinfo('foo@conch.joyent.us:123')->path('/me'))
 		->status_is(204, 'user can also use the app with basic auth');
 
-	$t->post_ok("/user/$new_user_id/revoke")
-		->status_is(204, 'revoked all tokens for the new user');
+    $t->post_ok("/user/$new_user_id/revoke?login_only=1")
+        ->status_is(204, 'revoked login tokens for the new user');
+
+    $t2->get_ok('/me', { Authorization => "Bearer $jwt_token.$jwt_sig" })
+        ->status_is(401, 'new user cannot authenticate with the login JWT after login tokens are revoked');
+
+    $t2->get_ok('/me', { Authorization => "Bearer $api_token" })
+        ->status_is(204, 'new user can still use the api token');
 
 	$t2->get_ok('/me')
 		->status_is(401, 'new user cannot authenticate with persistent session after session is cleared');
 
-	$t2->get_ok('/me', { Authorization => "Bearer $jwt_token.$jwt_sig" })
-		->status_is(401, 'new user cannot authenticate with JWT after the login token is revoked');
+    $t->post_ok("/user/$new_user_id/revoke?api_only=1")
+        ->status_is(204, 'revoked api tokens for the new user');
 
-    $t2->get_ok('/me', { Authorization => 'Bearer '.$api_token })
-        ->status_is(401, 'new user cannot use an api token either');
+    $t2->get_ok('/me', { Authorization => "Bearer $api_token" })
+        ->status_is(401, 'new user cannot authenticate with the api token after api tokens are revoked');
 
 	$t2->post_ok(
 		'/login' => json => {

--- a/t/integration/00_only_1_user_loaded.t
+++ b/t/integration/00_only_1_user_loaded.t
@@ -1236,6 +1236,9 @@ subtest 'user tokens' => sub {
     $t->delete_ok('/user/me/token/my first token')
         ->status_is(404);
 
+    $t->delete_ok('/user/me/token')
+        ->status_is(204);
+
     $t2 = Test::Conch->new(pg => $t->pg);
     $t2->get_ok('/user/me', { Authorization => 'Bearer '.$token })
         ->status_is(401);

--- a/t/pod-spelling.t
+++ b/t/pod-spelling.t
@@ -22,6 +22,7 @@ all_pod_files_spelling_ok(qw(lib t misc));
 
 __DATA__
 ANDed
+api
 auth
 az
 bunyan


### PR DESCRIPTION
- fixed naming of login tokens
- new endpoints:

    DELETE /user/me/token
    GET    /user/#target_user_id_or_email/token
    DELETE /user/#target_user_id_or_email/token
    GET    /user/#target_user_id_or_email/token/:token_name
    DELETE /user/#target_user_id_or_email/token/:token_name

Token removal endpoints accept `?login_only=1`, `?api_only=1`

closes #735, #738.
