### PR TITLE
In Docker, upgrade Postgres to v10

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 local
+postgres

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,41 +1,20 @@
 FROM ubuntu:bionic
-LABEL maintainer "sungo@joyent.com"
-LABEL org.label-schema.vendor "Joyent, Inc"
-LABEL org.label-schema.docker.cmd.test "docker run 'make build test'"
-LABEL org.label-schema.vcs-url "https://github.com/joyent/conch.git"
-
-# Postgres is included so the user can run `make test` which requires the ability to stand up a real temporary Postgres database
-
-# The Joyent production database is (as of writing) PostgreSQL 9.6 so we do the
-# magic dance to get 9.6 for ourselves, since bionic ships 10.
 
 ENV DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update && \
+	apt-get upgrade -y --no-install-recommends && \
 	apt-get install -y --no-install-recommends \
 		build-essential \
 		ca-certificates \
 		carton \
+		curl \
 		git \
 		libssl-dev \
 		libzip-dev \
 		perl-doc \
 		unzip \
-	&& apt-get clean
-
-RUN apt-get update && \
-	apt-get install -y --no-install-recommends \
-		curl \
-		gnupg2 \
-		software-properties-common \
-	&& apt-get clean
-
-RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-
-RUN add-apt-repository "deb https://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main" && \
-	apt-get update && \
-	apt-get install -y --no-install-recommends \
-		postgresql-9.6 \
-		postgresql-contrib-9.6 \
+		postgresql \
 		libpq-dev \
 	&& apt-get clean
 
@@ -46,9 +25,6 @@ COPY . /app/conch
 
 ARG VCS_REF="master"
 ARG VERSION="v0.0.0-dirty"
-
-LABEL org.label-schema.vcs-ref $VCS_REF
-LABEL org.label-schema.version $VERSION
 
 ENV HARNESS_OPTIONS j6:c
 RUN make forcebuild && rm -r local/cache && rm -r ~/.cpanm

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,42 +1,22 @@
 FROM ubuntu:bionic
-LABEL maintainer "sungo@joyent.com"
-LABEL org.label-schema.vendor "Joyent, Inc"
-LABEL org.label-schema.vcs-url "https://github.com/joyent/conch.git"
 
-# Postgres is included so the user can run `make test` which requires the ability to stand up a real temporary Postgres database
-
-# The Joyent production database is (as of writing) PostgreSQL 9.6 so we do the
-# magic dance to get 9.6 for ourselves, since bionic ships 10.
 ENV DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update && \
+	apt-get upgrade -y --no-install-recommends && \
 	apt-get install -y --no-install-recommends \
 		build-essential \
 		ca-certificates \
 		carton \
+		curl \
 		git \
 		libssl-dev \
 		libzip-dev \
 		perl-doc \
 		unzip \
-	&& apt-get clean
-
-RUN apt-get update && \
-	apt-get install -y --no-install-recommends \
-		curl \
-		gnupg2 \
-		software-properties-common \
-	&& apt-get clean
-
-RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-
-RUN add-apt-repository "deb https://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main" && \
-	apt-get update && \
-	apt-get install -y --no-install-recommends \
-		postgresql-9.6 \
-		postgresql-contrib-9.6 \
+		postgresql \
 		libpq-dev \
 	&& apt-get clean
-
 
 RUN mkdir -p /app/conch
 WORKDIR /app/conch
@@ -46,18 +26,17 @@ COPY . /app/conch
 ARG VCS_REF="master"
 ARG VERSION="v0.0.0-dirty"
 
-LABEL org.label-schema.vcs-ref $VCS_REF
-LABEL org.label-schema.version $VERSION
-
 ENV LANG C.UTF-8
 ENV EV_EXTRA_DEFS -DEV_NO_ATFORK
 ENV MOJO_CONFIG /app/conch/etc/conch.conf
 
+# The port hypnotoad listens on is defined in its config so the exposed port
+# may need to be changed at runtime to match that config.
 ENV MOJO_LISTEN http://0.0.0.0:5000
 EXPOSE 5000
 
-ENTRYPOINT ["make"]
 ENV HARNESS_OPTIONS j6:c
+ENTRYPOINT ["make"]
 CMD [ "forcebuild", "test"]
 
 # vim: se syn=dockerfile:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ project. All of these should be run in the top level directory.
 
 #### Needed Packages
 
-* PostgreSQL 10
+* PostgreSQL 10.9
 * Git
 * Perl, 5.26 or above (e.g. via [perlbrew](https://perlbrew.pl/))
 * [Carton](https://metacpan.org/dist/Carton)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ project. All of these should be run in the top level directory.
 
 #### Needed Packages
 
-* PostgreSQL 9.6.x
+* PostgreSQL 10
 * Git
 * Perl, 5.26 or above (e.g. via [perlbrew](https://perlbrew.pl/))
 * [Carton](https://metacpan.org/dist/Carton)

--- a/lib/Conch/Plugin/Database.pm
+++ b/lib/Conch/Plugin/Database.pm
@@ -155,7 +155,7 @@ line of the exception.
     # are not aware of any issues on PostgreSQL 10.x.
     my ($major, $minor, $rest) = $pgsql_version =~ /PostgreSQL (\d+)\.(\d+)(\.\d+)?\b/;
     $minor //= 0;
-    $app->log->warn("Running $major.$minor$rest, expected at least 9.6!") if "$major.$minor" < 9.6;
+    $app->log->warn("Running $major.$minor$rest, expected at least 10.9!") if "$major.$minor" < 10.9;
 
 
     my ($latest_migration, $expected_latest_migration) = Conch::DB::Util::get_migration_level($app->schema);


### PR DESCRIPTION
Both dockerfiles now use postgres 10 which ships with ubuntu:bionic.

Part of https://github.com/joyent/buildops-infra/issues/87