### PR TITLE
do not dump the entire device report into the log on error

### DIFF
--- a/lib/Conch/Validation.pm
+++ b/lib/Conch/Validation.pm
@@ -65,7 +65,6 @@ no Moo::sification;
 use strictures 2;
 use experimental 'signatures';
 use Types::Standard qw(Str ArrayRef HashRef InstanceOf);
-use Mojo::JSON;
 use Try::Tiny;
 use Conch::ValidationError;
 use Path::Tiny;
@@ -345,8 +344,8 @@ sub run ($self, $data) {
                 map s/^.* at (.+ line \d+)\.?$/$1/mr, split /\R/, $err;
         }
 
-        $self->log->error("Validation '".$self->name."' threw an exception: ".$message);
-        $self->log->debug("Bad data: ". Mojo::JSON::to_json($data));
+        $self->log->error("Validation '".$self->name.'\' threw an exception on device id \''
+            .$self->device->id.'\': '.$message);
 
         my $validation_error = {
             message  => $message,

--- a/t/validation-system/exceptions.t
+++ b/t/validation-system/exceptions.t
@@ -45,7 +45,7 @@ subtest '->run, local exception' => sub {
     );
 
     $t->log_is(
-        re(qr/Validation 'local_exception' threw an exception: I did something dumb/),
+        re(qr/Validation 'local_exception' threw an exception on device id '${\$device->id}': I did something dumb/),
         'logged the unexpected exception',
     );
 };
@@ -113,7 +113,7 @@ subtest '->run, blessed external exception containing a stack trace' => sub {
     );
 
     $t->log_is(
-        re(qr/Validation 'mutate_device' threw an exception: .*cannot execute UPDATE in a read-only transaction/),
+        re(qr/Validation 'mutate_device' threw an exception on device id '${\$device->id}': .*cannot execute UPDATE in a read-only transaction/),
         'logged the unexpected exception',
     );
 };


### PR DESCRIPTION
we already logged the device_report id, and we include the device id here, so
that is sufficient to find the bad data

(same as PR#840, but for v3)