### PR TITLE
fix: hdd_size validation when specification is unset

### DIFF
--- a/lib/Conch/Validation/HddSize.pm
+++ b/lib/Conch/Validation/HddSize.pm
@@ -9,7 +9,7 @@ use constant category    => 'DISK';
 use constant description => 'Check hard drive sizes';
 
 sub validate ($self, $data) {
-    my $hw_spec = from_json($self->hardware_product_specification // {});
+    my $hw_spec = from_json($self->hardware_product_specification // '{}');
 
     return if not $hw_spec->{disk_size};
 


### PR DESCRIPTION
This fixes: "malformed JSON string..." in null hardware_product specification entries

(cherry picked from commit ed9282e72075f56c0c2ecf4a16b5ac7a645adf51)