### PR TITLE
fix /device/:id/interface/:iface_name/:field_name

### DIFF
--- a/docs/modules/Conch::Controller::DeviceInterface.md
+++ b/docs/modules/Conch::Controller::DeviceInterface.md
@@ -12,13 +12,19 @@ Chainable action that looks up the device interface by its id or name.
 
 Retrieves the value of the specified device\_nic field for the specified device interface.
 
+Response uses the DeviceNicField json schema.
+
 ## get\_one
 
 Retrieves all device\_nic fields for the specified device interface.
 
+Response uses the DeviceNic json schema.
+
 ## get\_all
 
 Retrieves all device\_nic records for the specified device.
+
+Response uses the DeviceNics json schema.
 
 # LICENSING
 

--- a/docs/modules/Conch::DB::ResultSet::DeviceNic.md
+++ b/docs/modules/Conch::DB::ResultSet::DeviceNic.md
@@ -23,6 +23,10 @@ network interface(s) named "ipmi1".
 Suitable for embedding as a sub-query; post-processing will be required to extract the two
 columns into the desired format.
 
+## fields
+
+The list of fields associated with each network interface entry.
+
 # LICENSING
 
 Copyright Joyent, Inc.

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -383,18 +383,22 @@ definitions:
     items:
       $ref: /definitions/DeviceNic
   DeviceNic:
+    allOf:
+      - $ref: /definitions/DeviceNicFields
+      - type: object
+        required:
+          - device_id
+          - mac
+          - iface_name
+          - iface_vendor
+          - iface_driver
+          - state
+          - speed
+          - ipaddr
+          - mtu
+  DeviceNicFields:
     type: object
     additionalProperties: false
-    required:
-      - device_id
-      - mac
-      - iface_name
-      - iface_vendor
-      - iface_driver
-      - state
-      - speed
-      - ipaddr
-      - mtu
     properties:
       device_id:
         $ref: /definitions/device_id
@@ -425,8 +429,14 @@ definitions:
           - type: integer
           - type: 'null'
   DeviceNicField:
-    type: object
-    maxProperties: 1
+    allOf:
+      - $ref: /definitions/DeviceNicFields
+      - type: object
+        maxProperties: 1
+      - not:
+          type: object
+          required:
+            - device_id
   DevicePXE:
     type: object
     additionalProperties: false

--- a/lib/Conch.pm
+++ b/lib/Conch.pm
@@ -133,7 +133,7 @@ sub startup {
     Conch::ValidationSystem->new(log => $self->log, schema => $self->ro_schema)
         ->check_validation_plans;
 
-    Conch::Route->all_routes($self->routes);
+    Conch::Route->all_routes($self->routes, $self);
 }
 
 1;

--- a/lib/Conch/Controller/DeviceInterface.pm
+++ b/lib/Conch/Controller/DeviceInterface.pm
@@ -46,11 +46,7 @@ Response uses the DeviceNicField json schema.
 =cut
 
 sub get_one_field ($c) {
-    my $field = $c->stash('field_name');
-
-    return $c->status(400, "column '$field' is not recognized.")
-        if none { $field eq $_ } $c->schema->source('device_nic')->columns;
-
+    my $field = $c->stash('field');
     my $rs = $c->stash('device_interface_rs');
     return $c->status(200, { $field => $rs->get_column($field)->single });
 }

--- a/lib/Conch/Controller/DeviceInterface.pm
+++ b/lib/Conch/Controller/DeviceInterface.pm
@@ -59,6 +59,7 @@ sub get_one_field ($c) {
 Retrieves all device_nic fields for the specified device interface.
 
 Response uses the DeviceNic json schema.
+
 =cut
 
 sub get_one ($c) {

--- a/lib/Conch/Controller/DeviceInterface.pm
+++ b/lib/Conch/Controller/DeviceInterface.pm
@@ -25,7 +25,8 @@ sub find_device_interface ($c) {
         .' for device_id '.$c->stash('device_id'));
 
     my $nic_rs = $c->stash('device_rs')
-        ->search_related('device_nics', { iface_name => $interface_name });
+        ->search_related('device_nics', { iface_name => $interface_name })
+        ->active;
     if (not $nic_rs->exists) {
         $c->log->debug("Failed to find interface $interface_name for device ".$c->stash('device_id'));
         return $c->status(404);
@@ -75,7 +76,7 @@ Response uses the DeviceNics json schema.
 =cut
 
 sub get_all ($c) {
-    my $rs = $c->stash('device_rs')->related_resultset('device_nics');
+    my $rs = $c->stash('device_rs')->related_resultset('device_nics')->active;
     return $c->status(200, [ $rs->all ]);
 }
 

--- a/lib/Conch/DB/ResultSet/DeviceNic.pm
+++ b/lib/Conch/DB/ResultSet/DeviceNic.pm
@@ -52,6 +52,17 @@ sub nic_ipmi ($self) {
         ->columns([ \'array[mac::text, host(ipaddr)]' ]);
 }
 
+=head2 fields
+
+The list of fields associated with each network interface entry.
+
+=cut
+
+sub fields ($self) {
+    my %exclude; @exclude{qw(device_id deactivated created updated)} = ();
+    grep !exists $exclude{$_}, $self->result_source->columns;
+}
+
 1;
 __END__
 

--- a/lib/Conch/Route.pm
+++ b/lib/Conch/Route.pm
@@ -33,7 +33,8 @@ Set up the full route structure
 
 sub all_routes (
     $class,
-    $root,    # this is the base routing object
+    $root,  # this is the base routing object
+    $app,   # the Conch app
 ) {
 
     # provides a route to chain to that first checks the user is a system admin.
@@ -87,7 +88,7 @@ sub all_routes (
     $secured->post('/refresh_token')->to('login#refresh_token');
 
     Conch::Route::Workspace->routes($secured->any('/workspace'));
-    Conch::Route::Device->routes($secured->any('/device'));
+    Conch::Route::Device->routes($secured->any('/device'), $app);
     Conch::Route::DeviceReport->routes($secured->any('/device_report'));
     Conch::Route::Relay->routes($secured->any('/relay'));
     Conch::Route::User->routes($secured->any('/user'));

--- a/lib/Conch/Route/Device.pm
+++ b/lib/Conch/Route/Device.pm
@@ -50,6 +50,7 @@ Sets up the routes for /device:
 sub routes {
     my $class = shift;
     my $device = shift; # secured, under /device
+    my $app = shift;
 
     # POST /device/:device_id
     $device->post('/:device_id')->to('device_report#process');
@@ -136,7 +137,8 @@ sub routes {
             $with_interface_name->get('/')->to('#get_one');
 
             # GET /device/:device_id/interface/:interface_name/:field
-            $with_interface_name->get('/:field_name')->to('#get_one_field');
+            $with_interface_name->get('/:field', [ field => [ $app->db_device_nics->fields ] ])
+                ->to('#get_one_field');
         }
     }
 }

--- a/t/integration/crud/devices.t
+++ b/t/integration/crud/devices.t
@@ -288,6 +288,12 @@ subtest 'device network interfaces' => sub {
         ->status_is(200)
         ->json_schema_is('DeviceNic');
 
+    $t->get_ok('/device/TEST/interface/ipmi1/device_id')
+        ->status_is(404);
+
+    $t->get_ok('/device/TEST/interface/ipmi1/created')
+        ->status_is(404);
+
     $t->get_ok('/device/TEST/interface/ipmi1/mac')
         ->status_is(200)
         ->json_schema_is('DeviceNicField')

--- a/t/json-validation.t
+++ b/t/json-validation.t
@@ -1,0 +1,36 @@
+use strict;
+use warnings;
+
+use Test::Conch;
+use Test::More;
+use Test::Warnings;
+use JSON::Validator;
+use Test::Deep;
+use Test::Fatal;
+
+my $t = Test::Conch->new;
+
+subtest '/device/:id/interface/:iface_name/:field validation' => sub {
+    my $validator = $t->app->get_response_validator;
+    my $schema = $validator->get('/definitions/DeviceNicField');
+
+    cmp_deeply(
+        [ $validator->validate({ device_id => 'TEST' }, $schema) ],
+        [ methods(message => re(qr/should not match/i)) ],
+        'device_id is not a valid response field',
+    );
+
+    cmp_deeply(
+        [ $validator->validate({ created => '2018-01-02T00:00:00.000+00:20' }, $schema) ],
+        [ methods(message => re(qr/not allowed/i)) ],
+        'created is not a valid response field',
+    );
+
+    cmp_deeply(
+        [ $validator->validate({ iface_name => 'foo' }, $schema) ],
+        [],
+        'iface_name is a valid response field',
+    );
+};
+
+done_testing;


### PR DESCRIPTION
tighten both the endpoint route definition and the json schema so they only allows what they should.