### PR TITLE
sysadmin token endpoints

### DIFF
--- a/lib/Conch/Controller/User.pm
+++ b/lib/Conch/Controller/User.pm
@@ -546,6 +546,8 @@ Deactivates an api token from future use.
 =cut
 
 sub expire_api_token ($c) {
+    $c->log->warn('user '.$c->stash('user')->name.' expired user session token "'
+        .$c->stash('token_name').'" for user '.$c->stash('target_user')->name);
     $c->stash('token_rs')->expire;
     return $c->status(204);
 }

--- a/lib/Conch/Controller/User.pm
+++ b/lib/Conch/Controller/User.pm
@@ -32,7 +32,7 @@ sub revoke_user_tokens ($c) {
 	my $user = $c->stash('target_user');
 
 	$c->log->debug('revoking session tokens for user ' . $user->name . ', forcing them to /login again');
-	$user->delete_related('user_session_tokens');
+    $user->user_session_tokens->unexpired->expire;
 	$user->update({ refuse_session_auth => 1 });
 
 	$c->status(204);

--- a/lib/Conch/Controller/User.pm
+++ b/lib/Conch/Controller/User.pm
@@ -19,22 +19,12 @@ Conch::Controller::User
 
 =head1 METHODS
 
-=head2 revoke_own_tokens
-
-Revoke all the user's own session tokens.
-B<NOTE>: This will cause the next request to fail authentication.
-
-=cut
-
-sub revoke_own_tokens ($c) {
-	$c->log->debug('revoking user token for user ' . $c->stash('user')->name . ' at their request');
-	$c->stash('user')->delete_related('user_session_tokens');
-	$c->status(204);
-}
-
 =head2 revoke_user_tokens
 
-Revoke *all* of a specified user's session tokens. System admin only.
+Revoke *all* of a specified user's session tokens and prevents future session authentication,
+forcing the user to /login again.
+
+System admin only (unless reached via /user/me).
 
 =cut
 
@@ -58,7 +48,7 @@ sub set_settings ($c) {
     my $input = $c->validate_input('UserSettings');
     return if not $input;
 
-	my $user = $c->stash('user');
+    my $user = $c->stash('target_user');
 	Mojo::Exception->throw('Could not find previously stashed user')
 		unless $user;
 
@@ -74,7 +64,7 @@ sub set_settings ($c) {
 
 =head2 set_setting
 
-Set the value of a single setting for the user
+Set the value of a single setting for the target user.
 
 FIXME: the key name is repeated in the URL and the payload :(
 
@@ -94,7 +84,7 @@ sub set_setting ($c) {
 		}
 	) unless $value;
 
-	my $user = $c->stash('user');
+    my $user = $c->stash('target_user');
 	Mojo::Exception->throw('Could not find previously stashed user')
 		unless $user;
 
@@ -118,12 +108,12 @@ sub set_setting ($c) {
 
 =head2 get_settings
 
-Get the key/values of every setting for a User
+Get the key/values of every setting for a user.
 
 =cut
 
 sub get_settings ($c) {
-	my $user = $c->stash('user');
+    my $user = $c->stash('target_user');
 	Mojo::Exception->throw('Could not find previously stashed user')
 		unless $user;
 
@@ -138,14 +128,14 @@ sub get_settings ($c) {
 
 =head2 get_setting
 
-Get the individual key/value pair for a setting for the User
+Get the individual key/value pair for a setting for the target user.
 
 =cut
 
 sub get_setting ($c) {
 	my $key = $c->stash('key');
 
-	my $user = $c->stash('user');
+    my $user = $c->stash('target_user');
 	Mojo::Exception->throw('Could not find previously stashed user')
 		unless $user;
 
@@ -161,14 +151,14 @@ sub get_setting ($c) {
 
 =head2 delete_setting
 
-Delete a single setting for a user, provided it was set previously
+Delete a single setting for a user, provided it was set previously.
 
 =cut
 
 sub delete_setting ($c) {
 	my $key = $c->stash('key');
 
-	my $user = $c->stash('user');
+    my $user = $c->stash('target_user');
 	Mojo::Exception->throw('Could not find previously stashed user')
 		unless $user;
 
@@ -320,7 +310,7 @@ sub find_user ($c) {
 
 =head2 get
 
-Gets information about a user. System admin only.
+Gets information about a user. System admin only (unless reached via /user/me).
 Response uses the UserDetailed json schema.
 
 =cut
@@ -348,19 +338,6 @@ sub update ($c) {
 	$user->update($input);
 
 	$user->discard_changes({ prefetch => { user_workspace_roles => 'workspace' } });
-	return $c->status(200, $user);
-}
-
-=head2 get_me
-
-Just like 'get', only for the logged-in user.
-Response uses the UserDetailed json schema.
-
-=cut
-
-sub get_me ($c) {
-	my $user = $c->stash('user')
-		->discard_changes({ prefetch => { user_workspace_roles => 'workspace' } });
 	return $c->status(200, $user);
 }
 
@@ -475,7 +452,7 @@ Response uses the UserTokens json schema.
 =cut
 
 sub get_api_tokens ($c) {
-    my $rs = $c->stash('user')
+    my $rs = $c->stash('target_user')
         ->user_session_tokens
         ->api_only
         ->unexpired
@@ -497,23 +474,27 @@ sub create_api_token ($c) {
     return $c->status(400, { error => 'name "'.$input->{name}.'" is reserved' })
         if $input->{name} =~ /^login_jwt_/;
 
+    my $user = $c->stash('target_user');
+
     return $c->status(400, { error => 'name "'.$input->{name}.'" is already in use' })
-        if $c->stash('user')->user_session_tokens->search({ name => $input->{name} })->exists;
+        if $user->user_session_tokens->search({ name => $input->{name} })->exists;
 
     # default expiration: 5 years
     my $expires_abs = time + (($c->config('jwt') || {})->{custom_token_expiry} // 86400*365*5);
 
     # TODO: ew ew ew, some duplication with Conch::Controller::Login::_create_jwt.
     my ($new_db_row, $token) = $c->db_user_session_tokens->generate_for_user(
-        $c->stash('user_id'), $expires_abs, $input->{name});
+        $user->id, $expires_abs, $input->{name});
 
     my $jwt = Mojo::JWT->new(
-        claims => { uid => $c->stash('user_id'), jti => $token },
+        claims => { uid => $user->id, jti => $token },
         secret => $c->config('secrets')->[0],
         expires => $expires_abs,
     )->encode;
 
-    $c->res->headers->location($c->url_for('/user/me/token/'.$input->{name}));
+    $c->res->headers->location($c->url_for('/user/'
+        .($user->id eq $c->stash('user_id') ? 'me' : $user->id)
+        .'/token/'.$input->{name}));
     return $c->status(201, {
         token => $jwt,
         $new_db_row->TO_JSON->%*,
@@ -525,19 +506,20 @@ sub create_api_token ($c) {
 Chainable action that takes the 'token_name' provided in the path and looks it up in the
 database, stashing a resultset to access it as 'token_rs'.
 
-Only the current user may access the token. Only api tokens may be retrieved by this flow.
+Only api tokens may be retrieved by this flow.
 
 =cut
 
 sub find_api_token ($c) {
     return $c->status(404) if $c->stash('token_name') =~ /^login_jwt_/;
-    my $token_rs = $c->stash('user')
+    my $token_rs = $c->stash('target_user')
         ->user_session_tokens
         ->unexpired
-        ->search({ user_id => $c->stash('user_id'), name => $c->stash('token_name') });
+        ->search({ name => $c->stash('token_name') });
 
     if (not $token_rs->exists) {
-        $c->log->debug('Could not find token named "'.$c->stash('token_name').' for user_id '.$c->stash('user_id'));
+        $c->log->debug('Could not find token named "'.$c->stash('token_name')
+            .' for user_id '.$c->stash('target_user')->id);
         return $c->status(404);
     }
 

--- a/lib/Conch/Controller/User.pm
+++ b/lib/Conch/Controller/User.pm
@@ -466,29 +466,30 @@ sub deactivate ($c) {
 	return $c->status(204);
 }
 
-=head2 get_tokens
+=head2 get_api_tokens
 
-Get a list of unexpired tokens for the user.
+Get a list of unexpired tokens for the user (api only).
 
 Response uses the UserTokens json schema.
 
 =cut
 
-sub get_tokens ($c) {
+sub get_api_tokens ($c) {
     my $rs = $c->stash('user')
         ->user_session_tokens
+        ->api_only
         ->unexpired
         ->order_by('name');
     return $c->status(200, [ $rs->all ]);
 }
 
-=head2 create_token
+=head2 create_api_token
 
 Create a new token, creating a JWT from it.  Response uses the NewUserToken json schema.
 
 =cut
 
-sub create_token ($c) {
+sub create_api_token ($c) {
     my $input = $c->validate_input('NewUserToken');
     return if not $input;
 
@@ -519,16 +520,17 @@ sub create_token ($c) {
     });
 }
 
-=head2 find_token
+=head2 find_api_token
 
 Chainable action that takes the 'token_name' provided in the path and looks it up in the
 database, stashing a resultset to access it as 'token_rs'.
 
-Only the current user may access the token.
+Only the current user may access the token. Only api tokens may be retrieved by this flow.
 
 =cut
 
-sub find_token ($c) {
+sub find_api_token ($c) {
+    return $c->status(404) if $c->stash('token_name') =~ /^login_jwt_/;
     my $token_rs = $c->stash('user')
         ->user_session_tokens
         ->unexpired
@@ -543,25 +545,25 @@ sub find_token ($c) {
     return 1;
 }
 
-=head2 get_token
+=head2 get_api_token
 
-Get information about the specified (unexpired) token.
+Get information about the specified (unexpired) api token.
 
 Response uses the UserToken json schema.
 
 =cut
 
-sub get_token ($c) {
+sub get_api_token ($c) {
     return $c->status(200, $c->stash('token_rs')->single);
 }
 
-=head2 expire_token
+=head2 expire_api_token
 
-Deactivates a token from future use.
+Deactivates an api token from future use.
 
 =cut
 
-sub expire_token ($c) {
+sub expire_api_token ($c) {
     $c->stash('token_rs')->expire;
     return $c->status(204);
 }

--- a/lib/Conch/DB/AsEpoch.pm
+++ b/lib/Conch/DB/AsEpoch.pm
@@ -22,8 +22,10 @@ This code is postgres-specific.
 =head2 as_epoch
 
 Adds to a resultset a selection list for a timestamp column as a unix epoch time.
+If the column already existed in the selection list (presumably using the default time format),
+it is replaced.
 
-In this example, a 'created' column will be added to the result, containing a value in unix
+In this example, a 'created' column will be included in the result, containing a value in unix
 epoch time format (number of seconds since 1970-01-01 00:00:00 UTC).
 
     $rs = $rs->as_epoch('created');

--- a/lib/Conch/DB/Result/UserSessionToken.pm
+++ b/lib/Conch/DB/Result/UserSessionToken.pm
@@ -153,7 +153,7 @@ Boolean indicating whether this token was created via the main /login flow.
 =cut
 
 sub is_login ($self) {
-    $self->name =~ /^login_jwt_\d+$/;
+    $self->name =~ /^login_jwt_[\d_]+$/;
 }
 
 1;

--- a/lib/Conch/DB/ResultSet/UserSessionToken.pm
+++ b/lib/Conch/DB/ResultSet/UserSessionToken.pm
@@ -67,7 +67,8 @@ Chainable resultset to search for login tokens (created via the main /login flow
 =cut
 
 sub login_only ($self) {
-    $self->search({ name => { '-similar to' => 'login_jwt_[0-9_]+' } });
+    my $me = $self->current_source_alias;
+    $self->search({ $me.'.name' => { '-similar to' => 'login_jwt_[0-9_]+' } });
 }
 
 =head2 expire

--- a/lib/Conch/DB/ResultSet/UserSessionToken.pm
+++ b/lib/Conch/DB/ResultSet/UserSessionToken.pm
@@ -71,6 +71,17 @@ sub login_only ($self) {
     $self->search({ $me.'.name' => { '-similar to' => 'login_jwt_[0-9_]+' } });
 }
 
+=head2 api_only
+
+Chainable resultset to search for api tokens (NOT created via the main /login flow).
+
+=cut
+
+sub api_only ($self) {
+    my $me = $self->current_source_alias;
+    $self->search({ $me.'.name' => { '-not similar to' => 'login_jwt_[0-9_]+' } });
+}
+
 =head2 expire
 
 Update all matching rows by setting expires = now(). (Returns the number of rows updated.)

--- a/lib/Conch/DB/ResultSet/UserSessionToken.pm
+++ b/lib/Conch/DB/ResultSet/UserSessionToken.pm
@@ -67,7 +67,7 @@ Chainable resultset to search for login tokens (created via the main /login flow
 =cut
 
 sub login_only ($self) {
-    $self->search({ name => { '-similar to' => 'login_jwt_[0-9]+' } });
+    $self->search({ name => { '-similar to' => 'login_jwt_[0-9_]+' } });
 }
 
 =head2 expire

--- a/lib/Conch/Route/User.pm
+++ b/lib/Conch/Route/User.pm
@@ -33,6 +33,11 @@ Sets up the routes for /user:
     DELETE  /user/#target_user_id_or_email?clear_tokens=<1|0>
     POST    /user/#target_user_id_or_email/revoke
     DELETE  /user/#target_user_id_or_email/password?clear_tokens=<login_only|0|all>&send_password_reset_mail=<1|0>
+
+    GET     /user/#target_user_id_or_email/token
+    GET     /user/#target_user_id_or_email/token/:token_name
+    DELETE  /user/#target_user_id_or_email/token/:token_name
+
     GET     /user
     POST    /user?send_mail=<1|0>
 
@@ -121,6 +126,21 @@ sub routes {
         $user->require_system_admin->get('/')->to('#list');
         # POST /user?send_mail=<1|0>
         $user->require_system_admin->post('/')->to('#create');
+
+        {
+            my $user_with_target_token = $user_with_target->any('/token');
+
+            # GET /user/#target_user_id_or_email/token
+            $user_with_target_token->get('/')->to('#get_api_tokens');
+
+            my $with_token = $user_with_target_token->under('/:token_name')->to('#find_api_token');
+
+            # GET /user/#target_user_id_or_email/token/:token_name
+            $with_token->get('/')->to('#get_api_token');
+
+            # DELETE /user/#target_user_id_or_email/token/:token_name
+            $with_token->delete('/')->to('#expire_api_token');
+        }
     }
 }
 

--- a/lib/Conch/Route/User.pm
+++ b/lib/Conch/Route/User.pm
@@ -21,7 +21,7 @@ Sets up the routes for /user:
     GET     /user/me/settings/#key
     POST    /user/me/settings/#key
     DELETE  /user/me/settings/#key
-    POST    /user/me/password?clear_tokens=<0|login_only|all>
+    POST    /user/me/password?clear_tokens=<login_only|0|all>
 
     GET     /user/me/token
     POST    /user/me/token
@@ -30,12 +30,11 @@ Sets up the routes for /user:
 
     GET     /user/#target_user_id_or_email
     POST    /user/#target_user_id_or_email
-    DELETE  /user/#target_user_id_or_email?clear_tokens=<0|1>
+    DELETE  /user/#target_user_id_or_email?clear_tokens=<1|0>
     POST    /user/#target_user_id_or_email/revoke
-    DELETE  /user/#target_user_id_or_email/password
-    DELETE  /user/#target_user_id_or_email/password?clear_tokens=<0|login_only|all>&send_password_reset_mail=<0|1>
+    DELETE  /user/#target_user_id_or_email/password?clear_tokens=<login_only|0|all>&send_password_reset_mail=<1|0>
     GET     /user
-    POST    /user?send_mail=<0|1>
+    POST    /user?send_mail=<1|0>
 
 =cut
 
@@ -77,7 +76,7 @@ sub routes {
         }
 
         # after changing password, (possibly) pass through to logging out too
-        # POST /user/me/password?clear_tokens=<0|login_only|all>
+        # POST /user/me/password?clear_tokens=<login_only|0|all>
         $user_me->under('/password')->to('#change_own_password')
             ->post('/')->to('login#session_logout');
 
@@ -109,17 +108,17 @@ sub routes {
         $user_with_target->get('/')->to('#get');
         # POST /user/#target_user_id_or_email
         $user_with_target->post('/')->to('#update');
-        # DELETE /user/#target_user_id_or_email?clear_tokens=<0|1>
+        # DELETE /user/#target_user_id_or_email?clear_tokens=<1|0>
         $user_with_target->delete('/')->to('#deactivate');
 
         # POST /user/#target_user_id_or_email/revoke
         $user_with_target->post('/revoke')->to('#revoke_user_tokens');
-        # DELETE /user/#target_user_id_or_email/password?clear_tokens=<0|login_only|all>&send_password_reset_mail=<0|1>
+        # DELETE /user/#target_user_id_or_email/password?clear_tokens=<login_only|0|all>&send_password_reset_mail=<1|0>
         $user_with_target->delete('/password')->to('#reset_user_password');
 
         # GET /user
         $user->require_system_admin->get('/')->to('#list');
-        # POST /user?send_mail=<0|1>
+        # POST /user?send_mail=<1|0>
         $user->require_system_admin->post('/')->to('#create');
     }
 }

--- a/lib/Conch/Route/User.pm
+++ b/lib/Conch/Route/User.pm
@@ -84,17 +84,17 @@ sub routes {
             my $user_me_token = $user_me->any('/token');
 
             # GET /user/me/token
-            $user_me_token->get('/')->to('#get_tokens');
+            $user_me_token->get('/')->to('#get_api_tokens');
             # POST /user/me/token
-            $user_me_token->post('/')->to('#create_token');
+            $user_me_token->post('/')->to('#create_api_token');
 
-            my $with_token = $user_me_token->under('/:token_name')->to('#find_token');
+            my $with_token = $user_me_token->under('/:token_name')->to('#find_api_token');
 
             # GET /user/me/token/:token_name
-            $with_token->get('/')->to('#get_token');
+            $with_token->get('/')->to('#get_api_token');
 
             # DELETE /user/me/token/:token_name
-            $with_token->delete('/')->to('#expire_token');
+            $with_token->delete('/')->to('#expire_api_token');
         }
     }
 

--- a/lib/Conch/Route/User.pm
+++ b/lib/Conch/Route/User.pm
@@ -15,7 +15,7 @@ Conch::Route::User
 Sets up the routes for /user:
 
     GET     /user/me
-    POST    /user/me/revoke
+    POST    /user/me/revoke?login_only=<0|1> or ?api_only=<0|1>
     POST    /user/me/password?clear_tokens=<login_only|0|all>
     GET     /user/me/settings
     POST    /user/me/settings
@@ -31,7 +31,7 @@ Sets up the routes for /user:
     GET     /user/#target_user_id_or_email
     POST    /user/#target_user_id_or_email
     DELETE  /user/#target_user_id_or_email?clear_tokens=<1|0>
-    POST    /user/#target_user_id_or_email/revoke
+    POST    /user/#target_user_id_or_email/revoke?login_only=<0|1> or ?api_only=<0|1>
     DELETE  /user/#target_user_id_or_email/password?clear_tokens=<login_only|0|all>&send_password_reset_mail=<1|0>
 
     GET     /user/#target_user_id_or_email/token
@@ -59,7 +59,7 @@ sub routes {
         # GET /user/me
         $user_me->get('/')->to('#get');
 
-        # POST /user/me/revoke
+        # POST /user/me/revoke?login_only=<0|1> or ?api_only=<0|1>
         $user_me->post('/revoke')->to('#revoke_user_tokens');
 
         # POST /user/me/password?clear_tokens=<login_only|0|all>
@@ -117,7 +117,7 @@ sub routes {
         # DELETE /user/#target_user_id_or_email?clear_tokens=<1|0>
         $user_with_target->delete('/')->to('#deactivate');
 
-        # POST /user/#target_user_id_or_email/revoke
+        # POST /user/#target_user_id_or_email/revoke?login_only=<0|1> or ?api_only=<0|1>
         $user_with_target->post('/revoke')->to('#revoke_user_tokens');
         # DELETE /user/#target_user_id_or_email/password?clear_tokens=<login_only|0|all>&send_password_reset_mail=<1|0>
         $user_with_target->delete('/password')->to('#reset_user_password');

--- a/lib/Conch/Route/User.pm
+++ b/lib/Conch/Route/User.pm
@@ -16,12 +16,12 @@ Sets up the routes for /user:
 
     GET     /user/me
     POST    /user/me/revoke
+    POST    /user/me/password?clear_tokens=<login_only|0|all>
     GET     /user/me/settings
     POST    /user/me/settings
     GET     /user/me/settings/#key
     POST    /user/me/settings/#key
     DELETE  /user/me/settings/#key
-    POST    /user/me/password?clear_tokens=<login_only|0|all>
 
     GET     /user/me/token
     POST    /user/me/token
@@ -56,6 +56,11 @@ sub routes {
         # POST /user/me/revoke
         $user_me->post('/revoke')->to('#revoke_own_tokens');
 
+        # POST /user/me/password?clear_tokens=<login_only|0|all>
+        # (after changing password, (possibly) pass through to logging out too)
+        $user_me->under('/password')->to('#change_own_password')
+            ->post('/')->to('login#session_logout');
+
         {
             my $user_me_settings = $user_me->any('/settings');
 
@@ -74,11 +79,6 @@ sub routes {
             # DELETE /user/me/settings/#key
             $user_me_settings_with_key->delete('/')->to('#delete_setting');
         }
-
-        # after changing password, (possibly) pass through to logging out too
-        # POST /user/me/password?clear_tokens=<login_only|0|all>
-        $user_me->under('/password')->to('#change_own_password')
-            ->post('/')->to('login#session_logout');
 
         {
             my $user_me_token = $user_me->any('/token');

--- a/lib/Conch/Route/Workspace.pm
+++ b/lib/Conch/Route/Workspace.pm
@@ -33,7 +33,7 @@ Sets up the routes for /workspace:
     GET     /workspace/:workspace_id_or_name/relay/:relay_id/device
 
     GET     /workspace/:workspace_id_or_name/user
-    POST    /workspace/:workspace_id_or_name/user?send_mail=<0|1>
+    POST    /workspace/:workspace_id_or_name/user?send_mail=<1|0>
     DELETE  /workspace/:workspace_id_or_name/user/#target_user_id_or_email
 
 Note that in all routes using C<:workspace_id_or_name>, the stash for C<workspace_id> will be
@@ -109,7 +109,7 @@ sub routes {
 
         # GET /workspace/:workspace_id_or_name/user
         $with_workspace->get('/user')->to('workspace_user#list');
-        # POST /workspace/:workspace_id_or_name/user?send_mail=<0|1>
+        # POST /workspace/:workspace_id_or_name/user?send_mail=<1|0>
         $with_workspace->post('/user')->to('workspace_user#add_user');
         # DELETE /workspace/:workspace_id_or_name/user/#target_user_id_or_email
         $with_workspace->under('/user/#target_user_id_or_email')->to('user#find_user')

--- a/t/integration/00_only_1_user_loaded.t
+++ b/t/integration/00_only_1_user_loaded.t
@@ -838,6 +838,8 @@ subtest 'JWT authentication' => sub {
 	)->status_is( 204, "Revoke tokens for self" );
 	$t->get_ok( "/workspace", { Authorization => "Bearer $jwt_token_2" } )
 		->status_is( 401, "Cannot use after self revocation" );
+
+    $t->authenticate;
 };
 
 subtest 'modify another user' => sub {
@@ -1235,6 +1237,9 @@ subtest 'user tokens' => sub {
     $t2 = Test::Conch->new(pg => $t->pg);
     $t2->get_ok('/user/me', { Authorization => 'Bearer '.$jwt })
         ->status_is(401);
+
+    # session was wiped; need to re-auth.
+    $t->authenticate;
 };
 
 warnings(sub {

--- a/t/pod-spelling.t
+++ b/t/pod-spelling.t
@@ -22,6 +22,7 @@ all_pod_files_spelling_ok(qw(lib t misc));
 
 __DATA__
 ANDed
+api
 auth
 az
 bunyan


### PR DESCRIPTION
- fixed naming of login tokens
- all `/user/me/token` endpoints only operate on api tokens
- new endpoints, which also only operate on api tokens:

    `GET    /user/#target_user_id_or_email/token`
    `GET    /user/#target_user_id_or_email/token/:token_name`
   ` DELETE /user/#target_user_id_or_email/token/:token_name`

- `/user/*/revoke` endpoints now accept `?login_only=1`, `?api_only=1`

closes #735, #738. (replaces #737.)