### PR TITLE
clean up user authentication

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -23,7 +23,6 @@ requires 'Encode', '2.98';
 requires 'IPC::System::Simple';
 requires 'Dir::Self';
 requires 'Carp';
-requires 'Crypt::Eksblowfish::Bcrypt';
 requires 'Module::Runtime';
 requires 'Email::Valid';
 requires 'Email::Simple';
@@ -72,7 +71,8 @@ requires 'DateTime::Format::Pg';    # used by DBIx::Class::Storage::DBI::Pg
 requires 'DBIx::Class::InflateColumn::TimeMoment';
 requires 'Lingua::EN::Inflexion';
 requires 'Text::CSV_XS';
-
+requires 'DBIx::Class::PassphraseColumn', dist => 'ETHER/DBIx-Class-PassphraseColumn-0.04-TRIAL.tar.gz';
+requires 'Authen::Passphrase::BlowfishCrypt';
 
 on 'test' => sub {
     requires 'Test::More';

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -28,6 +28,67 @@ DISTRIBUTIONS
       Algorithm::Diff::_impl 1.1903
     requirements:
       ExtUtils::MakeMaker 0
+  Authen-DecHpwd-2.007
+    pathname: Z/ZE/ZEFRAM/Authen-DecHpwd-2.007.tar.gz
+    provides:
+      Authen::DecHpwd 2.007
+    requirements:
+      Data::Integer 0.003
+      Digest::CRC 0.14
+      Exporter 0
+      Module::Build 0
+      Scalar::String 0
+      Test::More 0
+      constant 0
+      parent 0
+      perl 5.006
+      strict 0
+      warnings 0
+  Authen-Passphrase-0.008
+    pathname: Z/ZE/ZEFRAM/Authen-Passphrase-0.008.tar.gz
+    provides:
+      Authen::Passphrase 0.008
+      Authen::Passphrase::AcceptAll 0.008
+      Authen::Passphrase::BigCrypt 0.008
+      Authen::Passphrase::BlowfishCrypt 0.008
+      Authen::Passphrase::Clear 0.008
+      Authen::Passphrase::Crypt16 0.008
+      Authen::Passphrase::DESCrypt 0.008
+      Authen::Passphrase::EggdropBlowfish 0.008
+      Authen::Passphrase::LANManager 0.008
+      Authen::Passphrase::LANManagerHalf 0.008
+      Authen::Passphrase::MD5Crypt 0.008
+      Authen::Passphrase::MySQL323 0.008
+      Authen::Passphrase::MySQL41 0.008
+      Authen::Passphrase::NTHash 0.008
+      Authen::Passphrase::NetscapeMail 0.008
+      Authen::Passphrase::PHPass 0.008
+      Authen::Passphrase::RejectAll 0.008
+      Authen::Passphrase::SaltedDigest 0.008
+      Authen::Passphrase::VMSPurdy 0.008
+    requirements:
+      Authen::DecHpwd 2.003
+      Carp 0
+      Crypt::DES 0
+      Crypt::Eksblowfish::Bcrypt 0.008
+      Crypt::Eksblowfish::Uklblowfish 0.008
+      Crypt::MySQL 0.03
+      Crypt::PasswdMD5 1.0
+      Crypt::UnixCrypt_XS 0.08
+      Data::Entropy::Algorithms 0
+      Digest 1.00
+      Digest::MD4 1.2
+      Digest::MD5 1.9953
+      Digest::SHA 0
+      MIME::Base64 2.21
+      Module::Build 0
+      Module::Runtime 0.011
+      Params::Classify 0
+      Test::More 0
+      parent 0
+      perl 5.006
+      strict 0
+      warnings 0
   B-Hooks-EndOfScope-0.24
     pathname: E/ET/ETHER/B-Hooks-EndOfScope-0.24.tar.gz
     provides:
@@ -344,6 +405,12 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       Pod::Text 2.08
+  Crypt-DES-2.07
+    pathname: D/DP/DPARIS/Crypt-DES-2.07.tar.gz
+    provides:
+      Crypt::DES 2.07
+    requirements:
+      ExtUtils::MakeMaker 0
   Crypt-Eksblowfish-0.009
     pathname: Z/ZE/ZEFRAM/Crypt-Eksblowfish-0.009.tar.gz
     provides:
@@ -366,6 +433,37 @@ DISTRIBUTIONS
       perl 5.006
       strict 0
       warnings 0
+  Crypt-MySQL-0.04
+    pathname: I/IK/IKEBE/Crypt-MySQL-0.04.tar.gz
+    provides:
+      Crypt::MySQL 0.04
+    requirements:
+      Digest::SHA1 0
+      ExtUtils::CBuilder 0
+      Test::More 0
+  Crypt-PasswdMD5-1.40
+    pathname: R/RS/RSAVAGE/Crypt-PasswdMD5-1.40.tgz
+    provides:
+      Crypt::PasswdMD5 1.40
+    requirements:
+      Digest::MD5 2.53
+      Module::Build 0
+      Test::More 0.94
+      strict 0
+      warnings 0
+  Crypt-Rijndael-1.13
+    pathname: L/LE/LEONT/Crypt-Rijndael-1.13.tar.gz
+    provides:
+      Crypt::Rijndael 1.13
+    requirements:
+      ExtUtils::MakeMaker 0
+      perl 5.006
+  Crypt-UnixCrypt_XS-0.11
+    pathname: B/BO/BORISZ/Crypt-UnixCrypt_XS-0.11.tar.gz
+    provides:
+      Crypt::UnixCrypt_XS 0.11
+    requirements:
+      ExtUtils::MakeMaker 0
   DBD-Pg-3.8.0
     pathname: T/TU/TURNSTEP/DBD-Pg-3.8.0.tar.gz
     provides:
@@ -740,6 +838,18 @@ DISTRIBUTIONS
       Try::Tiny 0
       namespace::clean 0.23
       parent 0
+  DBIx-Class-InflateColumn-Authen-Passphrase-0.03
+    pathname: E/ET/ETHER/DBIx-Class-InflateColumn-Authen-Passphrase-0.03.tar.gz
+    provides:
+      DBIx::Class::InflateColumn::Authen::Passphrase 0.03
+    requirements:
+      Authen::Passphrase 0
+      DBIx::Class 0
+      ExtUtils::MakeMaker 0
+      parent 0
+      perl 5.006
+      strict 0
+      warnings 0
   DBIx-Class-InflateColumn-TimeMoment-0.050
     pathname: N/NI/NIGELM/DBIx-Class-InflateColumn-TimeMoment-0.050.tar.gz
     provides:
@@ -750,6 +860,22 @@ DISTRIBUTIONS
       Try::Tiny 0
       base 0
       namespace::clean 0
+      perl 5.008
+      strict 0
+      warnings 0
+  DBIx-Class-PassphraseColumn-0.04-TRIAL
+    pathname: E/ET/ETHER/DBIx-Class-PassphraseColumn-0.04-TRIAL.tar.gz
+    provides:
+      DBIx::Class::PassphraseColumn 0.04
+    requirements:
+      DBIx::Class 0
+      DBIx::Class::InflateColumn::Authen::Passphrase 0
+      Encode 0
+      ExtUtils::MakeMaker 0
+      Module::Runtime 0
+      Sub::Name 0
+      namespace::clean 0
+      parent 0
       perl 5.008
       strict 0
       warnings 0
@@ -852,6 +978,63 @@ DISTRIBUTIONS
       Exporter 0
       ExtUtils::MakeMaker 0
       perl 5.006
+  Data-Entropy-0.007
+    pathname: Z/ZE/ZEFRAM/Data-Entropy-0.007.tar.gz
+    provides:
+      Data::Entropy 0.007
+      Data::Entropy::Algorithms 0.007
+      Data::Entropy::RawSource::CryptCounter 0.007
+      Data::Entropy::RawSource::Local 0.007
+      Data::Entropy::RawSource::RandomOrg 0.007
+      Data::Entropy::RawSource::RandomnumbersInfo 0.007
+      Data::Entropy::Source 0.007
+    requirements:
+      Carp 0
+      Crypt::Rijndael 0
+      Data::Float 0.008
+      Errno 1.00
+      Exporter 0
+      HTTP::Lite 2.2
+      IO::File 1.03
+      Module::Build 0
+      Params::Classify 0
+      Test::More 0
+      constant 0
+      integer 0
+      parent 0
+      perl 5.006
+      strict 0
+      warnings 0
+  Data-Float-0.013
+    pathname: Z/ZE/ZEFRAM/Data-Float-0.013.tar.gz
+    provides:
+      Data::Float 0.013
+    requirements:
+      Carp 0
+      Exporter 0
+      Module::Build 0
+      Test::More 0
+      constant 0
+      integer 0
+      parent 0
+      perl 5.006
+      strict 0
+      warnings 0
+  Data-Integer-0.006
+    pathname: Z/ZE/ZEFRAM/Data-Integer-0.006.tar.gz
+    provides:
+      Data::Integer 0.006
+    requirements:
+      Carp 0
+      Exporter 0
+      Module::Build 0
+      Test::More 0
+      constant 0
+      integer 0
+      parent 0
+      perl 5.006
+      strict 0
+      warnings 0
   Data-OptList-0.110
     pathname: R/RJ/RJBS/Data-OptList-0.110.tar.gz
     provides:
@@ -1552,6 +1735,12 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 0
       Test::More 0
       perl 5.004
+  Digest-CRC-0.22.2
+    pathname: O/OL/OLIMAUL/Digest-CRC-0.22.2.tar.gz
+    provides:
+      Digest::CRC 0.22
+    requirements:
+      ExtUtils::MakeMaker 0
   Digest-HMAC-1.03
     pathname: G/GA/GAAS/Digest-HMAC-1.03.tar.gz
     provides:
@@ -1561,6 +1750,21 @@ DISTRIBUTIONS
     requirements:
       Digest::MD5 2
       Digest::SHA 1
+      ExtUtils::MakeMaker 0
+      perl 5.004
+  Digest-MD4-1.9
+    pathname: M/MI/MIKEM/DigestMD4/Digest-MD4-1.9.tar.gz
+    provides:
+      Digest::MD4 1.9
+    requirements:
+      ExtUtils::MakeMaker 0
+      File::Spec 0
+  Digest-SHA1-2.13
+    pathname: G/GA/GAAS/Digest-SHA1-2.13.tar.gz
+    provides:
+      Digest::SHA1 2.13
+    requirements:
+      Digest::base 1.00
       ExtUtils::MakeMaker 0
       perl 5.004
   Dir-Self-0.11
@@ -1959,6 +2163,17 @@ DISTRIBUTIONS
       perl 5.006
       strict 0
       vars 0
+      warnings 0
+  HTTP-Lite-2.44
+    pathname: N/NE/NEILB/HTTP-Lite-2.44.tar.gz
+    provides:
+      HTTP::Lite 2.44
+    requirements:
+      ExtUtils::MakeMaker 0
+      Fcntl 0
+      Socket 1.3
+      perl 5.005
+      strict 0
       warnings 0
   HTTP-Tinyish-0.15
     pathname: M/MI/MIYAGAWA/HTTP-Tinyish-0.15.tar.gz
@@ -3141,6 +3356,22 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 0
       Scalar::Util 0
       perl 5.006
+  Scalar-String-0.003
+    pathname: Z/ZE/ZEFRAM/Scalar-String-0.003.tar.gz
+    provides:
+      Scalar::String 0.003
+    requirements:
+      Carp 0
+      Exporter 0
+      Module::Build 0
+      Test::More 0
+      bytes 0
+      if 0
+      parent 0
+      perl 5.006
+      strict 0
+      utf8 0
+      warnings 0
   Scope-Guard-0.21
     pathname: C/CH/CHOCOLATE/Scope-Guard-0.21.tar.gz
     provides:

--- a/dev/sql/01-dev-user.sql
+++ b/dev/sql/01-dev-user.sql
@@ -1,5 +1,5 @@
 begin;
-insert into user_account(name, email, password_hash) values('conch','conch@conch.joyent.us','{CRYPT}$2a$04$h963P26i4rTMaVogvA2U7ePcZTYm2o0gfSHyxaUCZSuthkpg47Zbi');
+insert into user_account(name, email, password) values('conch','conch@conch.joyent.us','$2a$04$h963P26i4rTMaVogvA2U7ePcZTYm2o0gfSHyxaUCZSuthkpg47Zbi');
 insert into user_workspace_role(user_id,workspace_id,role) values(
 	(select id from user_account where name='conch' limit 1),
 	(select id from workspace where name='GLOBAL' limit 1),

--- a/docs/modules/Conch::Controller::Login.md
+++ b/docs/modules/Conch::Controller::Login.md
@@ -6,13 +6,7 @@ Conch::Controller::Login
 
 ## \_create\_jwt
 
-Create a JWT and sets it up to be returned in the response in two parts:
-
-```perl
-* the signature in a cookie named 'jwt_sig',
-* and a response body named 'jwt_token'. 'jwt_token' includes two claims: 'uid', for the
-  user ID, and 'jti', for the token ID.
-```
+Create a JWT and sets it up to be returned in the response body under the key 'jwt\_token'.
 
 ## authenticate
 
@@ -20,8 +14,7 @@ Handle the details of authenticating the user, with one of the following options
 
 ```perl
 * existing session for the user
-* JWT split between Authorization Bearer header value and jwt_sig cookie
-* JWT combined with a Authorization Bearer header using format "$jwt_token.$jwt_sig"
+* signed JWT in the Authorization Bearer header
 * Old 'conch' session cookie
 ```
 

--- a/docs/modules/Conch::Controller::Login.md
+++ b/docs/modules/Conch::Controller::Login.md
@@ -6,7 +6,8 @@ Conch::Controller::Login
 
 ## \_create\_jwt
 
-Create a JWT and sets it up to be returned in the response body under the key 'jwt\_token'.
+Create a JWT to be returned to the user, for future presentation in the 'Authorization Bearer'
+header.
 
 ## authenticate
 
@@ -23,7 +24,8 @@ subsequent routes and actions.
 
 ## session\_login
 
-Handles the act of logging in, given a user and password in the form. Returns a JWT token.
+Handles the act of logging in, given a user and password in the form.
+Response uses the Login json schema, containing a JWT.
 
 ## session\_logout
 

--- a/docs/modules/Conch::Controller::Login.md
+++ b/docs/modules/Conch::Controller::Login.md
@@ -19,7 +19,6 @@ Create a JWT and sets it up to be returned in the response in two parts:
 Handle the details of authenticating the user, with one of the following options:
 
 ```perl
-* HTTP Basic Auth
 * existing session for the user
 * JWT split between Authorization Bearer header value and jwt_sig cookie
 * JWT combined with a Authorization Bearer header using format "$jwt_token.$jwt_sig"

--- a/docs/modules/Conch::Controller::Login.md
+++ b/docs/modules/Conch::Controller::Login.md
@@ -4,10 +4,10 @@ Conch::Controller::Login
 
 # METHODS
 
-## \_create\_jwt
+## \_respond\_with\_jwt
 
-Create a JWT to be returned to the user, for future presentation in the 'Authorization Bearer'
-header.
+Create a response containing a login JWT, which the user should later present in the
+'Authorization Bearer' header.
 
 ## authenticate
 

--- a/docs/modules/Conch::Controller::Login.md
+++ b/docs/modules/Conch::Controller::Login.md
@@ -33,7 +33,7 @@ Logs a user out by expiring their session
 
 ## refresh\_token
 
-Refresh a user's JWT token. Deletes the old token.
+Refresh a user's JWT token. Deletes the old token and expires the session.
 
 # LICENSING
 

--- a/docs/modules/Conch::Controller::User.md
+++ b/docs/modules/Conch::Controller::User.md
@@ -132,7 +132,7 @@ Response uses the UserTokens json schema.
 
 ## create\_api\_token
 
-Create a new token, creating a JWT from it. Response uses the NewUserToken json schema.
+Generate a new token, creating a JWT from it. Response uses the NewUserToken json schema.
 This is the only time the token string is provided to the user, so don't lose it!
 
 ## find\_api\_token

--- a/docs/modules/Conch::DB::Result::UserAccount.md
+++ b/docs/modules/Conch::DB::Result::UserAccount.md
@@ -24,7 +24,7 @@ data_type: 'text'
 is_nullable: 0
 ```
 
-## password\_hash
+## password
 
 ```
 data_type: 'text'
@@ -117,21 +117,14 @@ Related object: [Conch::DB::Result::UserWorkspaceRole](../modules/Conch::DB::Res
 
 # METHODS
 
+## check\_password
+
+Checks the provided password against the value in the database, returning true/false.
+Because hard cryptography is used, this is \*not\* a fast call!
+
 ## TO\_JSON
 
 Include information about the user's workspaces, if available.
-
-## new
-
-Overrides original to move 'password' to 'password\_hash'.
-
-## update
-
-Overrides original to move 'password' to 'password\_hash'.
-
-## validate\_password
-
-Check whether the given password text has a hash matching the stored password hash.
 
 # LICENSING
 

--- a/docs/modules/Conch::DB::Result::UserSessionToken.md
+++ b/docs/modules/Conch::DB::Result::UserSessionToken.md
@@ -17,13 +17,6 @@ is_nullable: 0
 size: 16
 ```
 
-## token\_hash
-
-```
-data_type: 'bytea'
-is_nullable: 0
-```
-
 ## expires
 
 ```
@@ -54,10 +47,18 @@ data_type: 'timestamp with time zone'
 is_nullable: 1
 ```
 
+## id
+
+```
+data_type: 'uuid'
+default_value: gen_random_uuid()
+is_nullable: 0
+size: 16
+```
+
 # PRIMARY KEY
 
-- ["user\_id"](#user_id)
-- ["token\_hash"](#token_hash)
+- ["id"](#id)
 
 # UNIQUE CONSTRAINTS
 

--- a/docs/modules/Conch::DB::ResultSet::UserAccount.md
+++ b/docs/modules/Conch::DB::ResultSet::UserAccount.md
@@ -6,33 +6,6 @@ Conch::DB::ResultSet::UserAccount
 
 Interface to queries against the `user_account` table.
 
-## create
-
-This method is built in to all resultsets. In [Conch::DB::Result::UserAccount](../modules/Conch::DB::Result::UserAccount) we have
-overrides allowing us to receive the `password` key, which we hash into `password_hash`.
-
-```perl
-$schema->resultset('user_account') or $c->db_user_accounts
-  ->create({
-    name => ...,        # required, but usually the same as email :/
-    email => ...,       # required
-    password => ...,    # required, if password_hash not provided
-  });
-```
-
-## update
-
-This method is built in to all resultsets. In [Conch::DB::Result::UserAccount](../modules/Conch::DB::Result::UserAccount) we have
-overrides allowing us to receive the `password` key, which we hash into `password_hash`.
-
-```perl
-$schema->resultset('user_account') or $c->db_user_accounts
-  ->update({
-    password => ...,
-    ... possibly other things
-  });
-```
-
 ## lookup\_by\_email
 
 Queries for user by (case-insensitive) email address.

--- a/docs/modules/Conch::DB::ResultSet::UserSessionToken.md
+++ b/docs/modules/Conch::DB::ResultSet::UserSessionToken.md
@@ -18,11 +18,6 @@ Chainable resultset to limit results to session tokens that are not expired.
 
 Chainable resultset to limit results to those that aren't expired.
 
-## search\_for\_user\_token
-
-Chainable resultset to search for matching tokens.
-This does \*not\* check the expires field: chain with 'unexpired' if this is desired.
-
 ## login\_only
 
 Chainable resultset to search for login tokens (created via the main /login flow).
@@ -34,13 +29,6 @@ Chainable resultset to search for api tokens (NOT created via the main /login fl
 ## expire
 
 Update all matching rows by setting expires = now(). (Returns the number of rows updated.)
-
-## generate\_for\_user
-
-Generates a session token for the user and stores it in the database.
-'expires' is an epoch time.
-
-Returns the db row inserted, and the token string that we generated.
 
 # LICENSING
 

--- a/docs/modules/Conch::Plugin::AuthHelpers.md
+++ b/docs/modules/Conch::Plugin::AuthHelpers.md
@@ -33,6 +33,17 @@ workspace (as indicated by :workspace\_id in the path).
 Users with the admin flag set will always return true, even if no user\_workspace\_role records
 are present.
 
+## generate\_jwt
+
+Generates a session token for the specified user and stores it in the database.
+Returns the new row and the JWT.
+
+`expires` is an epoch time.
+
+## generate\_jwt\_from\_token
+
+Given a session token, generate a JWT for it.
+
 # LICENSING
 
 Copyright Joyent, Inc.

--- a/lib/Conch/Controller/Login.pm
+++ b/lib/Conch/Controller/Login.pm
@@ -107,9 +107,12 @@ sub authenticate ($c) {
         $c->stash('token_id', $jwt_claims->{token_id});
     }
 
-    # did we manage to authenticate the user, or find session info indicating we did so
-    # earlier (via /login)?
-    $user_id ||= $c->session('user') if $c->session('user') and is_uuid($c->session('user'));
+    if ($c->session('user')) {
+        return $c->status(400, { error => 'user session is invalid' })
+            if not is_uuid($c->session('user')) or ($user_id and $c->session('user') ne $user_id);
+        $c->log->debug('using session user='.$c->session('user'));
+        $user_id ||= $c->session('user');
+    }
 
     if ($user_id) {
         $c->log->debug('looking up user by id '.$user_id.'...');

--- a/lib/Conch/Controller/Login.pm
+++ b/lib/Conch/Controller/Login.pm
@@ -92,9 +92,6 @@ sub authenticate ($c) {
             return $c->status(401);
         }
 
-        # clear out all expired session tokens
-        $c->db_user_session_tokens->expired->delete;
-
         if (not $session_token = $c->db_user_session_tokens
                 ->unexpired
                 ->search({ id => $jwt_claims->{token_id}, user_id => $user_id })
@@ -113,6 +110,9 @@ sub authenticate ($c) {
         $c->log->debug('using session user='.$c->session('user'));
         $user_id ||= $c->session('user');
     }
+
+    # clear out all expired session tokens
+    $c->db_user_session_tokens->expired->delete;
 
     if ($user_id) {
         $c->log->debug('looking up user by id '.$user_id.'...');

--- a/lib/Conch/Controller/Login.pm
+++ b/lib/Conch/Controller/Login.pm
@@ -167,7 +167,7 @@ sub session_login ($c) {
         return $c->status(401);
     }
 
-    if (not $user->validate_password($input->{password})) {
+    if (not $user->check_password($input->{password})) {
         $c->log->debug('password validation for '.($input->{user}//$input->{email}).' failed');
         return $c->status(401);
     }

--- a/lib/Conch/Controller/User.pm
+++ b/lib/Conch/Controller/User.pm
@@ -4,6 +4,7 @@ use Mojo::Base 'Mojolicious::Controller', -signatures;
 
 use List::Util 'pairmap';
 use Mojo::JSON qw(to_json from_json);
+use Authen::Passphrase::RejectAll;
 
 =pod
 
@@ -450,7 +451,7 @@ sub deactivate ($c) {
 
     $c->log->warn('user '.$c->stash('user')->name.' deactivating user '.$user->name
         .($workspaces ? ', direct member of workspaces: '.$workspaces : ''));
-    $user->update({ password => $c->random_string, deactivated => \'now()' });
+    $user->update({ password => Authen::Passphrase::RejectAll->new, deactivated => \'now()' });
 
     $user->delete_related('user_workspace_roles');
 

--- a/lib/Conch/DB/Result/UserSessionToken.pm
+++ b/lib/Conch/DB/Result/UserSessionToken.pm
@@ -35,11 +35,6 @@ __PACKAGE__->table("user_session_token");
   is_nullable: 0
   size: 16
 
-=head2 token_hash
-
-  data_type: 'bytea'
-  is_nullable: 0
-
 =head2 expires
 
   data_type: 'timestamp with time zone'
@@ -62,13 +57,18 @@ __PACKAGE__->table("user_session_token");
   data_type: 'timestamp with time zone'
   is_nullable: 1
 
+=head2 id
+
+  data_type: 'uuid'
+  default_value: gen_random_uuid()
+  is_nullable: 0
+  size: 16
+
 =cut
 
 __PACKAGE__->add_columns(
   "user_id",
   { data_type => "uuid", is_foreign_key => 1, is_nullable => 0, size => 16 },
-  "token_hash",
-  { data_type => "bytea", is_nullable => 0 },
   "expires",
   { data_type => "timestamp with time zone", is_nullable => 0 },
   "name",
@@ -82,21 +82,26 @@ __PACKAGE__->add_columns(
   },
   "last_used",
   { data_type => "timestamp with time zone", is_nullable => 1 },
+  "id",
+  {
+    data_type => "uuid",
+    default_value => \"gen_random_uuid()",
+    is_nullable => 0,
+    size => 16,
+  },
 );
 
 =head1 PRIMARY KEY
 
 =over 4
 
-=item * L</user_id>
-
-=item * L</token_hash>
+=item * L</id>
 
 =back
 
 =cut
 
-__PACKAGE__->set_primary_key("user_id", "token_hash");
+__PACKAGE__->set_primary_key("id");
 
 =head1 UNIQUE CONSTRAINTS
 
@@ -133,11 +138,11 @@ __PACKAGE__->belongs_to(
 
 
 # Created by DBIx::Class::Schema::Loader v0.07049
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:15Sr4wSfiSJztRKBxV4kzQ
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:z2yHwYmbD8FJiwNYT64xBA
 
 __PACKAGE__->add_columns(
+    '+id' => { is_serializable => 0 },
     '+user_id' => { is_serializable => 0 },
-    '+token_hash' => { is_serializable => 0 },
     '+created' => { retrieve_on_insert => 1 },
     '+expires' => { retrieve_on_insert => 1 },
 );

--- a/lib/Conch/DB/ResultSet/UserAccount.pm
+++ b/lib/Conch/DB/ResultSet/UserAccount.pm
@@ -15,33 +15,6 @@ Conch::DB::ResultSet::UserAccount
 
 Interface to queries against the C<user_account> table.
 
-=head2 create
-
-This method is built in to all resultsets. In L<Conch::DB::Result::UserAccount> we have
-overrides allowing us to receive the C<password> key, which we hash into C<password_hash>.
-
-    $schema->resultset('user_account') or $c->db_user_accounts
-      ->create({
-        name => ...,        # required, but usually the same as email :/
-        email => ...,       # required
-        password => ...,    # required, if password_hash not provided
-      });
-
-=cut
-
-=head2 update
-
-This method is built in to all resultsets. In L<Conch::DB::Result::UserAccount> we have
-overrides allowing us to receive the C<password> key, which we hash into C<password_hash>.
-
-    $schema->resultset('user_account') or $c->db_user_accounts
-      ->update({
-        password => ...,
-        ... possibly other things
-      });
-
-=cut
-
 =head2 lookup_by_email
 
 Queries for user by (case-insensitive) email address.

--- a/lib/Conch/Plugin/Logging.pm
+++ b/lib/Conch/Plugin/Logging.pm
@@ -74,7 +74,7 @@ sub register ($self, $app, $config) {
           : 'NOT AUTHED';
 
         my $req_headers = $c->req->headers->to_hash(1);
-        delete $req_headers->@{qw(Authorization Cookie jwt_token jwt_sig)};
+        delete $req_headers->@{qw(Authorization Cookie jwt_token)};
 
         my $res_headers = $c->res->headers->to_hash(1);
         delete $res_headers->@{qw(Set-Cookie)};

--- a/lib/Conch/Plugin/Rollbar.pm
+++ b/lib/Conch/Plugin/Rollbar.pm
@@ -77,7 +77,7 @@ sub _record_exception ($c, $exception, @) {
     my $user = $c->stash('user');
 
     my $headers = $c->req->headers->to_hash(1);
-    delete $headers->@{qw(Authorization Cookie jwt_token jwt_sig)};
+    delete $headers->@{qw(Authorization Cookie jwt_token)};
 
     my $rollbar_id = create_uuid_str();
     my $request_id = length($c->req->url) ? $c->req->request_id : undef;

--- a/lib/Test/Conch.pm
+++ b/lib/Test/Conch.pm
@@ -5,6 +5,7 @@ use Mojo::Base 'Test::Mojo', -signatures;
 
 use Test::More ();
 use Test::PostgreSQL;
+BEGIN { $ENV{CONCH_BLOWFISH_COST} = 1 }  # make /login run in 0.1ms instead of 4s
 use Conch::DB;
 use Test::Conch::Fixtures;
 use Path::Tiny;
@@ -35,7 +36,7 @@ Includes JSON validation ability.
 # see also the 'conch_user' fixture in Test::Conch::Fixtures
 use constant CONCH_USER => 'conch';
 use constant CONCH_EMAIL => 'conch@conch.joyent.us';
-use constant CONCH_PASSWORD => 'CONCH_PASSWORD';
+use constant CONCH_PASSWORD => '*';     # in the test fixture, all passwords are accepted
 
 $ENV{EMAIL_SENDER_TRANSPORT} = 'Test';  # see Email::Sender::Manual::QuickStart
 
@@ -473,7 +474,7 @@ Optionally will bail out of *all* tests on failure. This will set 'user' in the 
 sub authenticate ($self, %args) {
     $args{bailout} //= 1 if not $args{email};
     $args{email} //= CONCH_EMAIL;
-    $args{password} //= $args{email} eq 'conch@conch.joyent.us' ? CONCH_PASSWORD : $args{email};
+    $args{password} //= CONCH_PASSWORD; # note that if a fixture is used, everything is accepted (for speed)
 
     local $Test::Builder::Level = $Test::Builder::Level + 1;
     $self->post_ok('/login', json => { %args{qw(email password)} })

--- a/lib/Test/Conch/Fixtures.pm
+++ b/lib/Test/Conch/Fixtures.pm
@@ -9,6 +9,7 @@ use MooX::HandlesVia;
 use List::Util 'any';
 use Scalar::Util 'blessed';
 use Storable 'dclone';
+use Authen::Passphrase::AcceptAll;
 use namespace::autoclean;
 
 =pod
@@ -58,7 +59,7 @@ my %canned_definitions = (
         using => {
             name => 'conch',
             email => 'conch@conch.joyent.us',
-            password => 'CONCH_PASSWORD',
+            password => Authen::Passphrase::AcceptAll->new,
             is_admin => 1,
         },
     },
@@ -67,7 +68,7 @@ my %canned_definitions = (
         using => {
             name => 'null_user',
             email => 'null_user@conch.joyent.us',
-            password => 'null_user@conch.joyent.us',  # convention for test accounts
+            password => Authen::Passphrase::AcceptAll->new,
             is_admin => 0,
         },
     },
@@ -76,7 +77,7 @@ my %canned_definitions = (
         using => {
             name => 'ro_user',
             email => 'ro_user@conch.joyent.us',
-            password => 'ro_user@conch.joyent.us',  # convention for test accounts
+            password => Authen::Passphrase::AcceptAll->new,
             is_admin => 0,
         },
     },
@@ -85,7 +86,7 @@ my %canned_definitions = (
         using => {
             name => 'rw_user',
             email => 'rw_user@conch.joyent.us',
-            password => 'rw_user@conch.joyent.us',  # convention for test accounts
+            password => Authen::Passphrase::AcceptAll->new,
             is_admin => 0,
         },
     },

--- a/sql/migrations/0120-user_session_token-id-is-uuid.sql
+++ b/sql/migrations/0120-user_session_token-id-is-uuid.sql
@@ -1,0 +1,13 @@
+SELECT run_migration(120, $$
+
+    -- all existing tokens are invalid since their payload contains
+    -- discontinued fields, and all application secrets are being rotated out.
+    delete from user_session_token;
+
+    alter table user_session_token
+        add column id uuid default gen_random_uuid() not null,
+        drop constraint user_session_token_pkey,
+        drop column token_hash,
+        add primary key (id);
+
+$$);

--- a/sql/migrations/0121-user_account-password.sql
+++ b/sql/migrations/0121-user_account-password.sql
@@ -1,0 +1,10 @@
+SELECT run_migration(121, $$
+
+    -- remove all the legacy leading '{CRYPT}' from password_hash.
+    update user_account
+        set password_hash = substr(password_hash, 8)
+        where password_hash like '{CRYPT}%';
+
+    alter table user_account rename column password_hash to password;
+
+$$);

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -545,11 +545,11 @@ ALTER TABLE public.user_relay_connection OWNER TO conch;
 
 CREATE TABLE public.user_session_token (
     user_id uuid NOT NULL,
-    token_hash bytea NOT NULL,
     expires timestamp with time zone NOT NULL,
     name text NOT NULL,
     created timestamp with time zone DEFAULT now() NOT NULL,
-    last_used timestamp with time zone
+    last_used timestamp with time zone,
+    id uuid DEFAULT public.gen_random_uuid() NOT NULL
 );
 
 
@@ -944,7 +944,7 @@ ALTER TABLE ONLY public.user_relay_connection
 --
 
 ALTER TABLE ONLY public.user_session_token
-    ADD CONSTRAINT user_session_token_pkey PRIMARY KEY (user_id, token_hash);
+    ADD CONSTRAINT user_session_token_pkey PRIMARY KEY (id);
 
 
 --

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -512,7 +512,7 @@ ALTER TABLE public.relay OWNER TO conch;
 CREATE TABLE public.user_account (
     id uuid DEFAULT public.gen_random_uuid() NOT NULL,
     name text NOT NULL,
-    password_hash text NOT NULL,
+    password text NOT NULL,
     created timestamp with time zone DEFAULT now() NOT NULL,
     last_login timestamp with time zone,
     email text NOT NULL,

--- a/t/conch-log.t
+++ b/t/conch-log.t
@@ -660,41 +660,6 @@ sub add_test_routes ($app) {
         'dispatch line for /login error in audit mode does NOT contain the request body',
     );
 
-    $t->get_ok($t->ua->server->url->userinfo('foo@conch.joyent.us:123')->path('/me'))
-        ->status_is(401);
-
-    cmp_deeply(
-        decode_json((split(/\n/, $fake_log_file))[-1]),
-        +{
-            name => 'conch-api',
-            hostname => $hostname,
-            pid => $$,
-            time => re(qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/),
-            v => 2,
-            level => 'info',
-            req_id => $t->tx->res->headers->header('Request-Id'),
-            msg => 'dispatch',
-            api_version => re($api_version_re),
-            latency => re(qr/^\d+$/),
-            req => {
-                user        => 'NOT AUTHED',
-                method      => 'GET',
-                url         => '/me',
-                remoteAddress => '127.0.0.1',
-                remotePort  => ignore,
-                headers     => superhashof({}),
-                query_params => {},
-                body        => '',
-            },
-            res => {
-                headers => superhashof({}),
-                statusCode => 401,
-                body => { error => 'Unauthorized' },
-            },
-        },
-        'dispatch line for basic auth in audit mode does NOT contain the password',
-    );
-
     $t->load_fixture('conch_user_global_workspace');
     my $user_id = $t->app->db_user_accounts->search({ email => $t->CONCH_EMAIL })->get_column('id')->single;
     $t->authenticate->json_has('/jwt_token');

--- a/t/integration/users.t
+++ b/t/integration/users.t
@@ -693,20 +693,18 @@ subtest 'user tokens (our own)' => sub {
         ->json_is('/email' => $t2->CONCH_EMAIL);
     undef $t2;
 
+    cmp_deeply(
+        $t->app->db_user_session_tokens->search({ name => 'my first 💩 // to.ken @@' })
+            ->as_epoch('last_used')->get_column('last_used')->single,
+        within_tolerance(time, plus_or_minus => 10),
+        'token was last used approximately now',
+    );
+
     $t->delete_ok('/user/me/token/my first 💩 // to.ken @@')
         ->status_is(204);
 
     $t->get_ok('/user/me/token/my first 💩 // to.ken @@')
         ->status_is(404);
-
-    my $last_used = $t->app->db_user_session_tokens->search({ name => 'my first 💩 // to.ken @@' })
-        ->as_epoch('last_used')->get_column('last_used')->single;
-
-    cmp_deeply(
-        $last_used,
-        within_tolerance(time, plus_or_minus => 10),
-        'token was last used approximately now',
-    );
 
     $t->get_ok('/user/me/token')
         ->status_is(200)

--- a/t/integration/users.t
+++ b/t/integration/users.t
@@ -493,12 +493,10 @@ subtest 'modify another user' => sub {
 
     # in order to get the user's new password, we need to extract it from a method call before
     # we forget it -- so we pull it out of the call to UserAccount->update.
-    my $orig_update = \&Conch::DB::Result::UserAccount::update;
+    use Class::Method::Modifiers 'before';
     my $_new_password;
-    no warnings 'redefine';
-    local *Conch::DB::Result::UserAccount::update = sub {
+    before 'Conch::DB::Result::UserAccount::update' => sub {
         $_new_password = $_[1]->{password} if exists $_[1]->{password};
-        $orig_update->(@_);
     };
 
     $t->delete_ok('/user/foobar/password')


### PR DESCRIPTION
- drop support for basic auth (user+password in URL) (closes #762.)

- drop support for breaking up the JWT and putting part of it in a cookie (closes #778.)

- user_session_token now has a uuid primary key (closes #761.)  All current tokens are purged.

- bespoke password handling code is removed; blowfish cost parameter increased to harden security.

- login token is reused if it has over half its life left, rather than creating another (closes #829.)

