### PR TITLE
v3: relays!

### DIFF
--- a/docs/modules/Conch::Controller::Relay.md
+++ b/docs/modules/Conch::Controller::Relay.md
@@ -16,6 +16,13 @@ Requires the user to be a system admin.
 
 Response uses the Relays json schema.
 
+## get
+
+Get the details of a single relay.
+Requires the user to be a system admin, or have previously registered the relay.
+
+Response uses the Relay json schema.
+
 # LICENSING
 
 Copyright Joyent, Inc.

--- a/docs/modules/Conch::Controller::Relay.md
+++ b/docs/modules/Conch::Controller::Relay.md
@@ -11,7 +11,8 @@ not already exist.
 
 ## list
 
-If the user is a system admin, retrieve a list of all active relays in the database
+If the user is a system admin, retrieve a list of all active relays in the database.
+Requires the user to be a system admin.
 
 Response uses the Relays json schema.
 

--- a/docs/modules/Conch::Controller::Relay.md
+++ b/docs/modules/Conch::Controller::Relay.md
@@ -7,7 +7,7 @@ Conch::Controller::Relay
 ## register
 
 Registers a relay and connects it with the current user. The relay is created if the relay does
-not already exist.
+not already exist, or is updated with additional payload information otherwise.
 
 ## list
 

--- a/docs/modules/Conch::DB::Result::DeviceRelayConnection.md
+++ b/docs/modules/Conch::DB::Result::DeviceRelayConnection.md
@@ -16,14 +16,6 @@ is_foreign_key: 1
 is_nullable: 0
 ```
 
-## relay\_id
-
-```
-data_type: 'text'
-is_foreign_key: 1
-is_nullable: 0
-```
-
 ## first\_seen
 
 ```perl
@@ -40,6 +32,15 @@ data_type: 'timestamp with time zone'
 default_value: current_timestamp
 is_nullable: 0
 original: {default_value => \"now()"}
+```
+
+## relay\_id
+
+```
+data_type: 'uuid'
+is_foreign_key: 1
+is_nullable: 0
+size: 16
 ```
 
 # PRIMARY KEY

--- a/docs/modules/Conch::DB::Result::Relay.md
+++ b/docs/modules/Conch::DB::Result::Relay.md
@@ -8,14 +8,14 @@ Conch::DB::Result::Relay
 
 # ACCESSORS
 
-## id
+## serial\_number
 
 ```
 data_type: 'text'
 is_nullable: 0
 ```
 
-## alias
+## name
 
 ```
 data_type: 'text'
@@ -68,9 +68,24 @@ is_nullable: 0
 original: {default_value => \"now()"}
 ```
 
+## id
+
+```
+data_type: 'uuid'
+default_value: gen_random_uuid()
+is_nullable: 0
+size: 16
+```
+
 # PRIMARY KEY
 
 - ["id"](#id)
+
+# UNIQUE CONSTRAINTS
+
+## `relay_serial_number_key`
+
+- ["serial\_number"](#serial_number)
 
 # RELATIONS
 

--- a/docs/modules/Conch::DB::Result::UserRelayConnection.md
+++ b/docs/modules/Conch::DB::Result::UserRelayConnection.md
@@ -17,14 +17,6 @@ is_nullable: 0
 size: 16
 ```
 
-## relay\_id
-
-```
-data_type: 'text'
-is_foreign_key: 1
-is_nullable: 0
-```
-
 ## first\_seen
 
 ```perl
@@ -41,6 +33,15 @@ data_type: 'timestamp with time zone'
 default_value: current_timestamp
 is_nullable: 0
 original: {default_value => \"now()"}
+```
+
+## relay\_id
+
+```
+data_type: 'uuid'
+is_foreign_key: 1
+is_nullable: 0
+size: 16
 ```
 
 # PRIMARY KEY

--- a/docs/modules/Conch::Route::Relay.md
+++ b/docs/modules/Conch::Route::Relay.md
@@ -10,7 +10,7 @@ Sets up the routes for /relay:
 
 Unless otherwise noted, all routes require authentication.
 
-### `POST /relay/:relay_id/register`
+### `POST /relay/:relay_serial_number/register`
 
 - Request: request.yaml#/RegisterRelay
 - Response: `204 NO CONTENT`

--- a/docs/modules/Conch::Route::Relay.md
+++ b/docs/modules/Conch::Route::Relay.md
@@ -20,6 +20,11 @@ Unless otherwise noted, all routes require authentication.
 - Requires system admin authorization
 - Response: response.yaml#/Relays
 
+### `GET /relay/:relay_serial_number`
+
+- Requires system admin authorization, or the user to have previously registered the relay.
+- Response: response.yaml#/Relay
+
 # LICENSING
 
 Copyright Joyent, Inc.

--- a/docs/modules/Conch::Route::Relay.md
+++ b/docs/modules/Conch::Route::Relay.md
@@ -13,7 +13,7 @@ Unless otherwise noted, all routes require authentication.
 ### `POST /relay/:relay_serial_number/register`
 
 - Request: request.yaml#/RegisterRelay
-- Response: `204 NO CONTENT`
+- Response: `201 CREATED` or `204 NO CONTENT`, plus Location header
 
 ### `GET /relay`
 

--- a/docs/modules/Conch::Route::Relay.md
+++ b/docs/modules/Conch::Route::Relay.md
@@ -20,7 +20,7 @@ Unless otherwise noted, all routes require authentication.
 - Requires system admin authorization
 - Response: response.yaml#/Relays
 
-### `GET /relay/:relay_serial_number`
+### `GET /relay/:relay_id_or_serial_number`
 
 - Requires system admin authorization, or the user to have previously registered the relay.
 - Response: response.yaml#/Relay

--- a/json-schema/common.yaml
+++ b/json-schema/common.yaml
@@ -13,7 +13,7 @@ definitions:
   macaddr:
     type: string
     pattern: "^[0-9a-f]{2}:[0-9a-f]{2}:[0-9a-f]{2}:[0-9a-f]{2}:[0-9a-f]{2}:[0-9a-f]{2}$"
-  relay_id:
+  relay_serial_number:
     type: string
     pattern: ^\S+$
   device_id:

--- a/json-schema/device_report.yaml
+++ b/json-schema/device_report.yaml
@@ -130,7 +130,7 @@ definitions:
           - serial
         properties:
           serial:
-            $ref: common.yaml#/definitions/relay_id
+            $ref: common.yaml#/definitions/relay_serial_number
       serial_number:
         $ref: common.yaml#/definitions/device_id
       state:

--- a/json-schema/request.yaml
+++ b/json-schema/request.yaml
@@ -505,8 +505,8 @@ definitions:
       - serial
     properties:
       serial:
-        $ref: common.yaml#/definitions/relay_id
-      alias:
+        $ref: common.yaml#/definitions/relay_serial_number
+      name:
         type: string
       version:
         description: usually a git commit SHA

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -1163,7 +1163,8 @@ definitions:
       additionalProperties: false
       required:
         - id
-        - alias
+        - serial_number
+        - name
         - version
         - ipaddr
         - ssh_port
@@ -1174,8 +1175,10 @@ definitions:
         - num_devices
       properties:
         id:
-          $ref: common.yaml#/definitions/relay_id
-        alias:
+          $ref: common.yaml#/definitions/uuid
+        serial_number:
+          $ref: common.yaml#/definitions/relay_serial_number
+        name:
           oneOf:
             - type: string
             - type: 'null'
@@ -1360,16 +1363,19 @@ definitions:
     additionalProperties: false
     required:
       - id
-      - alias
-      - created
+      - serial_number
+      - name
+      - version
       - ipaddr
       - ssh_port
+      - created
       - updated
-      - version
     properties:
       id:
-        $ref: common.yaml#/definitions/relay_id
-      alias:
+        $ref: common.yaml#/definitions/uuid
+      serial_number:
+        $ref: common.yaml#/definitions/relay_serial_number
+      name:
         oneOf:
           - type: string
           - type: 'null'

--- a/lib/Conch/Controller/Relay.pm
+++ b/lib/Conch/Controller/Relay.pm
@@ -54,6 +54,27 @@ sub list ($c) {
     $c->status(200, [ $c->db_relays->active->order_by('id')->all ]);
 }
 
+=head2 get
+
+Get the details of a single relay.
+Requires the user to be a system admin, or have previously registered the relay.
+
+Response uses the Relay json schema.
+
+=cut
+
+sub get ($c) {
+    my $rs = $c->db_relays->active->search_rs({ id => $c->stash('relay_serial_number') });
+    return $c->status(404) if not $rs->exists;
+
+    $rs = $rs->search({ user_id => $c->stash('user_id') }, { join => 'user_relay_connections' })
+        if not $c->is_system_admin;
+
+    my $relay = $rs->single;
+    return $c->status(403) if not $relay;
+    $c->status(200, $relay);
+}
+
 1;
 __END__
 

--- a/lib/Conch/Controller/Relay.pm
+++ b/lib/Conch/Controller/Relay.pm
@@ -42,7 +42,8 @@ sub register ($c) {
 
 =head2 list
 
-If the user is a system admin, retrieve a list of all active relays in the database
+If the user is a system admin, retrieve a list of all active relays in the database.
+Requires the user to be a system admin.
 
 Response uses the Relays json schema.
 

--- a/lib/Conch/Controller/Relay.pm
+++ b/lib/Conch/Controller/Relay.pm
@@ -22,7 +22,7 @@ sub register ($c) {
     return if not $input;
 
     return $c->status(400, { error => 'serial number in path doesn\'t match payload data' })
-        if $c->stash('relay_id') ne $input->{serial};
+        if $c->stash('relay_serial_number') ne $input->{serial};
 
 
     my $relay = $c->db_relays->update_or_create({

--- a/lib/Conch/DB/Result/DeviceRelayConnection.pm
+++ b/lib/Conch/DB/Result/DeviceRelayConnection.pm
@@ -34,12 +34,6 @@ __PACKAGE__->table("device_relay_connection");
   is_foreign_key: 1
   is_nullable: 0
 
-=head2 relay_id
-
-  data_type: 'text'
-  is_foreign_key: 1
-  is_nullable: 0
-
 =head2 first_seen
 
   data_type: 'timestamp with time zone'
@@ -54,12 +48,17 @@ __PACKAGE__->table("device_relay_connection");
   is_nullable: 0
   original: {default_value => \"now()"}
 
+=head2 relay_id
+
+  data_type: 'uuid'
+  is_foreign_key: 1
+  is_nullable: 0
+  size: 16
+
 =cut
 
 __PACKAGE__->add_columns(
   "device_id",
-  { data_type => "text", is_foreign_key => 1, is_nullable => 0 },
-  "relay_id",
   { data_type => "text", is_foreign_key => 1, is_nullable => 0 },
   "first_seen",
   {
@@ -75,6 +74,8 @@ __PACKAGE__->add_columns(
     is_nullable   => 0,
     original      => { default_value => \"now()" },
   },
+  "relay_id",
+  { data_type => "uuid", is_foreign_key => 1, is_nullable => 0, size => 16 },
 );
 
 =head1 PRIMARY KEY
@@ -125,7 +126,7 @@ __PACKAGE__->belongs_to(
 
 
 # Created by DBIx::Class::Schema::Loader v0.07049
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:u0kdqblFBrr0zsYv2zDU5g
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:9KcINGmXryGqjfv5NzQvXg
 
 __PACKAGE__->has_many(
   "user_relay_connections",

--- a/lib/Conch/DB/Result/Relay.pm
+++ b/lib/Conch/DB/Result/Relay.pm
@@ -28,12 +28,12 @@ __PACKAGE__->table("relay");
 
 =head1 ACCESSORS
 
-=head2 id
+=head2 serial_number
 
   data_type: 'text'
   is_nullable: 0
 
-=head2 alias
+=head2 name
 
   data_type: 'text'
   is_nullable: 1
@@ -72,12 +72,19 @@ __PACKAGE__->table("relay");
   is_nullable: 0
   original: {default_value => \"now()"}
 
+=head2 id
+
+  data_type: 'uuid'
+  default_value: gen_random_uuid()
+  is_nullable: 0
+  size: 16
+
 =cut
 
 __PACKAGE__->add_columns(
-  "id",
+  "serial_number",
   { data_type => "text", is_nullable => 0 },
-  "alias",
+  "name",
   { data_type => "text", is_nullable => 1 },
   "version",
   { data_type => "text", is_nullable => 1 },
@@ -101,6 +108,13 @@ __PACKAGE__->add_columns(
     is_nullable   => 0,
     original      => { default_value => \"now()" },
   },
+  "id",
+  {
+    data_type => "uuid",
+    default_value => \"gen_random_uuid()",
+    is_nullable => 0,
+    size => 16,
+  },
 );
 
 =head1 PRIMARY KEY
@@ -114,6 +128,20 @@ __PACKAGE__->add_columns(
 =cut
 
 __PACKAGE__->set_primary_key("id");
+
+=head1 UNIQUE CONSTRAINTS
+
+=head2 C<relay_serial_number_key>
+
+=over 4
+
+=item * L</serial_number>
+
+=back
+
+=cut
+
+__PACKAGE__->add_unique_constraint("relay_serial_number_key", ["serial_number"]);
 
 =head1 RELATIONS
 
@@ -149,7 +177,7 @@ __PACKAGE__->has_many(
 
 
 # Created by DBIx::Class::Schema::Loader v0.07049
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:GYdtFEOP7vwaSfglNtVehw
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:H0EoEEnlWK/jcq27Jrz+bw
 
 __PACKAGE__->add_columns(
     '+deactivated' => { is_serializable => 0 },

--- a/lib/Conch/DB/Result/UserRelayConnection.pm
+++ b/lib/Conch/DB/Result/UserRelayConnection.pm
@@ -35,12 +35,6 @@ __PACKAGE__->table("user_relay_connection");
   is_nullable: 0
   size: 16
 
-=head2 relay_id
-
-  data_type: 'text'
-  is_foreign_key: 1
-  is_nullable: 0
-
 =head2 first_seen
 
   data_type: 'timestamp with time zone'
@@ -55,13 +49,18 @@ __PACKAGE__->table("user_relay_connection");
   is_nullable: 0
   original: {default_value => \"now()"}
 
+=head2 relay_id
+
+  data_type: 'uuid'
+  is_foreign_key: 1
+  is_nullable: 0
+  size: 16
+
 =cut
 
 __PACKAGE__->add_columns(
   "user_id",
   { data_type => "uuid", is_foreign_key => 1, is_nullable => 0, size => 16 },
-  "relay_id",
-  { data_type => "text", is_foreign_key => 1, is_nullable => 0 },
   "first_seen",
   {
     data_type     => "timestamp with time zone",
@@ -76,6 +75,8 @@ __PACKAGE__->add_columns(
     is_nullable   => 0,
     original      => { default_value => \"now()" },
   },
+  "relay_id",
+  { data_type => "uuid", is_foreign_key => 1, is_nullable => 0, size => 16 },
 );
 
 =head1 PRIMARY KEY
@@ -126,7 +127,7 @@ __PACKAGE__->belongs_to(
 
 
 # Created by DBIx::Class::Schema::Loader v0.07049
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:aR4gZ+TwJhzfL38PFNfm3g
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:yuxJRLzF48Nk/Eyom+u0gw
 
 1;
 __END__

--- a/lib/Conch/Route/Relay.pm
+++ b/lib/Conch/Route/Relay.pm
@@ -22,8 +22,8 @@ sub routes {
 
     $relay->to({ controller => 'relay' });
 
-    # POST /relay/:relay_id/register
-    $relay->post('/:relay_id/register')->to('#register');
+    # POST /relay/:relay_serial_number/register
+    $relay->post('/:relay_serial_number/register')->to('#register');
 
     # GET /relay
     $relay->get('/')->to('#list');
@@ -36,7 +36,7 @@ __END__
 
 Unless otherwise noted, all routes require authentication.
 
-=head3 C<POST /relay/:relay_id/register>
+=head3 C<POST /relay/:relay_serial_number/register>
 
 =over 4
 

--- a/lib/Conch/Route/Relay.pm
+++ b/lib/Conch/Route/Relay.pm
@@ -28,8 +28,8 @@ sub routes {
     # GET /relay
     $relay->get('/')->to('#list');
 
-    # GET /relay/:relay_serial_number
-    $relay->get('/:relay_serial_number')->to('#get');
+    # GET /relay/:relay_id_or_serial_number
+    $relay->get('/:relay_id_or_serial_number')->to('#get');
 }
 
 1;
@@ -59,7 +59,7 @@ Unless otherwise noted, all routes require authentication.
 
 =back
 
-=head3 C<GET /relay/:relay_serial_number>
+=head3 C<GET /relay/:relay_id_or_serial_number>
 
 =over 4
 

--- a/lib/Conch/Route/Relay.pm
+++ b/lib/Conch/Route/Relay.pm
@@ -27,6 +27,9 @@ sub routes {
 
     # GET /relay
     $relay->get('/')->to('#list');
+
+    # GET /relay/:relay_serial_number
+    $relay->get('/:relay_serial_number')->to('#get');
 }
 
 1;
@@ -53,6 +56,16 @@ Unless otherwise noted, all routes require authentication.
 =item * Requires system admin authorization
 
 =item * Response: response.yaml#/Relays
+
+=back
+
+=head3 C<GET /relay/:relay_serial_number>
+
+=over 4
+
+=item * Requires system admin authorization, or the user to have previously registered the relay.
+
+=item * Response: response.yaml#/Relay
 
 =back
 

--- a/lib/Conch/Route/Relay.pm
+++ b/lib/Conch/Route/Relay.pm
@@ -45,7 +45,7 @@ Unless otherwise noted, all routes require authentication.
 
 =item * Request: request.yaml#/RegisterRelay
 
-=item * Response: C<204 NO CONTENT>
+=item * Response: C<201 CREATED> or C<204 NO CONTENT>, plus Location header
 
 =back
 

--- a/lib/Conch/Route/Workspace.pm
+++ b/lib/Conch/Route/Workspace.pm
@@ -64,8 +64,8 @@ sub routes {
 
         # GET /workspace/:workspace_id_or_name/relay
         $with_workspace->get('/relay')->to('workspace_relay#list');
-        # GET /workspace/:workspace_id_or_name/relay/:relay_id/device
-        $with_workspace->get('/relay/:relay_id/device')->to('workspace_relay#get_relay_devices');
+        # GET /workspace/:workspace_id_or_name/relay/<relay_id:uuid>/device
+        $with_workspace->get('/relay/<relay_id:uuid>/device')->to('workspace_relay#get_relay_devices');
 
         # GET /workspace/:workspace_id_or_name/user
         $with_workspace->get('/user')->to('workspace_user#list');

--- a/sql/migrations/0108-relay-id-is-uuid.sql
+++ b/sql/migrations/0108-relay-id-is-uuid.sql
@@ -1,0 +1,51 @@
+SELECT run_migration(108, $$
+
+    alter table relay rename column id to serial_number;
+    alter table relay rename column alias to name;
+    alter table relay add column id uuid default gen_random_uuid() not null;
+    alter table relay add constraint relay_serial_number_key unique (serial_number);
+
+    alter table device_relay_connection rename column relay_id to relay_serial_number;
+    alter table device_relay_connection add column relay_id uuid;
+    update device_relay_connection
+        set relay_id = relay.id
+        from relay
+        where relay.serial_number = device_relay_connection.relay_serial_number;
+    alter table device_relay_connection
+        drop column relay_serial_number,
+        -- commented out constraints/indexes drop off on their own
+        -- drop constraint device_relay_connection_pkey,
+        -- drop constraint device_relay_connection_relay_id_fkey,
+        add primary key (device_id, relay_id);
+
+    -- drop index device_relay_connection_relay_id_idx;
+    create index device_relay_connection_relay_id_idx on device_relay_connection (relay_id);
+
+
+    alter table user_relay_connection rename column relay_id to relay_serial_number;
+    alter table user_relay_connection add column relay_id uuid;
+    update user_relay_connection
+        set relay_id = relay.id
+        from relay
+        where relay.serial_number = user_relay_connection.relay_serial_number;
+    alter table user_relay_connection
+        drop column relay_serial_number,
+        -- drop constraint user_relay_connection_pkey,
+        -- drop constraint user_relay_connection_relay_id_fkey,
+        add primary key (user_id, relay_id);
+
+    -- drop index user_relay_connection_relay_id_idx;
+    create index user_relay_connection_relay_id_idx on user_relay_connection (relay_id);
+
+    alter table relay drop constraint relay_pkey;
+    alter table relay add primary key (id);
+
+    alter table device_relay_connection
+        add constraint device_relay_connection_relay_id_fkey foreign key (relay_id)
+            references relay(id);
+
+    alter table user_relay_connection
+        add constraint user_relay_connection_relay_id_fkey foreign key (relay_id)
+            references relay(id);
+
+$$);

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -314,9 +314,9 @@ ALTER TABLE public.device_nic OWNER TO conch;
 
 CREATE TABLE public.device_relay_connection (
     device_id text NOT NULL,
-    relay_id text NOT NULL,
     first_seen timestamp with time zone DEFAULT now() NOT NULL,
-    last_seen timestamp with time zone DEFAULT now() NOT NULL
+    last_seen timestamp with time zone DEFAULT now() NOT NULL,
+    relay_id uuid NOT NULL
 );
 
 
@@ -505,14 +505,15 @@ ALTER TABLE public.rack_role OWNER TO conch;
 --
 
 CREATE TABLE public.relay (
-    id text NOT NULL,
-    alias text,
+    serial_number text NOT NULL,
+    name text,
     version text,
     ipaddr inet,
     ssh_port integer,
     deactivated timestamp with time zone,
     created timestamp with time zone DEFAULT now() NOT NULL,
     updated timestamp with time zone DEFAULT now() NOT NULL,
+    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
     CONSTRAINT relay_ssh_port_check CHECK ((ssh_port >= 0))
 );
 
@@ -545,9 +546,9 @@ ALTER TABLE public.user_account OWNER TO conch;
 
 CREATE TABLE public.user_relay_connection (
     user_id uuid NOT NULL,
-    relay_id text NOT NULL,
     first_seen timestamp with time zone DEFAULT now() NOT NULL,
-    last_seen timestamp with time zone DEFAULT now() NOT NULL
+    last_seen timestamp with time zone DEFAULT now() NOT NULL,
+    relay_id uuid NOT NULL
 );
 
 
@@ -927,6 +928,14 @@ ALTER TABLE ONLY public.rack_role
 
 ALTER TABLE ONLY public.relay
     ADD CONSTRAINT relay_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: relay relay_serial_number_key; Type: CONSTRAINT; Schema: public; Owner: conch
+--
+
+ALTER TABLE ONLY public.relay
+    ADD CONSTRAINT relay_serial_number_key UNIQUE (serial_number);
 
 
 --

--- a/t/integration/crud/devices.t
+++ b/t/integration/crud/devices.t
@@ -71,7 +71,7 @@ subtest 'unlocated device, no registered relay' => sub {
 
 subtest 'unlocated device with a registered relay' => sub {
     $t->post_ok('/relay/deadbeef/register', json => { serial => 'deadbeef' })
-        ->status_is(204);
+        ->status_is(201);
 
     my $report = path('t/integration/resource/passing-device-report.json')->slurp_utf8;
     $t->post_ok('/device/TEST', { 'Content-Type' => 'application/json' }, $report)

--- a/t/integration/crud/devices.t
+++ b/t/integration/crud/devices.t
@@ -575,6 +575,8 @@ subtest 'Device PXE' => sub {
     $t->authenticate(email => $admin_user->email);
     my $layout = $t->load_fixture('rack_0a_layout_3_6');
 
+    my $relay = $t->app->db_relays->create({ serial_number => 'my_relay' });
+
     my $device_pxe = $t->app->db_devices->create({
         id => 'PXE_TEST',
         hardware_product_id => $layout->hardware_product_id,
@@ -582,7 +584,7 @@ subtest 'Device PXE' => sub {
         health => 'unknown',
         device_relay_connections => [{
             relay => {
-                id => 'relay_id',
+                id => $relay->id,
                 user_relay_connections => [ { user_id => $t->load_fixture('conch_user')->id } ],
             }
         }],

--- a/t/integration/crud/relay.t
+++ b/t/integration/crud/relay.t
@@ -84,6 +84,16 @@ $t->get_ok('/relay')
         }, (0..1)
     ]);
 
+{
+    my $other_user = $t->load_fixture('null_user');
+    my $t2 = Test::Conch->new(pg => $t->pg);
+    $t2->authenticate(email => $other_user->email);
+
+    $t2->get_ok('/relay')
+        ->status_is(403);
+}
+
+
 $relay0->user_relay_connections->update({
     first_seen => '1999-01-01',
     last_seen => '1999-01-01',

--- a/t/integration/crud/workspace-devices.t
+++ b/t/integration/crud/workspace-devices.t
@@ -44,7 +44,7 @@ $t->post_ok('/relay/deadbeef/register',
             version  => '0.0.1',
             ipaddr   => '127.0.0.1',
             ssh_port => 22,
-            alias    => 'test relay',
+            name     => 'test relay',
         })
     ->status_is(201);
 

--- a/t/integration/crud/workspace-devices.t
+++ b/t/integration/crud/workspace-devices.t
@@ -46,7 +46,7 @@ $t->post_ok('/relay/deadbeef/register',
             ssh_port => 22,
             alias    => 'test relay',
         })
-    ->status_is(204);
+    ->status_is(201);
 
 my $report = path('t/integration/resource/passing-device-report.json')->slurp_utf8;
 $t->post_ok('/device/TEST', { 'Content-Type' => 'application/json' }, $report)

--- a/t/integration/device-reports.t
+++ b/t/integration/device-reports.t
@@ -42,7 +42,7 @@ subtest preliminaries => sub {
         ->json_is({ error => 'relay serial deadbeef is not registered' });
 
     $t->post_ok('/relay/deadbeef/register', json => { serial => 'deadbeef' })
-        ->status_is(204);
+        ->status_is(201);
 
     $t->post_ok('/device/TEST', { 'Content-Type' => 'application/json' }, $report)
         ->status_is(422)

--- a/t/integration/device-validations.t
+++ b/t/integration/device-validations.t
@@ -31,7 +31,7 @@ my ($server_validation_plan) = $t->load_validation_plans([{
 }]);
 
 $t->post_ok('/relay/deadbeef/register', json => { serial => 'deadbeef' })
-    ->status_is(204);
+    ->status_is(201);
 
 # create the device and two reports
 $t->post_ok('/device/TEST', { 'Content-Type' => 'application/json' }, $error_report)


### PR DESCRIPTION
- relay.id is now a uuid; old id is now known as 'serial_number'
- relay.alias is renamed 'name'
- new endpoint: `GET /relay/:id_or_serial_number`

closes #760.