### PR TITLE
POST /rack/:id/assignment now overwrites existing assignments

### DIFF
--- a/docs/modules/Conch::Controller::Rack.md
+++ b/docs/modules/Conch::Controller::Rack.md
@@ -47,6 +47,7 @@ Response uses the RackAssignments json schema.
 ## set\_assignment
 
 Assigns devices to rack layouts, also optionally updating asset\_tags.
+Existing devices in referenced slots will be removed as needed.
 
 ## delete\_assignment
 


### PR DESCRIPTION
Rather than requiring the user to move aside existing devices in the layout of
concern, or to remove devices from their previous assignments, we now do all
this work in one go, atomically.

closes #797.