### PR TITLE
do not wipe out the user password before we send it to the user

### DIFF
--- a/lib/Conch/Controller/User.pm
+++ b/lib/Conch/Controller/User.pm
@@ -284,7 +284,7 @@ sub reset_user_password ($c) {
 	}
 
 	$c->log->warn('user ' . $c->stash('user')->name . ' resetting password for user ' . $user->name);
-	$user->update(\%update);
+	$user->update({ %update });
 
 	return $c->status(204) if not $c->req->query_params->param('send_password_reset_mail') // 1;
 


### PR DESCRIPTION
This follows up on the fix in #708, where we were not sending the right password. But without
this fix too, the user will get nothing at all in their email, which is just as unhelpful.