### PR TITLE
v2: no log report data

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -89,8 +89,6 @@ on 'test' => sub {
     requires 'MooX::HandlesVia';
     requires 'Storable';
     requires 'Test::Deep::NumberTolerant';
-
-    local $ENV{PERL_USE_UNSAFE_INC} = 1;
     requires 'Test::Spelling';
 };
 

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -3532,17 +3532,21 @@ DISTRIBUTIONS
       Test::Builder::Module 0
       Test::More 0.47
       perl 5.006
-  Test-Spelling-0.20
-    pathname: S/SA/SARTAK/Test-Spelling-0.20.tar.gz
+  Test-Spelling-0.25
+    pathname: C/CA/CAPOEIRAB/Test-Spelling-0.25.tar.gz
     provides:
-      Test::Spelling 0.20
+      Test::Spelling 0.25
     requirements:
-      ExtUtils::MakeMaker 6.59
-      IPC::Run3 0.044
-      Pod::Spell 1.01
-      Test::More 0.88
-      Test::Tester 0
-      perl 5.006
+      Exporter 5.57
+      ExtUtils::MakeMaker 0
+      File::Spec 0
+      IPC::Run3 0
+      Pod::Spell 0
+      Symbol 0
+      Test::Builder 0
+      Text::Wrap 0
+      strict 0
+      warnings 0
   Test-Warn-0.36
     pathname: B/BI/BIGJ/Test-Warn-0.36.tar.gz
     provides:

--- a/lib/Conch/Validation.pm
+++ b/lib/Conch/Validation.pm
@@ -65,7 +65,6 @@ no Moo::sification;
 use strictures 2;
 use experimental 'signatures';
 use Types::Standard qw(Str ArrayRef HashRef InstanceOf);
-use Mojo::JSON;
 use Try::Tiny;
 use Conch::ValidationError;
 use Path::Tiny;
@@ -345,8 +344,8 @@ sub run ($self, $data) {
                 map s/^.* at (.+ line \d+)\.?$/$1/mr, split /\R/, $err;
         }
 
-        $self->log->error("Validation '".$self->name."' threw an exception: ".$message);
-        $self->log->debug("Bad data: ". Mojo::JSON::to_json($data));
+        $self->log->error("Validation '".$self->name.'\' threw an exception on device id \''
+            .$self->device->id.'\': '.$message);
 
         my $validation_error = {
             message  => $message,

--- a/t/validation-system/exceptions.t
+++ b/t/validation-system/exceptions.t
@@ -51,7 +51,7 @@ subtest '->run, local exception' => sub {
 
     like(
         $fake_log,
-        qr/Validation 'local_exception' threw an exception: I did something dumb/,
+        qr/Validation 'local_exception' threw an exception on device id 'HAL': I did something dumb/,
         'logged the unexpected exception',
     );
 };
@@ -121,7 +121,7 @@ subtest '->run, blessed external exception containing a stack trace' => sub {
 
     like(
         $fake_log,
-        qr/Validation 'mutate_device' threw an exception: .*cannot execute UPDATE in a read-only transaction/,
+        qr/Validation 'mutate_device' threw an exception on device id 'HAL': .*cannot execute UPDATE in a read-only transaction/,
         'logged the unexpected exception',
     );
 };


### PR DESCRIPTION
do not dump the entire device report into the log on error

we already logged the device_report id, and we include the device id here, so
that is sufficient to find the bad data
