### PR TITLE
Align the Workspace route with the WorkspaceDevice controller

### DIFF
--- a/docs/modules/Conch::Route::Workspace.md
+++ b/docs/modules/Conch::Route::Workspace.md
@@ -18,8 +18,8 @@ GET     /workspace/:workspace_id_or_name/device
             ?graduated=<T|F>
             ?validated=<T|F>
             ?health=<error|fail|unknown|pass>
-            ?active=T
-            ?ids_only=T
+            ?active=1
+            ?ids_only=1
 GET     /workspace/:workspace_id_or_name/device/active
 GET     /workspace/:workspace_id_or_name/device/pxe
 

--- a/lib/Conch/Route/Workspace.pm
+++ b/lib/Conch/Route/Workspace.pm
@@ -23,8 +23,8 @@ Sets up the routes for /workspace:
                 ?graduated=<T|F>
                 ?validated=<T|F>
                 ?health=<error|fail|unknown|pass>
-                ?active=T
-                ?ids_only=T
+                ?active=1
+                ?ids_only=1
     GET     /workspace/:workspace_id_or_name/device/active
     GET     /workspace/:workspace_id_or_name/device/pxe
 
@@ -70,13 +70,13 @@ sub routes {
         # GET /workspace/:workspace_id_or_name/device?<various query params>
         $with_workspace->get('/device')->to('workspace_device#list');
 
-        # GET /workspace/:workspace_id_or_name/device/active -> /workspace/:workspace_id_or_name/device?active=t
+        # GET /workspace/:workspace_id_or_name/device/active -> /workspace/:workspace_id_or_name/device?active=1
         $with_workspace->get(
             '/device/active',
             sub ($c) {
                 $c->redirect_to(
                     $c->url_for('/workspace/'.$c->stash('workspace_id').'/device')
-                        ->query(active => 't'));
+                        ->query(active => '1'));
             }
         );
 

--- a/t/integration/crud/workspace-devices.t
+++ b/t/integration/crud/workspace-devices.t
@@ -171,12 +171,12 @@ $t->get_ok("/workspace/$global_ws_id/device?ids_only=1&health=pass")
     ->json_schema_is('DeviceIds')
     ->json_is(['TEST']);
 
-$t->get_ok("/workspace/$global_ws_id/device?active=t")
+$t->get_ok("/workspace/$global_ws_id/device?active=1")
     ->status_is(200)
     ->json_schema_is('Devices')
     ->json_is([ $devices_data->[0] ]);
 
-$t->get_ok("/workspace/$global_ws_id/device?active=t&graduated=t")
+$t->get_ok("/workspace/$global_ws_id/device?active=1&graduated=t")
     ->status_is(200)
     ->json_schema_is('Devices')
     ->json_is([ $devices_data->[0] ]);
@@ -186,7 +186,7 @@ $t->get_ok("/workspace/$global_ws_id/device?active=t&graduated=t")
 subtest 'Redirect /workspace/:id/device/active' => sub {
     $t->get_ok("/workspace/$global_ws_id/device/active")
         ->status_is(302)
-        ->location_is("/workspace/$global_ws_id/device?active=t");
+        ->location_is("/workspace/$global_ws_id/device?active=1");
 
     my $temp = $t->ua->max_redirects;
     $t->ua->max_redirects(1);


### PR DESCRIPTION
A couple of our query parmas in `Conch::Controller::WorkspaceDevice`
don't explicitly need a `T` or `F`. This aligns the redirect and docs in
the route with the expectations in documented in the controller.