### PR TITLE
add the concept of phases at the rack level

### DIFF
--- a/json-schema/input.yaml
+++ b/json-schema/input.yaml
@@ -91,6 +91,8 @@ definitions:
         $ref: /definitions/uuid
       role:
         $ref: /definitions/uuid
+      phase:
+        $ref: /definitions/device_phase
   RackUpdate:
     type: object
     additionalProperties: false
@@ -109,6 +111,8 @@ definitions:
         oneOf:
           - type: 'null'
           - type: string
+      phase:
+        $ref: /definitions/device_phase
   RackAssignmentUpdates:
     type: array
     uniqueItems: true
@@ -147,6 +151,14 @@ definitions:
       rack_unit_start:
         type: integer
         description: Starting RU slot position
+  RackPhase:
+    type: object
+    additionaProperties: false
+    required:
+      - phase
+    properties:
+      phase:
+        $ref: /definitions/device_phase
   RackRoleCreate:
     type: object
     additionalProperties: false

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -835,6 +835,7 @@ definitions:
       - name
       - role
       - datacenter
+      - phase
       - slots
     properties:
       id:
@@ -846,6 +847,8 @@ definitions:
       datacenter:
         description: datacenter room AZ
         type: string
+      phase:
+        $ref: /definitions/device_phase
       slots:
         type: array
         uniqueItems: true
@@ -1353,6 +1356,7 @@ definitions:
       - role
       - serial_number
       - asset_tag
+      - phase
       - created
       - updated
     properties:
@@ -1372,6 +1376,8 @@ definitions:
         oneOf:
           - $ref: /definitions/device_asset_tag
           - type: 'null'
+      phase:
+        $ref: /definitions/device_phase
       created:
         type: string
         format: date-time

--- a/lib/Conch/Controller/WorkspaceRack.pm
+++ b/lib/Conch/Controller/WorkspaceRack.pm
@@ -129,7 +129,7 @@ sub get_layout ($c) {
             ->search(undef,
                 {
                     columns => {
-                        ( map {; $_ => "rack.$_" } qw(id name) ),
+                        ( map {; $_ => "rack.$_" } qw(id name phase) ),
                         role => 'rack_role.name',
                         datacenter => 'datacenter_room.az',
                         'layout.rack_unit_start' => 'rack_layouts.rack_unit_start',
@@ -155,7 +155,7 @@ sub get_layout ($c) {
         my $rsrc = $c->schema->source('device');
 
         my $layout = {
-            ( map { $_ => $raw_data[0]->{$_} } qw(id name role datacenter) ),
+            ( map { $_ => $raw_data[0]->{$_} } qw(id name role datacenter phase) ),
             slots => [
                 map {
                     my $device = delete $_->{layout}{device};

--- a/lib/Conch/DB/Result/Rack.pm
+++ b/lib/Conch/DB/Result/Rack.pm
@@ -78,6 +78,13 @@ __PACKAGE__->table("rack");
   data_type: 'text'
   is_nullable: 1
 
+=head2 phase
+
+  data_type: 'enum'
+  default_value: 'integration'
+  extra: {custom_type_name => "device_phase_enum",list => ["integration","installation","production","diagnostics","decommissioned"]}
+  is_nullable: 0
+
 =cut
 
 __PACKAGE__->add_columns(
@@ -112,6 +119,22 @@ __PACKAGE__->add_columns(
   { data_type => "text", is_nullable => 1 },
   "asset_tag",
   { data_type => "text", is_nullable => 1 },
+  "phase",
+  {
+    data_type => "enum",
+    default_value => "integration",
+    extra => {
+      custom_type_name => "device_phase_enum",
+      list => [
+        "integration",
+        "installation",
+        "production",
+        "diagnostics",
+        "decommissioned",
+      ],
+    },
+    is_nullable => 0,
+  },
 );
 
 =head1 PRIMARY KEY
@@ -214,8 +237,12 @@ Composing rels: L</workspace_racks> -> workspace
 __PACKAGE__->many_to_many("workspaces", "workspace_racks", "workspace");
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2019-03-07 10:14:51
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:G50OZHxFNQDcAfKEuYUX+w
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2019-04-18 13:31:36
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:gsU10g932Bm/rPRdxIykyA
+
+__PACKAGE__->add_columns(
+    '+phase' => { retrieve_on_insert => 1 },
+);
 
 sub TO_JSON {
     my $self = shift;

--- a/lib/Conch/Route/Datacenter.pm
+++ b/lib/Conch/Route/Datacenter.pm
@@ -43,6 +43,7 @@ Sets up the routes for /dc, /room, /rack_role, /rack and /layout:
     GET     /rack/:rack_id/assignment
     POST    /rack/:rack_id/assignment
     DELETE  /rack/:rack_id/assignment
+    POST    /rack/:rack_id/phase?rack_only=<0|1>
 
     GET     /layout
     POST    /layout
@@ -148,6 +149,9 @@ sub routes {
         $with_rack->post('/assignment')->to('#set_assignment');
         # DELETE /rack/:rack_id/assignment
         $with_rack->delete('/assignment')->to('#delete_assignment');
+
+        # POST /rack/:rack_id/phase?rack_only=<0|1>
+        $with_rack->post('/phase')->to('#set_phase');
     }
 
     # /layout

--- a/sql/migrations/0091-rack-phase.sql
+++ b/sql/migrations/0091-rack-phase.sql
@@ -1,0 +1,5 @@
+SELECT run_migration(91, $$
+
+    alter table rack add column phase device_phase_enum default 'integration' not null;
+
+$$);

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -492,7 +492,8 @@ CREATE TABLE public.rack (
     created timestamp with time zone DEFAULT now() NOT NULL,
     updated timestamp with time zone DEFAULT now() NOT NULL,
     serial_number text,
-    asset_tag text
+    asset_tag text,
+    phase public.device_phase_enum DEFAULT 'integration'::public.device_phase_enum NOT NULL
 );
 
 

--- a/t/integration/crud/devices.t
+++ b/t/integration/crud/devices.t
@@ -188,7 +188,7 @@ subtest 'located device' => sub {
             hardware_product => $hardware_product_id,
             location => {
                 rack => {
-                    (map +($_ => $rack->$_), qw(id name datacenter_room_id serial_number asset_tag)),
+                    (map +($_ => $rack->$_), qw(id name datacenter_room_id serial_number asset_tag phase)),
                     role => $rack->rack_role_id,
                     (map +($_ => re(qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/)), qw(created updated)),
                 },

--- a/t/integration/crud/workspace-rack.t
+++ b/t/integration/crud/workspace-rack.t
@@ -99,6 +99,7 @@ subtest 'Add rack to workspace' => sub {
             role => 'rack_role 42U',
             # TODO? size => 42,
             datacenter => $room->az,
+            phase => 'integration',
             slots => [
                 {
                     id => ignore,
@@ -176,6 +177,7 @@ subtest 'Assign device to a location' => sub {
             role => 'rack_role 42U',
             # TODO? size => 42,
             datacenter => $room->az,
+            phase => 'integration',
             slots => [
                 {
                     id => ignore,


### PR DESCRIPTION
new endpoint: POST /rack/:id/phase

which updates the phase of all devices located in the rack, and/or the phase
of the rack itself.

closes #741.