### PR TITLE
schema tightening

### DIFF
--- a/docs/modules/conch-db-resultset-useraccount.md
+++ b/docs/modules/conch-db-resultset-useraccount.md
@@ -33,6 +33,17 @@ $schema->resultset('user_account') or $c->db_user_accounts
   });
 ```
 
+## lookup\_by\_email
+
+Queries for user by (case-insensitive) email address.
+by user id.
+
+If more than one user is found, we return the one created most recently, and a warning will be
+logged (via DBIx::Class::ResultSet::single).
+
+If you want to search only for \*active\* users, apply the `->active` resultset to the
+caller first.
+
 ## lookup\_by\_id\_or\_email
 
 Queries for user by (case-insensitive) email if string matches `/^email=/`, otherwise queries

--- a/json-schema/device_report.yaml
+++ b/json-schema/device_report.yaml
@@ -128,7 +128,7 @@ definitions:
           - serial
         properties:
           serial:
-            $ref: common.yaml#/definitions/non_empty_string
+            $ref: common.yaml#/definitions/relay_id
       serial_number:
         $ref: common.yaml#/definitions/device_id
       state:

--- a/json-schema/input.yaml
+++ b/json-schema/input.yaml
@@ -130,8 +130,8 @@ definitions:
       device_id:
         $ref: /definitions/device_id
       rack_unit_start:
-        type: integer
         description: Starting RU slot position
+        type: integer
       device_asset_tag:
         oneOf:
           - $ref: /definitions/device_asset_tag
@@ -151,8 +151,8 @@ definitions:
       device_id:
         $ref: /definitions/device_id
       rack_unit_start:
-        type: integer
         description: Starting RU slot position
+        type: integer
   RackPhase:
     type: object
     additionaProperties: false
@@ -378,8 +378,9 @@ definitions:
       hardware_vendor_id:
         $ref: /definitions/uuid
       vendor:
-        description: for backcompat only.
-        $ref: /definitions/uuid
+        allOf:
+          - description: for backcompat only.
+          - $ref: /definitions/uuid
       specification:
         description: json blob of additional data
         oneOf:
@@ -416,8 +417,9 @@ definitions:
       - password
     properties:
       user:
-        description: either a uuid, or email=<email address>
-        $ref: /definitions/non_empty_string
+        allOf:
+          - description: this is either a uuid, or email=<email address>
+          - $ref: /definitions/non_empty_string
       password:
         $ref: /definitions/non_empty_string
   ResetPassword:
@@ -581,8 +583,9 @@ definitions:
     type: array
     uniqueItems: true
     items:
-      description: datacenter room ids
-      $ref: /definitions/uuid
+      allOf:
+        - description: datacenter room ids
+        - $ref: /definitions/uuid
   RegisterRelay:
     type: object
     additionaProperties: false

--- a/json-schema/input.yaml
+++ b/json-schema/input.yaml
@@ -417,9 +417,9 @@ definitions:
       - password
     properties:
       user:
-        allOf:
-          - description: this is either a uuid, or email=<email address>
-          - $ref: /definitions/non_empty_string
+        anyOf:
+          - $ref: /definitions/uuid
+          - $ref: /definitions/email_address
       password:
         $ref: /definitions/non_empty_string
   ResetPassword:

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -52,12 +52,12 @@ definitions:
     type: object
     additionalProperties: false
     required:
+      - id
       - asset_tag
       - created
       - hardware_product
       - health
       - hostname
-      - id
       - graduated
       - last_seen
       - latest_triton_reboot
@@ -76,6 +76,8 @@ definitions:
       - latest_report
       - invalid_report
     properties:
+      id:
+        $ref: /definitions/device_id
       asset_tag:
         oneOf:
           - $ref: /definitions/device_asset_tag
@@ -91,8 +93,6 @@ definitions:
         oneOf:
           - type: string
           - type: 'null'
-      id:
-        $ref: /definitions/device_id
       graduated:
         oneOf:
           - type: string
@@ -140,7 +140,7 @@ definitions:
         $ref: /definitions/device_phase
       location:
         oneOf:
-          - $ref: "#/definitions/DeviceLocation"
+          - $ref: /definitions/DeviceLocation
           - type: 'null'
       nics: # NOTE: see also DeviceNic
         type: array
@@ -269,17 +269,17 @@ definitions:
     type: array
     uniqueItems: true
     items:
-      $ref: "#/definitions/Device"
+      $ref: /definitions/Device
   Device:
     type: object
     additionalProperties: false
     required:
+      - id
       - asset_tag
       - created
       - hardware_product
       - health
       - hostname
-      - id
       - graduated
       - last_seen
       - latest_triton_reboot
@@ -294,6 +294,8 @@ definitions:
       - rack_id
       - rack_unit_start
     properties:
+      id:
+        $ref: /definitions/device_id
       asset_tag:
         oneOf:
           - $ref: /definitions/device_asset_tag
@@ -309,8 +311,6 @@ definitions:
         oneOf:
           - type: string
           - type: 'null'
-      id:
-        $ref: /definitions/device_id
       graduated:
         oneOf:
           - type: string
@@ -439,13 +439,13 @@ definitions:
                   - vendor_name
                 properties:
                   name:
-                    type: string
                     description: datacenter.region
+                    type: string
                   vendor_name:
+                    description: datacenter.vendor_name
                     oneOf:
                       - type: 'null'
                       - type: string
-                    description: datacenter.vendor_name
               rack:
                 type: object
                 additionalProperties: false
@@ -522,13 +522,13 @@ definitions:
                 - vendor_name
               properties:
                 name:
-                  type: string
                   description: datacenter.region
+                  type: string
                 vendor_name:
+                  description: datacenter.vendor_name
                   oneOf:
                     - type: 'null'
                     - type: string
-                  description: datacenter.vendor_name
             rack:
               type: object
               additionalProperties: false
@@ -584,10 +584,8 @@ definitions:
       rack_unit_start:
         type: integer
       target_hardware_product:
+        description: Details of the hardware product the device is expected to be based on its current position and the rack layout.
         type: object
-        description: >
-          Details of the hardware product the device is expected to be based
-          on its current position and the rack layout.
         additionalProperties: false
         required:
           - id
@@ -596,22 +594,23 @@ definitions:
           - vendor
         properties:
           id:
-            $ref: /definitions/uuid
-            description: Hardware product ID
+            allOf:
+              - description: hardware product ID
+              - $ref: /definitions/uuid
           name:
-            type: string
             description: Hardware product name
+            type: string
           alias:
-            type: string
             description: Hardware product alias
-          vendor:
             type: string
+          vendor:
             description: Hardware product vendor name
+            type: string
   HardwareProducts:
     type: array
     uniqueItems: true
     items:
-      $ref: "#/definitions/HardwareProduct"
+      $ref: /definitions/HardwareProduct
   HardwareProduct:
     type: object
     additionalProperties: false
@@ -640,8 +639,9 @@ definitions:
           - type: string
           - type: 'null'
       hardware_vendor_id:
-        description: Hardware product vendor id
-        $ref: /definitions/uuid
+        allOf:
+          - description: Hardware product vendor id
+          - $ref: /definitions/uuid
       generation_name:
         oneOf:
           - type: string
@@ -673,12 +673,12 @@ definitions:
     type: object
     additionalProperties: false
     required:
+      - id
       - bios_firmware
       - cpu_num
       - cpu_type
       - dimms_num
       - hba_firmware
-      - id
       - nics_num
       - psu_total
       - purpose
@@ -702,6 +702,8 @@ definitions:
       - raid_lun_num
       - usb_num
     properties:
+      id:
+        $ref: /definitions/uuid
       bios_firmware:
         type: string
       cpu_num:
@@ -714,8 +716,6 @@ definitions:
         oneOf:
           - type: string
           - type: 'null'
-      id:
-        $ref: /definitions/uuid
       nics_num:
         type: integer
       psu_total:
@@ -858,36 +858,37 @@ definitions:
           type: object
           additionalProperties: false
           required:
+            - id
             - rack_unit_start
             - alias
-            - id
             - name
             - size
             - vendor
             - occupant
           properties:
-            rack_unit_start:
-              type: integer
-              description: Starting RU slot position
-            alias:
-              type: string
-              description: Hardware product alias
             id:
-              $ref: /definitions/uuid
-              description: Hardware product ID
-            name:
-              type: string
-              description: Hardware product name
-            size:
+              allOf:
+                - description: Hardware product ID
+                - $ref: /definitions/uuid
+            rack_unit_start:
+              description: Starting RU slot position
               type: integer
-              description: Number of RUs for slot
-            vendor:
+            alias:
+              description: Hardware product alias
               type: string
+            name:
+              description: Hardware product name
+              type: string
+            size:
+              description: Number of RUs for slot
+              type: integer
+            vendor:
               description: Hardware product vendor
+              type: string
             occupant:
               description: Device assigned to this slot, if any
               oneOf:
-                - $ref: "#/definitions/Device"
+                - $ref: /definitions/Device
                 - type: 'null'
   WorkspaceRackLayoutUpdateResponse:
     type: object
@@ -906,7 +907,7 @@ definitions:
   Validations:
     type: array
     items:
-      $ref: "#/definitions/Validation"
+      $ref: /definitions/Validation
   Validation:
     type: object
     additionalProperties: false
@@ -942,7 +943,7 @@ definitions:
     type: array
     uniqueItems: true
     items:
-      $ref: "#/definitions/ValidationPlan"
+      $ref: /definitions/ValidationPlan
   ValidationPlan:
     type: object
     additionalProperties: false
@@ -1041,7 +1042,7 @@ definitions:
     type: array
     uniqueItems: true
     items:
-      $ref: "#/definitions/ValidationStateWithResults"
+      $ref: /definitions/ValidationStateWithResults
   ValidationStateWithResults:
     type: object
     additionalProperties: false
@@ -1071,7 +1072,7 @@ definitions:
         type: array
         uniqueItems: true
         items:
-          $ref: "#/definitions/ValidationResult"
+          $ref: /definitions/ValidationResult
       status:
         $ref: /definitions/validation_status
       validation_plan_id:
@@ -1192,8 +1193,9 @@ definitions:
           - rw
           - admin
       role_via:
-        description: the id of the workspace where the permissions came from
-        $ref: /definitions/uuid
+        allOf:
+          - description: the id of the workspace where the permissions came from
+          - $ref: /definitions/uuid
   WorkspacesAndRoles:
     type: array
     uniqueItems: true
@@ -1220,8 +1222,9 @@ definitions:
         role:
           type: string
         role_via:
-          description: this is the id of the workspace where the permissions came from
-          $ref: /definitions/uuid
+          allOf:
+            - description: this is the id of the workspace where the permissions came from
+            - $ref: /definitions/uuid
   Datacenters:
     type: array
     uniqueItems: true
@@ -1285,8 +1288,9 @@ definitions:
           - type: string
           - type: 'null'
       datacenter:
-        description: datacenter id
-        $ref: /definitions/uuid
+        allOf:
+          - description: datacenter id
+          - $ref: /definitions/uuid
       created:
         type: string
         format: date-time
@@ -1297,19 +1301,21 @@ definitions:
     type: array
     uniqueItems: true
     items:
-      $ref: "#/definitions/Relay"
+      $ref: /definitions/Relay
   Relay:
     type: object
     additionalProperties: false
     required:
+      - id
       - alias
       - created
-      - id
       - ipaddr
       - ssh_port
       - updated
       - version
     properties:
+      id:
+        $ref: /definitions/relay_id
       alias:
         oneOf:
           - type: string
@@ -1317,8 +1323,6 @@ definitions:
       created:
         type: string
         format: date-time
-      id:
-        $ref: /definitions/relay_id
       ipaddr:
         oneOf:
           - $ref: /definitions/ipaddr
@@ -1346,7 +1350,7 @@ definitions:
     type: array
     uniqueItems: true
     items:
-      $ref: "#/definitions/Rack"
+      $ref: /definitions/Rack
   Rack:
     type: object
     additionalProperties: false
@@ -1411,12 +1415,12 @@ definitions:
     type: array
     uniqueItems: true
     items:
-      $ref: "#/definitions/RackRole"
+      $ref: /definitions/RackRole
   RackLayouts:
     type: array
     uniqueItems: true
     items:
-      $ref: "#/definitions/RackLayout"
+      $ref: /definitions/RackLayout
   RackLayout:
     type: object
     additionalProperties: false
@@ -1466,14 +1470,14 @@ definitions:
           - $ref: /definitions/device_asset_tag
           - type: 'null'
       hardware_product:
-        type: string
         description: name of the hardware_product designated for that slot
+        type: string
       rack_unit_start:
-        type: integer
         description: Starting RU slot position
-      rack_unit_size:
         type: integer
+      rack_unit_size:
         description: number of slots (expected to be) occupied by the hardware
+        type: integer
   User:
     type: object
     additionalProperties: false

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -1115,7 +1115,7 @@ definitions:
         - num_devices
       properties:
         id:
-          type: string
+          $ref: /definitions/relay_id
         alias:
           oneOf:
             - type: string

--- a/lib/Conch/Controller/Login.pm
+++ b/lib/Conch/Controller/Login.pm
@@ -175,7 +175,7 @@ sub authenticate ($c) {
 
     if ($user_id and is_uuid($user_id)) {
         $c->log->debug('looking up user by id '.$user_id.'...');
-        if (my $user = $c->db_user_accounts->active->lookup_by_id_or_email($user_id)) {
+        if (my $user = $c->db_user_accounts->active->find($user_id)) {
             if ($user_id and $jwt_sig) {
                 $c->log->debug('setting jwt_sig in cookie');
                 $c->cookie(
@@ -232,8 +232,8 @@ sub session_login ($c) {
     # TODO: it would be nice to be sure of which type of data we were being passed here, so we
     # don't have to look up by all columns.
     my $user_rs = $c->db_user_accounts->active;
-    my $user = $user_rs->lookup_by_id_or_email($input->{user})
-        || $user_rs->lookup_by_id_or_email('email='.$input->{user});
+    my $user = is_uuid($input->{user}) && $user_rs->find($input->{user})
+        || $user_rs->lookup_by_email($input->{user});
 
     if (not $user) {
         $c->log->debug('user lookup for '.$input->{user}.' failed');

--- a/lib/Conch/Controller/Schema.pm
+++ b/lib/Conch/Controller/Schema.pm
@@ -30,6 +30,9 @@ sub get ($c) {
     my $schema = _extract_schema_definition($validator, $name);
     return $c->status(404) if not $schema;
 
+    # ensure $id is unique
+    $schema->{'$id'} =~ s/^urn:\K/$type./;
+
     return $c->status(200, $schema);
 }
 

--- a/lib/Conch/DB/ResultSet/UserAccount.pm
+++ b/lib/Conch/DB/ResultSet/UserAccount.pm
@@ -42,6 +42,27 @@ allowing us to receive the 'password' key, which we hash into 'password_hash'.
 
 =cut
 
+=head2 lookup_by_email
+
+Queries for user by (case-insensitive) email address.
+by user id.
+
+If more than one user is found, we return the one created most recently, and a warning will be
+logged (via DBIx::Class::ResultSet::single).
+
+If you want to search only for *active* users, apply the C<< ->active >> resultset to the
+caller first.
+
+=cut
+
+sub lookup_by_email ($self, $email) {
+    return $self
+        ->search(\[ 'lower(email) = lower(?)', $email ])
+        ->order_by({ -desc => 'created' })
+        ->rows(1)
+        ->one_row;
+}
+
 =head2 lookup_by_id_or_email
 
 Queries for user by (case-insensitive) email if string matches C</^email=/>, otherwise queries

--- a/t/integration/00_only_1_user_loaded.t
+++ b/t/integration/00_only_1_user_loaded.t
@@ -28,6 +28,10 @@ $t->get_ok('/ping')
 $t->get_ok('/me')->status_is(401);
 $t->get_ok('/login')->status_is(401);
 
+$t->post_ok('/login', json => { user => 'a', password => 'b' })
+    ->status_is(400)
+    ->json_like('/error', qr/does not match/);
+
 my $now = Conch::Time->now;
 
 $t->authenticate;

--- a/t/schema.t
+++ b/t/schema.t
@@ -297,7 +297,7 @@ $t->get_ok('/schema/response/Login')
     ->json_schema_is($json_spec_schema)
     ->json_cmp_deeply({
         '$schema' => 'http://json-schema.org/draft-07/schema#',
-        '$id' => 'urn:Login.schema.json',
+        '$id' => 'urn:response.Login.schema.json',
         title => 'Login',
         type => 'object',
         additionalProperties => bool(0),
@@ -310,7 +310,7 @@ $t->get_ok('/schema/request/Login')
     ->json_schema_is($json_spec_schema)
     ->json_cmp_deeply({
         '$schema' => 'http://json-schema.org/draft-07/schema#',
-        '$id' => 'urn:Login.schema.json',
+        '$id' => 'urn:request.Login.schema.json',
         title => 'Login',
         type => 'object',
         additionalProperties => bool(0),

--- a/t/schema.t
+++ b/t/schema.t
@@ -308,11 +308,14 @@ $t->get_ok('/schema/request/Login')
         '$schema' => 'http://json-schema.org/draft-07/schema#',
         type => 'object',
         properties => {
-            user => { allOf => supersetof({'$ref' => '/definitions/non_empty_string'}) },
+            user => { anyOf => [ map +{ '$ref' => '/definitions/'.$_ }, qw(uuid email_address) ] },
             password => { '$ref' => '/definitions/non_empty_string' },
         },
         definitions => {
             non_empty_string => { type => 'string', minLength => 1 },
+            uuid => superhashof({}),
+            email_address => superhashof({}),
+            mojo_relaxed_placeholder => superhashof({}),
         },
     }));
 

--- a/t/schema.t
+++ b/t/schema.t
@@ -295,18 +295,26 @@ $t->get_ok('/schema/request/hello')
 $t->get_ok('/schema/response/Login')
     ->status_is(200)
     ->json_schema_is($json_spec_schema)
-    ->json_cmp_deeply(superhashof({
+    ->json_cmp_deeply({
         '$schema' => 'http://json-schema.org/draft-07/schema#',
+        '$id' => 'urn:Login.schema.json',
+        title => 'Login',
         type => 'object',
+        additionalProperties => bool(0),
+        required => ['jwt_token'],
         properties => { jwt_token => { type => 'string' } },
-    }));
+    });
 
 $t->get_ok('/schema/request/Login')
     ->status_is(200)
     ->json_schema_is($json_spec_schema)
-    ->json_cmp_deeply(superhashof({
+    ->json_cmp_deeply({
         '$schema' => 'http://json-schema.org/draft-07/schema#',
+        '$id' => 'urn:Login.schema.json',
+        title => 'Login',
         type => 'object',
+        additionalProperties => bool(0),
+        required => [ qw(user password) ],
         properties => {
             user => { anyOf => [ map +{ '$ref' => '/definitions/'.$_ }, qw(uuid email_address) ] },
             password => { '$ref' => '/definitions/non_empty_string' },
@@ -317,7 +325,8 @@ $t->get_ok('/schema/request/Login')
             email_address => superhashof({}),
             mojo_relaxed_placeholder => superhashof({}),
         },
-    }));
+    });
+
 
 $t->get_ok('/schema/request/HardwareProductCreate')
     ->status_is(200)

--- a/t/schema.t
+++ b/t/schema.t
@@ -308,7 +308,7 @@ $t->get_ok('/schema/request/Login')
         '$schema' => 'http://json-schema.org/draft-07/schema#',
         type => 'object',
         properties => {
-            user => { '$ref' => '/definitions/non_empty_string' },
+            user => { allOf => supersetof({'$ref' => '/definitions/non_empty_string'}) },
             password => { '$ref' => '/definitions/non_empty_string' },
         },
         definitions => {


### PR DESCRIPTION
- the input payload for `POST /login` must now be (in json) `{ user => $id, .. }` or `{ user => $email, .. }`, dropping support for `{ user => "email=$email", .. }`. I checked the shell, ui and relay code and none were using this unsupported form.

- `GET /schema/:request_or_response/:name` now returns a unique name in the `'$id'` field: previously, there was no disambiguation between request and response schemas, and some names appear in both files (e.g. 'Login').