### PR TITLE
validation for HDD sizes

### DIFF
--- a/docs/modules/Conch::Command::add_hdd_size_validation.md
+++ b/docs/modules/Conch::Command::add_hdd_size_validation.md
@@ -1,0 +1,19 @@
+# NAME
+
+add\_hdd\_size\_validation - Add the 'hdd\_size' validation to the Server validation plan
+
+# SYNOPSIS
+
+```
+bin/conch add_hdd_size_validation [long options...]
+
+    --help          print usage message and exit
+```
+
+# LICENSING
+
+Copyright Joyent, Inc.
+
+This Source Code Form is subject to the terms of the Mozilla Public License,
+v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+one at [http://mozilla.org/MPL/2.0/](http://mozilla.org/MPL/2.0/).

--- a/docs/modules/Conch::Validation::HddSize.md
+++ b/docs/modules/Conch::Validation::HddSize.md
@@ -1,0 +1,7 @@
+# LICENSING
+
+Copyright Joyent, Inc.
+
+This Source Code Form is subject to the terms of the Mozilla Public License,
+v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+one at [http://mozilla.org/MPL/2.0/](http://mozilla.org/MPL/2.0/).

--- a/json-schema/device_report.yaml
+++ b/json-schema/device_report.yaml
@@ -1,7 +1,7 @@
 ---
 $schema: 'http://json-schema.org/draft-07/schema#'
 definitions:
-  DeviceReport_v2.24:
+  DeviceReport_v2.29:
     description: the contents of a posted device report from relays and reporters
     type: object
     required:
@@ -60,6 +60,8 @@ definitions:
                 $ref: common.yaml#/definitions/int_or_stringy_int
               hba:
                 $ref: common.yaml#/definitions/int_or_stringy_int
+              block_sz:
+                type: integer
               # any additional fields are not currently used.
       device_type:
         type: string

--- a/json-schema/input.yaml
+++ b/json-schema/input.yaml
@@ -80,7 +80,7 @@ definitions:
       vendor_name:
         type: string
   DeviceReport:
-    $ref: device_report.yaml#/definitions/DeviceReport_v2.24
+    $ref: device_report.yaml#/definitions/DeviceReport_v2.29
   RackCreate:
     type: object
     additionalProperties: false

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -266,7 +266,7 @@ definitions:
         description: the contents of the device report. Given its age we cannot provide a schema.
         anyOf:
           - type: 'null'
-          - $ref: device_report.yaml#/definitions/DeviceReport_v2.24
+          - $ref: device_report.yaml#/definitions/DeviceReport_v2.29
           - type: object  # TODO: remove this loose alternative when we purge historical db records
       invalid_report:
         description: this could be anything, from encoded json to random junk

--- a/lib/Conch/Command/add_hdd_size_validation.pm
+++ b/lib/Conch/Command/add_hdd_size_validation.pm
@@ -1,0 +1,62 @@
+package Conch::Command::add_hdd_size_validation;
+
+=pod
+
+=head1 NAME
+
+add_hdd_size_validation - Add the 'hdd_size' validation to the Server validation plan
+
+=head1 SYNOPSIS
+
+    bin/conch add_hdd_size_validation [long options...]
+
+        --help          print usage message and exit
+
+=cut
+
+use Mojo::Base 'Mojolicious::Command', -signatures;
+use Getopt::Long::Descriptive;
+
+has description => 'Add the hdd_size validation to the Server validation_plan';
+
+has usage => sub { shift->extract_usage };  # extracts from SYNOPSIS
+
+sub run ($self, @opts) {
+    local @ARGV = @opts;
+    my ($opt, $usage) = describe_options(
+        # the descriptions aren't actually used anymore (mojo uses the synopsis instead)... but
+        # the 'usage' text block can be accessed with $usage->text
+        'add_hdd_size_validation %o',
+        [],
+        [ 'help',  'print usage message and exit', { shortcircuit => 1 } ],
+    );
+
+    my $validation_plan = $self->app->db_validation_plans
+        ->active
+        ->find({ name => 'Conch v1 Legacy Plan: Server' });
+
+    Conch::ValidationSystem->new(log => $self->app->log, schema => $self->app->schema)
+        ->load_validations;
+
+    my $hdd_size_validation = $self->app->db_validations
+        ->active
+        ->find({ module => 'Conch::Validation::HddSize' });
+
+    $validation_plan->add_to_validation_plan_members({ validation => $hdd_size_validation });
+}
+
+1;
+__END__
+
+=pod
+
+=head1 LICENSING
+
+Copyright Joyent, Inc.
+
+This Source Code Form is subject to the terms of the Mozilla Public License,
+v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+one at L<http://mozilla.org/MPL/2.0/>.
+
+=cut
+# vim: set ts=4 sts=4 sw=4 et :

--- a/lib/Conch/Validation/HddSize.pm
+++ b/lib/Conch/Validation/HddSize.pm
@@ -1,0 +1,53 @@
+package Conch::Validation::HddSize;
+
+use Mojo::Base 'Conch::Validation', -signatures;
+use Mojo::JSON 'from_json';
+
+use constant name        => 'hdd_size';
+use constant version     => 1;
+use constant category    => 'DISK';
+use constant description => 'Check hard drive sizes';
+
+sub validate ($self, $data) {
+    my $hw_spec = from_json($self->hardware_product_specification // {});
+
+    return if not $hw_spec->{disk_size};
+
+    foreach my $disk_serial (keys $data->{disks}->%*) {
+        my $drive_model = $data->{disks}{$disk_serial}{model};
+        if (not $drive_model) {
+            $self->fail('missing drive model for disk '.$disk_serial,
+                component_id => $disk_serial);
+            next;
+        }
+
+        # expected block_sz is indexed by disk 'model', falling back to '_default'.
+        my $size_spec = $hw_spec->{disk_size}{$drive_model} // $hw_spec->{disk_size}{_default};
+        if (not $size_spec) {
+            $self->fail('missing size specification for model '.$drive_model,
+                component_id => $disk_serial);
+            next;
+        }
+
+        $self->register_result(
+            got => $data->{disks}{$disk_serial}{block_sz},
+            expected => $size_spec,
+            component_id => $disk_serial,
+        );
+    }
+}
+
+1;
+__END__
+
+=pod
+
+=head1 LICENSING
+
+Copyright Joyent, Inc.
+
+This Source Code Form is subject to the terms of the Mozilla Public License,
+v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+one at L<http://mozilla.org/MPL/2.0/>.
+
+=cut

--- a/t/validations/hdd_size.t
+++ b/t/validations/hdd_size.t
@@ -1,0 +1,156 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Warnings;
+use Mojo::JSON 'to_json';
+use Test::Conch::Validation 'test_validation';
+
+test_validation(
+    'Conch::Validation::HddSize',
+    hardware_product => {
+        name => 'Test Product',
+        specification => to_json({}),
+    },
+    cases => [
+        {
+            description => 'no hardware specification for disk size',
+            data => {},
+            success_num => 0,
+            error_num => 0,
+        },
+    ],
+);
+
+test_validation(
+    'Conch::Validation::HddSize',
+    hardware_product => {
+        name => 'Test Product',
+        specification => to_json({
+            disk_size => {
+                pinto => 32,
+                gremlin => 64,
+            },
+        }),
+    },
+    cases => [
+        {
+            description => 'missing drive model',
+            data => {
+                disks => {
+                    foo => {
+                        vendor => 'some corp',
+                    },
+                },
+            },
+            failure_num => 1,
+        },
+        {
+            description => 'missing size specification for this model',
+            data => {
+                disks => {
+                    foo => {
+                        vendor => 'some corp',
+                        model => 'fiesta',
+                    },
+                },
+            },
+            failure_num => 1,
+        },
+        {
+            description => 'missing block_sz in report',
+            data => {
+                disks => {
+                    foo => {
+                        vendor => 'some corp',
+                        model => 'pinto',
+                    },
+                },
+            },
+            failure_num => 1,
+        },
+        {
+            description => 'wrong size',
+            data => {
+                disks => {
+                    foo => {
+                        model => 'pinto',
+                        block_sz => 64,
+                    },
+                },
+            },
+            failure_num => 1,
+        },
+        {
+            description => 'correct size',
+            data => {
+                disks => {
+                    foo => {
+                        model => 'pinto',
+                        block_sz => 32,
+                    },
+                },
+            },
+            success_num => 1,
+        },
+        {
+            description => 'correct size, multiple drives',
+            data => {
+                disks => {
+                    foo => {
+                        model => 'pinto',
+                        block_sz => 32,
+                    },
+                    bar => {
+                        model => 'gremlin',
+                        block_sz => 64,
+                    },
+                },
+            },
+            success_num => 2,
+        },
+    ],
+);
+
+test_validation(
+    'Conch::Validation::HddSize',
+    hardware_product => {
+        name => 'Test Product',
+        specification => to_json({
+            disk_size => {
+                _default => 128,
+                pinto => 32,
+                gremlin => 64,
+            },
+        }),
+    },
+    cases => [
+        {
+            description => 'missing size specification for this model - use default (fail)',
+            data => {
+                disks => {
+                    foo => {
+                        vendor => 'some corp',
+                        model => 'fiesta',
+                        block_sz => 64,
+                    },
+                },
+            },
+            failure_num => 1,
+        },
+        {
+            description => 'missing size specification for this model - use default (pass)',
+            data => {
+                disks => {
+                    foo => {
+                        vendor => 'some corp',
+                        model => 'fiesta',
+                        block_sz => 128,
+                    },
+                },
+            },
+            success_num => 1,
+        },
+    ],
+);
+
+done_testing;


### PR DESCRIPTION
This relies on the use of the 'specification' field in the hardware_product
table, specifically a section structured thusly (encoded as a json string):

    {
      disk_size => {
        <disk model> => <size in blocks>,
        ...,
        _default => <size to assume if the model is not listed here>,
      },
    }

Every device sku that needs a hard drive size validation will need this data
entered into its hardware_product.specification. Those skus that do not need
such validation need not have their data modified, and the validation will be
skipped.

closes #574.

Requires a utility to be run to add the validation to the appropriate plan before it can be used.