### PR TITLE
v3: role fixes part2

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -50,6 +50,7 @@ requires 'Role::Tiny';
 requires 'Getopt::Long::Descriptive';
 requires 'Session::Token';
 requires 'Sys::Hostname';
+requires 'Sub::Install';
 
 # debugging aids
 requires 'Data::Printer', '0.99_019', dist => 'GARU/Data-Printer-0.99_019.tar.gz';

--- a/docs/modules/Conch::Controller::Workspace.md
+++ b/docs/modules/Conch::Controller::Workspace.md
@@ -34,7 +34,8 @@ Response uses the WorkspacesAndRoles json schema.
 
 ## create\_sub\_workspace
 
-Create a new subworkspace for the indicated workspace.
+Create a new subworkspace for the indicated workspace. The user is given the 'admin' role on
+the new workspace.
 
 Response uses the WorkspaceAndRole json schema.
 

--- a/docs/modules/Conch::Controller::Workspace.md
+++ b/docs/modules/Conch::Controller::Workspace.md
@@ -39,6 +39,11 @@ the new workspace.
 
 Response uses the WorkspaceAndRole json schema.
 
+## \_user\_has\_workspace\_auth
+
+Verifies that the user indicated by the stashed `user_id` has (at least) this role on the
+workspace indicated by the provided `workspace_id` or one of its ancestors.
+
 # LICENSING
 
 Copyright Joyent, Inc.

--- a/docs/modules/Conch::Controller::Workspace.md
+++ b/docs/modules/Conch::Controller::Workspace.md
@@ -37,6 +37,9 @@ Response uses the WorkspacesAndRoles json schema.
 Create a new subworkspace for the indicated workspace. The user is given the 'admin' role on
 the new workspace.
 
+Optionally takes a query parameter `send_mail` (defaulting to true), to send an email
+to all parent workspace admins.
+
 Response uses the WorkspaceAndRole json schema.
 
 ## \_user\_has\_workspace\_auth

--- a/docs/modules/Conch::Controller::WorkspaceUser.md
+++ b/docs/modules/Conch::Controller::WorkspaceUser.md
@@ -6,7 +6,7 @@ Conch::Controller::WorkspaceUser
 
 ## list
 
-Get a list of users for the indicated workspace.
+Get a list of users for the indicated workspace (not including system admin users).
 Requires the 'admin' role on the workspace.
 
 Response uses the WorkspaceUsers json schema.

--- a/docs/modules/Conch::DB::Result::Workspace.md
+++ b/docs/modules/Conch::DB::Result::Workspace.md
@@ -86,6 +86,10 @@ Composing rels: ["workspace\_racks"](#workspace_racks) -> rack
 
 Include information about the user's role, if available.
 
+## role
+
+Accessor for informational column, which is by the serializer in the result data.
+
 ## user\_id\_for\_role
 
 Accessor for informational column, which is used by the serializer to signal we should fetch

--- a/docs/modules/Conch::DB::ResultSet::Workspace.md
+++ b/docs/modules/Conch::DB::ResultSet::Workspace.md
@@ -43,11 +43,20 @@ As [workspaces\_above](https://metacpan.org/pod/workspaces_above), but also incl
 `$workspace_id` can be a single workspace\_id, an arrayref of multiple distinct workspace\_ids,
 or a resultset, which must return a single column of distinct workspace\_id(s)).
 
+## add\_role\_column
+
+Query for workspace(s) with an extra field attached to the result, containing information about
+the effective role the user has for the workspace.
+
+The indicated role is used directly, with no additional queries done (consequently "role\_via"
+will not appear in the serialized data).  This is intended to be used in preference to
+["with\_role\_via\_data\_for\_user"](#with_role_via_data_for_user) when the user is a system admin.
+
 ## with\_role\_via\_data\_for\_user
 
 Query for workspace(s) with an extra field attached to the query which will signal the
-workspace serializer to include the "role" and "via" columns, containing information about the
-effective role the user has for the workspace.
+workspace serializer to include the "role" and "role\_via" columns, containing information about
+the effective role the user has for the workspace.
 
 Only one user\_id can be calculated at a time. If you need to generate workspace-and-role data
 for multiple users at once, you can manually do:
@@ -66,7 +75,8 @@ role that is attached to an ancestor workspace).
 
 ## admins
 
-All the 'admin' users for the provided workspace(s).
+All the 'admin' users for the provided workspace(s).  Pass a true argument to also include all
+system admin users in the result.
 
 ## \_workspaces\_subquery
 

--- a/docs/modules/Conch::Plugin::AuthHelpers.md
+++ b/docs/modules/Conch::Plugin::AuthHelpers.md
@@ -16,23 +16,6 @@ return $c->status(403) if not $c->is_system_admin;
 
 Verifies that the currently stashed user has the `is_admin` flag set.
 
-## is\_workspace\_admin
-
-```
-return $c->status(403) if not $c->is_workspace_admin;
-```
-
-Verifies that the user indicated by the stashed `user_id` has the 'admin' role on the
-workspace indicated by the stashed `workspace_id` or one of its ancestors.
-
-## user\_has\_workspace\_auth
-
-Verifies that the user indicated by the stashed `user_id` has (at least) this role on the
-workspace indicated by the stashed `workspace_id` or one of its ancestors.
-
-System admin users set will always return true, even if no user\_workspace\_role records are
-present.
-
 ## generate\_jwt
 
 Generates a session token for the specified user and stores it in the database.

--- a/docs/modules/Conch::Route::Workspace.md
+++ b/docs/modules/Conch::Route::Workspace.md
@@ -31,7 +31,10 @@ Users will require access to the workspace (or one of its ancestors) at a minimu
 - User requires the read-only role
 - Response: response.yaml#/WorkspacesAndRoles
 
-### `POST /workspace/:workspace_id_or_name/child`
+### `POST /workspace/:workspace_id_or_name/child?send_mail=<1|0>`
+
+Takes one optional query parameter `send_mail=<1|0>` (defaults to `1`) to send
+an email to the parent workspace admins.
 
 - User requires the read/write role
 - Request: request.yaml#/WorkspaceCreate

--- a/docs/modules/Conch::Route::Workspace.md
+++ b/docs/modules/Conch::Route::Workspace.md
@@ -33,7 +33,7 @@ Users will require access to the workspace (or one of its ancestors) at a minimu
 
 ### `POST /workspace/:workspace_id_or_name/child`
 
-- User requires the admin role
+- User requires the read/write role
 - Request: request.yaml#/WorkspaceCreate
 - Response: response.yaml#/WorkspaceAndRole
 

--- a/docs/modules/Test::Conch.md
+++ b/docs/modules/Test::Conch.md
@@ -164,9 +164,11 @@ See ["\_generate\_definition" in Test::Conch::Fixtures](../modules/Test::Conch::
 
 ## authenticate
 
-Authenticates a user in the current test instance. Uses default credentials if not provided.
-Optionally will bail out of \*all\* tests on failure. This will set 'user' in the session
-(`$t->app->session('user')`).
+Authenticates a user in the current test instance. Uses default (superuser) credentials if not
+provided.  Optionally will bail out of \*all\* tests on failure.
+
+This will set 'user' in the session (`$t->app->session('user')`), so a token is not needed
+on subsequent requests.
 
 ## txn\_local
 

--- a/lib/Conch/Command/clean_roles.pm
+++ b/lib/Conch/Command/clean_roles.pm
@@ -51,8 +51,11 @@ sub run ($self, @opts) {
             print '--> ', $uwr->role, ' role found for deactivated user. ';
             $delete = 1;
         }
-
-        if (my $role_via = $self->app->db_workspaces
+        elsif ($uwr->user_account->is_admin) {
+            print '--> unnecessary ', $uwr->role, ' role found for sysadmin user. ';
+            $delete = 1;
+        }
+        elsif (my $role_via = $self->app->db_workspaces
                 ->workspaces_above($uwr->workspace_id)
                 ->search_related('user_workspace_roles', {
                     'user_workspace_roles.user_id' => $uwr->user_id,

--- a/lib/Conch/Controller/Datacenter.pm
+++ b/lib/Conch/Controller/Datacenter.pm
@@ -17,8 +17,6 @@ Handles looking up the object by id.
 =cut
 
 sub find_datacenter ($c) {
-    return $c->status(403) if not $c->is_system_admin;
-
     my $datacenter_id = $c->stash('datacenter_id');
     my $datacenter = $c->db_datacenters->find($datacenter_id);
 
@@ -41,8 +39,6 @@ Response uses the Datacenters json schema.
 =cut
 
 sub get_all ($c) {
-    return $c->status(403) if not $c->is_system_admin;
-
     my @datacenters = $c->db_datacenters
         ->order_by([ qw(vendor region location) ])
         ->all;
@@ -59,7 +55,6 @@ Response uses the Datacenter json schema.
 =cut
 
 sub get_one ($c) {
-    return $c->status(403) if not $c->is_system_admin;
     $c->status(200, $c->stash('datacenter'));
 }
 
@@ -72,8 +67,6 @@ Response uses the DatacenterRoomsDetailed json schema.
 =cut
 
 sub get_rooms ($c) {
-    return $c->status(403) if not $c->is_system_admin;
-
     my @rooms = $c->db_datacenter_rooms->search({ datacenter_id => $c->stash('datacenter')->id })->all;
 
     $c->log->debug('Found '.scalar(@rooms).' datacenter rooms');
@@ -87,8 +80,6 @@ Create a new datacenter.
 =cut
 
 sub create ($c) {
-    return $c->status(403) if not $c->is_system_admin;
-
     my $input = $c->validate_request('DatacenterCreate');
     return if not $input;
 
@@ -116,8 +107,6 @@ Update an existing datacenter.
 =cut
 
 sub update ($c) {
-    return $c->status(403) if not $c->is_system_admin;
-
     my $input = $c->validate_request('DatacenterUpdate');
     return if not $input;
 
@@ -136,8 +125,6 @@ Permanently delete a datacenter.
 =cut
 
 sub delete ($c) {
-    return $c->status(403) if not $c->is_system_admin;
-
     if ($c->stash('datacenter')->related_resultset('datacenter_rooms')->exists) {
         $c->log->debug('Cannot delete datacenter: in use by one or more datacenter_rooms');
         return $c->status(409, { error => 'cannot delete a datacenter when a datacenter_room is referencing it' });

--- a/lib/Conch/Controller/DatacenterRoom.pm
+++ b/lib/Conch/Controller/DatacenterRoom.pm
@@ -17,8 +17,6 @@ Handles looking up the object by id.
 =cut
 
 sub find_datacenter_room ($c) {
-    return $c->status(403) if not $c->is_system_admin;
-
     my $room_id = $c->stash('datacenter_room_id');
     $c->log->debug('Looking up datacenter room '.$room_id);
     my $room = $c->db_datacenter_rooms->find($room_id);
@@ -42,8 +40,6 @@ Response uses the DatacenterRoomsDetailed json schema.
 =cut
 
 sub get_all ($c) {
-    return $c->status(403) if not $c->is_system_admin;
-
     my @rooms = $c->db_datacenter_rooms->order_by('alias')->all;
     $c->log->debug('Found '.scalar(@rooms).' datacenter rooms');
 
@@ -59,7 +55,6 @@ Response uses the DatacenterRoomDetailed json schema.
 =cut
 
 sub get_one ($c) {
-    return $c->status(403) if not $c->is_system_admin;
     $c->status(200, $c->stash('datacenter_room'));
 }
 
@@ -70,8 +65,6 @@ Create a new datacenter room.
 =cut
 
 sub create ($c) {
-    return $c->status(403) if not $c->is_system_admin;
-
     my $input = $c->validate_request('DatacenterRoomCreate');
     return if not $input;
 
@@ -87,8 +80,6 @@ Update an existing room.
 =cut
 
 sub update ($c) {
-    return $c->status(403) if not $c->is_system_admin;
-
     my $input = $c->validate_request('DatacenterRoomUpdate');
     return if not $input;
 
@@ -104,8 +95,6 @@ Permanently delete a datacenter room.
 =cut
 
 sub delete ($c) {
-    return $c->status(403) if not $c->is_system_admin;
-
     if ($c->stash('datacenter_room')->related_resultset('racks')->exists) {
         $c->log->debug('Cannot delete datacenter_room: in use by one or more racks');
         return $c->status(409, { error => 'cannot delete a datacenter_room when a rack is referencing it' });
@@ -123,8 +112,6 @@ Response uses the Racks json schema.
 =cut
 
 sub racks ($c) {
-    return $c->status(403) if not $c->is_system_admin;
-
     my @racks = $c->stash('datacenter_room')->related_resultset('racks')->all;
     $c->log->debug('Found '.scalar(@racks).' racks for datacenter room '.$c->stash('datacenter_room')->id);
     return $c->status(200, \@racks);

--- a/lib/Conch/Controller/HardwareProduct.pm
+++ b/lib/Conch/Controller/HardwareProduct.pm
@@ -87,8 +87,6 @@ Creates a new hardware_product, and possibly also a hardware_product_profile.
 =cut
 
 sub create ($c) {
-    return $c->status(403) if not $c->is_system_admin;
-
     my $input = $c->validate_request('HardwareProductCreate');
     return if not $input;
 
@@ -124,8 +122,6 @@ as needed.
 =cut
 
 sub update ($c) {
-    return $c->status(403) if not $c->is_system_admin;
-
     my $input = $c->validate_request('HardwareProductUpdate');
     return if not $input;
 
@@ -182,8 +178,6 @@ sub update ($c) {
 =cut
 
 sub delete ($c) {
-    return $c->status(403) if not $c->is_system_admin;
-
     my $id = $c->stash('hardware_product_rs')->get_column('id')->single;
     $c->stash('hardware_product_rs')->deactivate;
 

--- a/lib/Conch/Controller/HardwareVendor.pm
+++ b/lib/Conch/Controller/HardwareVendor.pm
@@ -72,8 +72,6 @@ sub get_one ($c) {
 =cut
 
 sub create ($c) {
-    return $c->status(403) if not $c->is_system_admin;
-
     $c->validate_request('Null');
     return if $c->res->code;
 

--- a/lib/Conch/Controller/Rack.pm
+++ b/lib/Conch/Controller/Rack.pm
@@ -36,7 +36,7 @@ sub find_rack ($c) {
       : (any { $method eq $_ } qw(POST PUT DELETE)) ? 'rw'
       : die 'need handling for '.$method.' method';
 
-    if (not $rack_rs->user_has_role($c->stash('user_id'), $requires_role)) {
+    if (not $c->is_system_admin and not $rack_rs->user_has_role($c->stash('user_id'), $requires_role)) {
         $c->log->debug('User lacks role to access rack'.$c->stash('rack_id'));
         return $c->status(403);
     }

--- a/lib/Conch/Controller/Rack.pm
+++ b/lib/Conch/Controller/Rack.pm
@@ -53,8 +53,6 @@ Stores data as a new rack row.
 =cut
 
 sub create ($c) {
-    return $c->status(403) if not $c->is_system_admin;
-
     my $input = $c->validate_request('RackCreate');
     return if not $input;
 
@@ -93,9 +91,6 @@ Response uses the Racks json schema.
 =cut
 
 sub get_all ($c) {
-    # TODO: instead of sysadmin privs, filter out results by workspace roles
-    return $c->status(403) if not $c->is_system_admin;
-
     my @racks = $c->db_racks->order_by('name')->all;
     $c->log->debug('Found '.scalar(@racks).' racks');
 

--- a/lib/Conch/Controller/Rack.pm
+++ b/lib/Conch/Controller/Rack.pm
@@ -37,7 +37,7 @@ sub find_rack ($c) {
       : die 'need handling for '.$method.' method';
 
     if (not $c->is_system_admin and not $rack_rs->user_has_role($c->stash('user_id'), $requires_role)) {
-        $c->log->debug('User lacks role to access rack'.$c->stash('rack_id'));
+        $c->log->debug('User lacks the required role ('.$requires_role.') for rack '.$c->stash('rack_id'));
         return $c->status(403);
     }
 

--- a/lib/Conch/Controller/RackLayout.pm
+++ b/lib/Conch/Controller/RackLayout.pm
@@ -19,8 +19,6 @@ Supports rack layout lookups by id.
 =cut
 
 sub find_rack_layout ($c) {
-    return $c->status(403) if not $c->is_system_admin;
-
     my $layout_rs = $c->db_rack_layouts->search({ 'rack_layout.id' => $c->stash('layout_id') });
     if (not $layout_rs->exists) {
         $c->log->debug('Could not find rack layout '.$c->stash('layout_id'));
@@ -39,8 +37,6 @@ Creates a new rack_layout entry according to the passed-in specification.
 =cut
 
 sub create ($c) {
-    return $c->status(403) if not $c->is_system_admin;
-
     my $input = $c->validate_request('RackLayoutCreate');
     return if not $input;
 
@@ -111,8 +107,6 @@ Response uses the RackLayouts json schema.
 =cut
 
 sub get_all ($c) {
-    return $c->status(403) if not $c->is_system_admin;
-
     my @layouts = $c->db_rack_layouts
         ->with_rack_unit_size
         ->order_by([ qw(rack_id rack_unit_start) ])

--- a/lib/Conch/Controller/RackRole.pm
+++ b/lib/Conch/Controller/RackRole.pm
@@ -17,8 +17,6 @@ Supports rack role lookups by uuid and name.
 =cut
 
 sub find_rack_role ($c) {
-    return $c->status(403) if not $c->is_system_admin;
-
     my $rack_role;
     if ($c->stash('rack_role_id_or_name') =~ /^(.+?)\=(.+)$/) {
         my ($key, $value) = ($1, $2);
@@ -52,8 +50,6 @@ Create a new rack role.
 =cut
 
 sub create ($c) {
-    return $c->status(403) if not $c->is_system_admin;
-
     my $input = $c->validate_request('RackRoleCreate');
     return if not $input;
 
@@ -76,7 +72,6 @@ Response uses the RackRole json schema.
 =cut
 
 sub get ($c) {
-    return $c->status(403) if not $c->is_system_admin;
     $c->status(200, $c->stash('rack_role'));
 }
 
@@ -89,8 +84,6 @@ Response uses the RackRoles json schema.
 =cut
 
 sub get_all ($c) {
-    return $c->status(403) if not $c->is_system_admin;
-
     my @rack_roles = $c->db_rack_roles->order_by('name')->all;
     $c->log->debug('Found '.scalar(@rack_roles).' rack roles');
 

--- a/lib/Conch/Controller/Relay.pm
+++ b/lib/Conch/Controller/Relay.pm
@@ -81,7 +81,11 @@ sub get ($c) {
         if not $c->is_system_admin;
 
     my $relay = $rs->single;
-    return $c->status(403) if not $relay;
+    if (not $relay) {
+        $c->log->debug('User cannot access unregistered relay '.$identifier);
+        return $c->status(403);
+    }
+
     $c->status(200, $relay);
 }
 

--- a/lib/Conch/Controller/Relay.pm
+++ b/lib/Conch/Controller/Relay.pm
@@ -56,7 +56,6 @@ Response uses the Relays json schema.
 =cut
 
 sub list ($c) {
-    return $c->status(403) if not $c->is_system_admin;
     $c->status(200, [ $c->db_relays->active->order_by('serial_number')->all ]);
 }
 

--- a/lib/Conch/Controller/User.pm
+++ b/lib/Conch/Controller/User.pm
@@ -95,7 +95,7 @@ sub revoke_user_tokens ($c) {
         $c->send_mail(
             template_file => 'revoked_user_tokens',
             From => 'noreply@conch.joyent.us',
-            Subject => 'Your Conch tokens have been revoked.',
+            Subject => 'Your Conch tokens have been revoked',
             token_names => \@token_names,
         );
     }
@@ -307,7 +307,7 @@ sub reset_user_password ($c) {
     $c->send_mail(
         template_file => 'changed_user_password',
         From => 'noreply@conch.joyent.us',
-        Subject => 'Your Conch password has changed.',
+        Subject => 'Your Conch password has changed',
         password => $update{password},
     ) if $params->{send_mail} // 1;
 
@@ -370,7 +370,7 @@ sub update ($c) {
         $c->send_mail(
             template_file => 'updated_user_account',
             From => 'noreply@conch.joyent.us',
-            Subject => 'Your Conch account has been updated.',
+            Subject => 'Your Conch account has been updated',
             orig_data => \%orig_columns,
             new_data => \%dirty_columns,
         );

--- a/lib/Conch/Controller/Workspace.pm
+++ b/lib/Conch/Controller/Workspace.pm
@@ -54,8 +54,10 @@ sub find_workspace ($c) {
       : (any { $method eq $_ } qw(POST PUT)) ? 'rw'
       : $method eq 'DELETE'                  ? 'admin'
       : die "need handling for $method method");
-    return $c->status(403)
-        if not $c->user_has_workspace_auth($c->stash('workspace_id'), $requires_role);
+    if (not $c->user_has_workspace_auth($c->stash('workspace_id'), $requires_role)) {
+        $c->log->debug('User lacks the required role ('.$requires_role.') for workspace '.$identifier);
+        return $c->status(403);
+    }
 
     # stash a resultset for easily accessing the workspace, e.g. for calling ->single, or
     # joining to.

--- a/lib/Conch/Controller/WorkspaceRack.pm
+++ b/lib/Conch/Controller/WorkspaceRack.pm
@@ -112,8 +112,6 @@ is assigned to the parent workspace of this one.
 =cut
 
 sub add ($c) {
-    return $c->status(403) if not $c->is_workspace_admin;
-
     my $input = $c->validate_request('WorkspaceAddRack');
     return if not $input;
 

--- a/lib/Conch/Controller/WorkspaceUser.pm
+++ b/lib/Conch/Controller/WorkspaceUser.pm
@@ -196,7 +196,7 @@ sub remove ($c) {
         $c->send_mail(
             template_file => 'workspace_user_remove_user',
             From => 'noreply@conch.joyent.us',
-            Subject => 'Your Conch workspaces have been updated.',
+            Subject => 'Your Conch workspaces have been updated',
             workspace => $workspace_name,
         );
         my @admins = $c->db_workspaces->and_workspaces_above($c->stash('workspace_id'))->admins

--- a/lib/Conch/Controller/WorkspaceUser.pm
+++ b/lib/Conch/Controller/WorkspaceUser.pm
@@ -27,9 +27,10 @@ sub list ($c) {
         ->and_workspaces_above($workspace_id)
         ->related_resultset('user_workspace_roles')
         ->related_resultset('user_account')
+        ->active
+        ->distinct
         ->order_by('user_account.name')
         ->columns([ map 'user_account.'.$_, qw(id name email) ])
-        ->active
         ->hri;
 
     my $user_data = [

--- a/lib/Conch/DB/Result/UserAccount.pm
+++ b/lib/Conch/DB/Result/UserAccount.pm
@@ -261,7 +261,7 @@ sub TO_JSON ($self) {
                     # $_ is a workspace where the user inherits a role
                     $seen_workspaces{$_->id}++ ? () : do {
                         # instruct the workspace serializer to fill in the role fields
-                        $_->user_id_for_role($self->id);
+                        $self->is_admin ? $_->role('admin') : $_->user_id_for_role($self->id);
                         $_->TO_JSON
                     }
                 ), $self->result_source->schema->resultset('workspace')

--- a/lib/Conch/Plugin/AuthHelpers.pm
+++ b/lib/Conch/Plugin/AuthHelpers.pm
@@ -33,44 +33,6 @@ Verifies that the currently stashed user has the C<is_admin> flag set.
         },
     );
 
-=head2 is_workspace_admin
-
-    return $c->status(403) if not $c->is_workspace_admin;
-
-Verifies that the user indicated by the stashed C<user_id> has the 'admin' role on the
-workspace indicated by the stashed C<workspace_id> or one of its ancestors.
-
-=cut
-
-    $app->helper(
-        is_workspace_admin => sub ($c) {
-            return $c->user_has_workspace_auth($c->stash('workspace_id'), 'admin');
-        },
-    );
-
-=head2 user_has_workspace_auth
-
-Verifies that the user indicated by the stashed C<user_id> has (at least) this role on the
-workspace indicated by the stashed C<workspace_id> or one of its ancestors.
-
-System admin users set will always return true, even if no user_workspace_role records are
-present.
-
-=cut
-
-    $app->helper(
-        user_has_workspace_auth => sub ($c, $workspace_id, $role_name) {
-            return 0 if not $c->stash('user_id');
-            return 0 if not $workspace_id;
-
-            return 1 if $c->is_system_admin;
-
-            $c->db_workspaces
-                ->and_workspaces_above($workspace_id)
-                ->related_resultset('user_workspace_roles')
-                ->user_has_role($c->stash('user_id'), $role_name);
-        },
-    );
 
 =head2 generate_jwt
 

--- a/lib/Conch/Route.pm
+++ b/lib/Conch/Route.pm
@@ -42,8 +42,7 @@ sub all_routes (
 ) {
 
     # provides a route to chain to that first checks the user is a system admin.
-    $root->add_shortcut(require_system_admin => sub {
-        my ($r, $path) = @_;
+    $root->add_shortcut(require_system_admin => sub ($r) {
         $r->any(sub ($c) {
             return $c->status(401)
                 if not $c->stash('user') or not $c->stash('user_id');

--- a/lib/Conch/Route.pm
+++ b/lib/Conch/Route.pm
@@ -47,8 +47,10 @@ sub all_routes (
             return $c->status(401)
                 if not $c->stash('user') or not $c->stash('user_id');
 
-            return $c->status(403, { error => 'Must be system admin' })
-                if not $c->is_system_admin;
+            if (not $c->is_system_admin) {
+                $c->log->debug('User must be system admin');
+                return $c->status(403);
+            }
 
             return 1;
         })->under;

--- a/lib/Conch/Route/Datacenter.pm
+++ b/lib/Conch/Route/Datacenter.pm
@@ -20,7 +20,7 @@ sub routes {
     my $class = shift;
     my $dc = shift;     # secured, under /dc
 
-    $dc->to({ controller => 'datacenter' });
+    $dc = $dc->require_system_admin->to({ controller => 'datacenter' });
 
     # GET /dc
     $dc->get('/')->to('#get_all');

--- a/lib/Conch/Route/DatacenterRoom.pm
+++ b/lib/Conch/Route/DatacenterRoom.pm
@@ -20,7 +20,7 @@ sub routes {
     my $class = shift;
     my $room = shift;   # secured, under /room
 
-    $room->to({ controller => 'datacenter_room' });
+    $room = $room->require_system_admin->to({ controller => 'datacenter_room' });
 
     # GET /room
     $room->get('/')->to('#get_all');

--- a/lib/Conch/Route/HardwareProduct.pm
+++ b/lib/Conch/Route/HardwareProduct.pm
@@ -26,7 +26,7 @@ sub routes {
     $hardware_product->get('/')->to('#list');
 
     # POST /hardware_product
-    $hardware_product->post('/')->to('#create');
+    $hardware_product->require_system_admin->post('/')->to('#create');
 
     {
         # /hardware_product/:hardware_product_id
@@ -47,10 +47,10 @@ sub routes {
             $_->get('/')->to('#get');
 
             # POST /hardware_product/<:identifier>
-            $_->post('/')->to('#update');
+            $_->require_system_admin->post('/')->to('#update');
 
             # DELETE /hardware_product/<:identifier>
-            $_->delete('/')->to('#delete');
+            $_->require_system_admin->delete('/')->to('#delete');
         }
     }
 }

--- a/lib/Conch/Route/HardwareVendor.pm
+++ b/lib/Conch/Route/HardwareVendor.pm
@@ -37,7 +37,7 @@ sub routes {
     }
 
     # POST /hardware_vendor/:hardware_vendor_name
-    $hv->post('/:hardware_vendor_name')->to('#create');
+    $hv->require_system_admin->post('/:hardware_vendor_name')->to('#create');
 }
 
 1;

--- a/lib/Conch/Route/Rack.pm
+++ b/lib/Conch/Route/Rack.pm
@@ -23,9 +23,9 @@ sub routes {
     $rack->to({ controller => 'rack' });
 
     # GET /rack
-    $rack->get('/')->to('#get_all');
+    $rack->require_system_admin->get('/')->to('#get_all');
     # POST /rack
-    $rack->post('/')->to('#create');
+    $rack->require_system_admin->post('/')->to('#create');
 
     my $with_rack = $rack->under('/<rack_id:uuid>')->to('#find_rack');
 

--- a/lib/Conch/Route/RackLayout.pm
+++ b/lib/Conch/Route/RackLayout.pm
@@ -20,7 +20,7 @@ sub routes {
     my $class = shift;
     my $layout = shift; # secured, under /layout
 
-    $layout->to({ controller => 'rack_layout' });
+    $layout = $layout->require_system_admin->to({ controller => 'rack_layout' });
 
     # GET /layout
     $layout->get('/')->to('#get_all');

--- a/lib/Conch/Route/Relay.pm
+++ b/lib/Conch/Route/Relay.pm
@@ -26,7 +26,7 @@ sub routes {
     $relay->post('/:relay_serial_number/register')->to('#register');
 
     # GET /relay
-    $relay->get('/')->to('#list');
+    $relay->require_system_admin->get('/')->to('#list');
 
     # GET /relay/:relay_id_or_serial_number
     $relay->get('/:relay_id_or_serial_number')->to('#get');

--- a/lib/Conch/Route/Workspace.pm
+++ b/lib/Conch/Route/Workspace.pm
@@ -49,7 +49,7 @@ sub routes {
         # GET /workspace/:workspace_id_or_name/rack
         $with_workspace->get('/rack')->to('workspace_rack#list');
         # POST /workspace/:workspace_id_or_name/rack
-        $with_workspace->post('/rack')->to('workspace_rack#add');
+        $with_workspace->post('/rack')->to('workspace_rack#add', require_role => 'admin');
 
         {
             my $with_workspace_rack =

--- a/lib/Conch/Route/Workspace.pm
+++ b/lib/Conch/Route/Workspace.pm
@@ -37,7 +37,7 @@ sub routes {
 
         # GET /workspace/:workspace_id_or_name/child
         $with_workspace->get('/child')->to('workspace#get_sub_workspaces');
-        # POST /workspace/:workspace_id_or_name/child
+        # POST /workspace/:workspace_id_or_name/child?send_mail=<1|0>
         $with_workspace->post('/child')->to('workspace#create_sub_workspace');
 
         # GET /workspace/:workspace_id_or_name/device?<various query params>
@@ -119,7 +119,10 @@ L<role|Conch::DB::Result::UserWorkspaceRole/role>, as indicated.
 
 =back
 
-=head3 C<POST /workspace/:workspace_id_or_name/child>
+=head3 C<< POST /workspace/:workspace_id_or_name/child?send_mail=<1|0> >>
+
+Takes one optional query parameter C<< send_mail=<1|0> >> (defaults to C<1>) to send
+an email to the parent workspace admins.
 
 =over 4
 

--- a/lib/Conch/Route/Workspace.pm
+++ b/lib/Conch/Route/Workspace.pm
@@ -123,7 +123,7 @@ L<role|Conch::DB::Result::UserWorkspaceRole/role>, as indicated.
 
 =over 4
 
-=item * User requires the admin role
+=item * User requires the read/write role
 
 =item * Request: request.yaml#/WorkspaceCreate
 

--- a/lib/Test/Conch.pm
+++ b/lib/Test/Conch.pm
@@ -471,9 +471,11 @@ sub generate_fixtures ($self, @specification) {
 
 =head2 authenticate
 
-Authenticates a user in the current test instance. Uses default credentials if not provided.
-Optionally will bail out of *all* tests on failure. This will set 'user' in the session
-(C<< $t->app->session('user') >>).
+Authenticates a user in the current test instance. Uses default (superuser) credentials if not
+provided.  Optionally will bail out of *all* tests on failure.
+
+This will set 'user' in the session (C<< $t->app->session('user') >>), so a token is not needed
+on subsequent requests.
 
 =cut
 

--- a/lib/Test/Conch/Fixtures.pm
+++ b/lib/Test/Conch/Fixtures.pm
@@ -54,7 +54,7 @@ my %canned_definitions = (
 
     # individual definitions
 
-    conch_user => {
+    super_user => {
         new => 'user_account',
         using => {
             name => 'conch',
@@ -81,6 +81,15 @@ my %canned_definitions = (
             is_admin => 0,
         },
     },
+    admin_user => {
+        new => 'user_account',
+        using => {
+            name => 'admin_user',
+            email => 'admin_user@conch.joyent.us',
+            password => Authen::Passphrase::AcceptAll->new,
+            is_admin => 0,
+        },
+    },
 
     # also created by migration 0012.
     global_workspace => {
@@ -91,16 +100,16 @@ my %canned_definitions = (
         },
     },
 
-    conch_user_global_workspace => {
+    admin_user_global_workspace => {
         new => 'user_workspace_role',
         using => {
             role => 'admin',
             # cannot do this until I fix https://github.com/Ovid/dbix-class-easyfixture/issues/15
-            # user_id => { conch_user => 'id' },
+            # user_id => { admin_user => 'id' },
             # workspace_id => { global_workspace => 'id' },
         },
         requires => {
-            conch_user => { our => 'user_id', their => 'id' },
+            admin_user => { our => 'user_id', their => 'id' },
             global_workspace => { our => 'workspace_id', their => 'id' },
         },
     },
@@ -282,11 +291,11 @@ sub generate_set ($self, $set_name, @args) {
                 using => { name => "sub_ws_$num" },
                 requires => { global_workspace => { our => 'parent_workspace_id', their => 'id' } },
             },
-            "conch_user_sub_workspace_${num}_ro" => {
+            "ro_user_sub_workspace_${num}_ro" => {
                 new => 'user_workspace_role',
                 using => { role => 'ro' },
                 requires => {
-                    conch_user => { our => 'user_id', their => 'id' },
+                    ro_user => { our => 'user_id', their => 'id' },
                     "sub_workspace_$num" => { our => 'workspace_id', their => 'id' },
                 },
             },

--- a/sql/migrations/0125-user_workspace_role-is_admin.sql
+++ b/sql/migrations/0125-user_workspace_role-is_admin.sql
@@ -1,0 +1,7 @@
+SELECT run_migration(125, $$
+
+    delete from user_workspace_role
+        using user_account
+        where user_account.is_admin is true;
+
+$$);

--- a/t/conch-log.t
+++ b/t/conch-log.t
@@ -469,8 +469,7 @@ sub add_test_routes ($t) {
         'dispatch line for /login error includes the response body',
     );
 
-    $t->load_fixture('conch_user_global_workspace');
-    my $user_id = $t->app->db_user_accounts->search({ email => $t->CONCH_EMAIL })->get_column('id')->single;
+    my $user_id = $t->load_fixture('super_user')->id;
     $t->authenticate->json_has('/jwt_token');
 
     cmp_deeply(
@@ -666,8 +665,7 @@ sub add_test_routes ($t) {
         'dispatch line for /login error in audit mode does NOT contain the request body',
     );
 
-    $t->load_fixture('conch_user_global_workspace');
-    my $user_id = $t->app->db_user_accounts->search({ email => $t->CONCH_EMAIL })->get_column('id')->single;
+    my $user_id = $t->load_fixture('super_user')->id;
     $t->authenticate->json_has('/jwt_token');
 
     cmp_deeply(

--- a/t/conch-log.t
+++ b/t/conch-log.t
@@ -469,7 +469,7 @@ sub add_test_routes ($t) {
         'dispatch line for /login error includes the response body',
     );
 
-    my $user_id = $t->load_fixture('super_user')->id;
+    my $user = $t->load_fixture('super_user');
     $t->authenticate->json_has('/jwt_token');
 
     cmp_deeply(
@@ -486,7 +486,7 @@ sub add_test_routes ($t) {
             api_version => re($api_version_re),
             latency => re(qr/^\d+$/),
             req => {
-                user        => $t->CONCH_EMAIL.' ('.$user_id.')',
+                user        => $user->email.' ('.$user->id.')',
                 method      => 'POST',
                 url         => '/login',
                 remoteAddress => '127.0.0.1',
@@ -665,7 +665,7 @@ sub add_test_routes ($t) {
         'dispatch line for /login error in audit mode does NOT contain the request body',
     );
 
-    my $user_id = $t->load_fixture('super_user')->id;
+    my $user = $t->load_fixture('super_user');
     $t->authenticate->json_has('/jwt_token');
 
     cmp_deeply(
@@ -682,7 +682,7 @@ sub add_test_routes ($t) {
             api_version => re($api_version_re),
             latency => re(qr/^\d+$/),
             req => {
-                user        => $t->CONCH_EMAIL.' ('.$user_id.')',
+                user        => $user->email.' ('.$user->id.')',
                 method      => 'POST',
                 url         => '/login',
                 remoteAddress => '127.0.0.1',
@@ -717,7 +717,7 @@ sub add_test_routes ($t) {
             api_version => re($api_version_re),
             latency => re(qr/^\d+$/),
             req => {
-                user        => $t->CONCH_EMAIL.' ('.$user_id.')',
+                user        => $user->email.' ('.$user->id.')',
                 method      => 'POST',
                 url         => '/user/me/token',
                 remoteAddress => '127.0.0.1',
@@ -753,7 +753,7 @@ sub add_test_routes ($t) {
             api_version => re($api_version_re),
             latency => re(qr/^\d+$/),
             req => {
-                user        => $t->CONCH_EMAIL.' ('.$user_id.')',
+                user        => $user->email.' ('.$user->id.')',
                 method      => 'POST',
                 url         => '/user/me/password',
                 remoteAddress => '127.0.0.1',

--- a/t/integration/crud/datacenter.t
+++ b/t/integration/crud/datacenter.t
@@ -5,7 +5,7 @@ use Test::Deep;
 use Test::Conch;
 
 my $t = Test::Conch->new;
-$t->load_fixture('conch_user_global_workspace');
+$t->load_fixture('super_user');
 
 $t->authenticate;
 

--- a/t/integration/crud/devices.t
+++ b/t/integration/crud/devices.t
@@ -51,7 +51,8 @@ subtest 'unlocated device, no registered relay' => sub {
     my $device_report_id = $t->tx->res->json->{device_report_id};
 
     $t->get_ok('/device/TEST')
-        ->status_is(403);
+        ->status_is(403)
+        ->log_debug_is('User cannot access unlocated device '.$test_device_id);
 
     $t->get_ok('/device_report/'.$device_report_id)
         ->status_is(403);
@@ -196,19 +197,25 @@ subtest 'unlocated device with a registered relay' => sub {
     $t2->authenticate(email => $null_user->email);
 
     $t2->get_ok('/device/TEST')
-        ->status_is(403);
+        ->status_is(403)
+        ->log_debug_is('User cannot access unlocated device '.$test_device_id);
 
     $t2->get_ok('/device_report/'.$validation_state->{device_report_id})
-        ->status_is(403);
+        ->status_is(403)
+        ->log_debug_is('User cannot access unlocated device '.$test_device_id);
 
     foreach my $query (@post_queries) {
         $t2->post_ok($query->@*)
-            ->status_is(403);
+            ->status_is(403)
+            ->log_debug_is('User cannot access unlocated device '.$test_device_id);
     }
 
     foreach my $query (@get_queries) {
         $t2->get_ok($query)
-            ->status_is(403);
+            ->status_is(403)
+            ->log_debug_is(
+                $query =~ /TEST/ ? 'User cannot access unlocated device '.$test_device_id
+                : 'User cannot access requested device(s)');
     }
 
     my @delete_queries = (
@@ -219,7 +226,8 @@ subtest 'unlocated device with a registered relay' => sub {
 
     foreach my $query (@delete_queries) {
         $t2->delete_ok($query)
-            ->status_is(403);
+            ->status_is(403)
+            ->log_debug_is('User cannot access unlocated device '.$test_device_id);
     }
 
     foreach my $query (@delete_queries) {
@@ -305,7 +313,8 @@ subtest 'located device' => sub {
     $t->txn_local('remove device from its workspace', sub ($t) {
         $t->app->db_workspace_racks->delete;
         $t->get_ok('/device/LOCATED_DEVICE')
-            ->status_is(403);
+            ->status_is(403)
+            ->log_debug_is('User lacks the required role (ro) for device '.$located_device_id);
     });
 
     subtest 'required role for POST queries' => sub {
@@ -329,7 +338,8 @@ subtest 'located device' => sub {
             }
         }
         $t->post_ok('/device/LOCATED_DEVICE/settings/hello', json => { 'hello' => 'bye' })
-            ->status_is(403);
+            ->status_is(403)
+            ->log_debug_is('User lacks the required role (admin) for device '.$located_device_id);
 
         $t->authenticate(email => $admin_user->email);
         $t->post_ok('/device/LOCATED_DEVICE/settings/hello', json => { 'hello' => 'bye' })
@@ -338,7 +348,8 @@ subtest 'located device' => sub {
         $t->authenticate(email => $ro_user->email);
         foreach my $query (@post_queries) {
             $t->post_ok($query->@*)
-                ->status_is(403);
+                ->status_is(403)
+                ->log_debug_is('User lacks the required role (rw) for device '.$located_device_id);
         }
     };
 
@@ -380,7 +391,10 @@ subtest 'located device' => sub {
 
             foreach my $query (@get_queries) {
                 $t->get_ok($query)
-                    ->status_is(403);
+                    ->status_is(403)
+                    ->log_debug_is(
+                        $query =~ /LOCATED_DEVICE/ ? 'User lacks the required role (ro) for device '.$located_device_id
+                        : 'User cannot access requested device(s)');
             }
 
             $ro_user->update({ is_admin => 1 });
@@ -395,16 +409,21 @@ subtest 'located device' => sub {
 
     subtest 'required role for DELETE queries' => sub {
         $t->authenticate(email => $ro_user->email);
-        $t->delete_ok('/device/LOCATED_DEVICE/settings/hello')
-            ->status_is(403);
-        $t->delete_ok('/device/LOCATED_DEVICE/settings/tag.hello')
-            ->status_is(403);
-        $t->delete_ok('/device/LOCATED_DEVICE/links')
-            ->status_is(403);
+
+        foreach my $query (qw(
+            /device/LOCATED_DEVICE/settings/hello
+            /device/LOCATED_DEVICE/settings/tag.hello
+            /device/LOCATED_DEVICE/links
+        )) {
+            $t->delete_ok($query)
+                ->status_is(403)
+                ->log_debug_is('User lacks the required role (rw) for device '.$located_device_id);
+        }
 
         $t->authenticate(email => $rw_user->email);
         $t->delete_ok('/device/LOCATED_DEVICE/settings/hello')
-            ->status_is(403);
+            ->status_is(403)
+            ->log_debug_is('User lacks the required role (admin) for device '.$located_device_id);
         $t->delete_ok('/device/LOCATED_DEVICE/settings/tag.hello')
             ->status_is(204);
         $t->delete_ok('/device/LOCATED_DEVICE/links')
@@ -692,23 +711,29 @@ subtest 'Device settings' => sub {
     $t->authenticate(email => $ro_user->email);
 
     $t->post_ok('/device/LOCATED_DEVICE/settings/foo', json => { foo => 'new_value' })
-        ->status_is(403);
+        ->status_is(403)
+        ->log_debug_is('User lacks the required role (rw) for device '.$located_device_id);
     $t->post_ok('/device/LOCATED_DEVICE/settings', json => { name => 'new value' })
-        ->status_is(403);
+        ->status_is(403)
+        ->log_debug_is('User lacks the required role (rw) for device '.$located_device_id);
     $t->delete_ok('/device/LOCATED_DEVICE/settings/foo')
-        ->status_is(403);
+        ->status_is(403)
+        ->log_debug_is('User lacks the required role (rw) for device '.$located_device_id);
 
     $t->authenticate(email => $rw_user->email);
 
     $t->post_ok('/device/LOCATED_DEVICE/settings', json => { key => 'value' })
         ->status_is(204);
     $t->post_ok('/device/LOCATED_DEVICE/settings/key', json => { key => 'new value' })
-        ->status_is(403);
+        ->status_is(403)
+        ->log_debug_is('User lacks the required role (admin) for device '.$located_device_id);
     $t->delete_ok('/device/LOCATED_DEVICE/settings/foo')
-        ->status_is(403);
+        ->status_is(403)
+        ->log_debug_is('User lacks the required role (admin) for device '.$located_device_id);
 
     $t->post_ok('/device/LOCATED_DEVICE/settings', json => { key => 'new value', 'tag.bar' => 'bar' })
-        ->status_is(403);
+        ->status_is(403)
+        ->log_debug_is('User lacks the required role (admin) for device '.$located_device_id);
     $t->post_ok('/device/LOCATED_DEVICE/settings', json => { 'tag.foo' => 'foo', 'tag.bar' => 'bar' })
         ->status_is(204);
 

--- a/t/integration/crud/hardware-product.t
+++ b/t/integration/crud/hardware-product.t
@@ -7,7 +7,7 @@ use Test::Deep;
 use Test::Conch;
 
 my $t = Test::Conch->new;
-$t->load_fixture('conch_user_global_workspace');
+$t->load_fixture('super_user');
 
 $t->authenticate;
 

--- a/t/integration/crud/hardware-vendor.t
+++ b/t/integration/crud/hardware-vendor.t
@@ -8,7 +8,7 @@ use Test::Deep;
 use Test::Conch;
 
 my $t = Test::Conch->new;
-$t->load_fixture(qw(conch_user_global_workspace hardware_vendor_0));
+$t->load_fixture(qw(super_user hardware_vendor_0));
 
 $t->authenticate;
 

--- a/t/integration/crud/rack-layouts.t
+++ b/t/integration/crud/rack-layouts.t
@@ -6,7 +6,7 @@ use Conch::UUID 'create_uuid_str';
 use Test::Conch;
 
 my $t = Test::Conch->new;
-$t->load_fixture('conch_user_global_workspace');
+$t->load_fixture('super_user');
 
 $t->authenticate;
 

--- a/t/integration/crud/rack-roles.t
+++ b/t/integration/crud/rack-roles.t
@@ -5,7 +5,7 @@ use Test::Deep;
 use Test::Conch;
 
 my $t = Test::Conch->new;
-$t->load_fixture('conch_user_global_workspace');
+$t->load_fixture('super_user');
 
 $t->authenticate;
 

--- a/t/integration/crud/racks.t
+++ b/t/integration/crud/racks.t
@@ -6,7 +6,7 @@ use Conch::UUID 'create_uuid_str';
 use Test::Conch;
 
 my $t = Test::Conch->new;
-$t->load_fixture('conch_user_global_workspace');
+$t->load_fixture('super_user');
 
 $t->authenticate;
 

--- a/t/integration/crud/racks.t
+++ b/t/integration/crud/racks.t
@@ -127,7 +127,8 @@ my $null_user = $t->generate_fixtures('user_account');
 my $t2 = Test::Conch->new(pg => $t->pg);
 $t2->authenticate(email => $null_user->email);
 $t2->delete_ok("/rack/$new_rack_id")
-    ->status_is(403);
+    ->status_is(403)
+    ->log_debug_is('User lacks the required role (rw) for rack '.$new_rack_id);
 
 $t->delete_ok("/rack/$new_rack_id")
     ->status_is(204);

--- a/t/integration/crud/relay.t
+++ b/t/integration/crud/relay.t
@@ -140,10 +140,12 @@ $t->get_ok('/relay')
     $t2->authenticate(email => $other_user->email);
 
     $t2->get_ok('/relay')
-        ->status_is(403);
+        ->status_is(403)
+        ->log_debug_is('User must be system admin');
 
     $t2->get_ok('/relay/relay0')
-        ->status_is(403);
+        ->status_is(403)
+        ->log_debug_is('User cannot access unregistered relay relay0');
 
     $t2->post_ok('/relay/relay0/register', json => { serial => 'relay0' })
         ->status_is(204)

--- a/t/integration/crud/rooms.t
+++ b/t/integration/crud/rooms.t
@@ -5,7 +5,7 @@ use Test::Deep;
 use Test::Conch;
 
 my $t = Test::Conch->new;
-$t->load_fixture('conch_user_global_workspace');
+$t->load_fixture('super_user');
 
 $t->authenticate;
 

--- a/t/integration/crud/validations.t
+++ b/t/integration/crud/validations.t
@@ -7,7 +7,7 @@ use Test::Deep;
 use Test::Conch;
 
 my $t = Test::Conch->new;
-$t->load_fixture('conch_user_global_workspace');
+$t->load_fixture('super_user');
 $t->load_validation_plans([{
     name        => 'Conch v1 Legacy Plan: Server',
     description => 'Test Plan',

--- a/t/integration/crud/workspace-devices.t
+++ b/t/integration/crud/workspace-devices.t
@@ -16,7 +16,8 @@ $t->load_validation_plans([{
     validations => [ 'Conch::Validation::DeviceProductName' ],
 }]);
 
-my $global_ws_id = $t->load_fixture('conch_user_global_workspace')->workspace_id;
+$t->load_fixture('super_user');
+my $global_ws_id = $t->load_fixture('global_workspace')->id;
 my @layouts = $t->load_fixture(map 'rack_0a_layout_'.$_, '1_2', '3_6');
 
 my @devices = map $t->app->db_devices->create($_), (

--- a/t/integration/crud/workspace-rack.t
+++ b/t/integration/crud/workspace-rack.t
@@ -8,7 +8,8 @@ use Test::Conch;
 use Conch::UUID 'create_uuid_str';
 
 my $t = Test::Conch->new;
-my $global_ws_id = $t->load_fixture('conch_user_global_workspace')->workspace_id;
+$t->load_fixture('super_user');
+my $global_ws_id = $t->load_fixture('global_workspace')->id;
 
 $t->authenticate;
 

--- a/t/integration/crud/workspace.t
+++ b/t/integration/crud/workspace.t
@@ -543,7 +543,8 @@ subtest 'Sub-Workspace' => sub {
     delete $users{GLOBAL};
 
     $untrusted->get_ok('/workspace/GLOBAL')
-        ->status_is(403);
+        ->status_is(403)
+        ->log_debug_is('User lacks the required role (ro) for workspace GLOBAL');
 
     $untrusted->get_ok('/workspace/child_ws')
         ->status_is(200)
@@ -556,10 +557,12 @@ subtest 'Sub-Workspace' => sub {
         ->json_is($workspace_data{untrusted_user}[1]);
 
     $untrusted->get_ok('/workspace/GLOBAL/user')
-        ->status_is(403);
+        ->status_is(403)
+        ->log_debug_is('User lacks the required role (admin) for workspace GLOBAL');
 
     $untrusted->get_ok('/workspace/child_ws/user')
-        ->status_is(403);
+        ->status_is(403)
+        ->log_debug_is('User lacks the required role (admin) for workspace child_ws');
 
     $t->post_ok('/workspace/child_ws/user', json => {
             email => 'untrusted_user@conch.joyent.us',
@@ -590,7 +593,8 @@ subtest 'Sub-Workspace' => sub {
         ->json_cmp_deeply($users{child_ws});
 
     $untrusted->get_ok('/workspace/GLOBAL/user')
-        ->status_is(403);
+        ->status_is(403)
+        ->log_debug_is('User lacks the required role (admin) for workspace GLOBAL');
 
     $untrusted->get_ok('/workspace/child_ws/user')
         ->status_is(200)
@@ -615,17 +619,21 @@ subtest 'Roles' => sub {
 
         $t->post_ok("/workspace/$global_ws_id/child",
                 json => { name => 'test', description => 'also test' })
-            ->status_is(403);
+            ->status_is(403)
+            ->log_debug_is('User lacks the required role (rw) for workspace '.$global_ws_id);
 
         $t->post_ok("/workspace/$global_ws_id/rack", json => { id => create_uuid_str() })
-            ->status_is(403);
+            ->status_is(403)
+            ->log_debug_is('User lacks the required role (rw) for workspace '.$global_ws_id);
 
         $t->post_ok("/workspace/$global_ws_id/user",
                 json => { user => 'another@wat.wat', role => 'ro' })
-            ->status_is(403);
+            ->status_is(403)
+            ->log_debug_is('User lacks the required role (admin) for workspace '.$global_ws_id);
 
         $t->get_ok("/workspace/$global_ws_id/user")
-            ->status_is(403);
+            ->status_is(403)
+            ->log_debug_is('User lacks the required role (admin) for workspace '.$global_ws_id);
 
         $t->post_ok('/logout')
             ->status_is(204);
@@ -646,10 +654,12 @@ subtest 'Roles' => sub {
 
         $t->post_ok("/workspace/$global_ws_id/user",
                 json => { user => 'another@wat.wat', role => 'ro' })
-            ->status_is(403);
+            ->status_is(403)
+            ->log_debug_is('User lacks the required role (admin) for workspace '.$global_ws_id);
 
         $t->get_ok("/workspace/$global_ws_id/user")
-            ->status_is(403);
+            ->status_is(403)
+            ->log_debug_is('User lacks the required role (admin) for workspace '.$global_ws_id);
     };
 };
 

--- a/t/integration/crud/workspace.t
+++ b/t/integration/crud/workspace.t
@@ -635,6 +635,11 @@ subtest 'Sub-Workspace' => sub {
         ->json_schema_is('WorkspaceAndRole')
         ->json_is($workspace_data{untrusted_user}[1]);
 
+    $untrusted->get_ok('/workspace')
+        ->status_is(200)
+        ->json_schema_is('WorkspacesAndRoles')
+        ->json_is($workspace_data{untrusted_user});
+
     $untrusted->get_ok('/workspace/GLOBAL/user')
         ->status_is(403)
         ->log_debug_is('User lacks the required role (admin) for workspace GLOBAL');

--- a/t/integration/crud/workspace.t
+++ b/t/integration/crud/workspace.t
@@ -478,7 +478,7 @@ subtest 'Sub-Workspace' => sub {
             {
                 To => '"test user" <test_user@conch.joyent.us>',
                 From => 'noreply@conch.joyent.us',
-                Subject => 'Your Conch workspaces have been updated.',
+                Subject => 'Your Conch workspaces have been updated',
                 body => re(qr/^You have been removed from the "child_ws" workspace at Joyent Conch\./m),
             },
             {

--- a/t/integration/crud/workspace.t
+++ b/t/integration/crud/workspace.t
@@ -648,10 +648,6 @@ subtest 'Roles' => sub {
             ->json_schema_is('WorkspacesAndRoles')
             ->json_is('/0/name' => 'GLOBAL');
 
-        $t->post_ok("/workspace/$global_ws_id/child",
-                json => { name => 'test', description => 'also test' })
-            ->status_is(403);
-
         $t->post_ok("/workspace/$global_ws_id/user",
                 json => { user => 'another@wat.wat', role => 'ro' })
             ->status_is(403)

--- a/t/integration/users.t
+++ b/t/integration/users.t
@@ -894,11 +894,14 @@ subtest 'user tokens (someone else\'s)' => sub {
 
     # can't use the sysadmin endpoints, even to ask about ourself
     $t_other_user->get_ok('/user/'.$email.'/token')
-        ->status_is(403);
+        ->status_is(403)
+        ->log_debug_is('User must be system admin');
     $t_other_user->get_ok('/user/'.$email.'/token/foo')
-        ->status_is(403);
+        ->status_is(403)
+        ->log_debug_is('User must be system admin');
     $t_other_user->delete_ok('/user/'.$email.'/token/foo')
-        ->status_is(403);
+        ->status_is(403)
+        ->log_debug_is('User must be system admin');
 
     $t_other_user->post_ok('/user/me/token', json => { name => 'my second token' })
         ->status_is(201)

--- a/t/integration/users.t
+++ b/t/integration/users.t
@@ -487,7 +487,7 @@ subtest 'modify another user' => sub {
         ->email_cmp_deeply({
             To => '"FOO" <foo@conch.joyent.us>',
             From => 'noreply@conch.joyent.us',
-            Subject => 'Your Conch account has been updated.',
+            Subject => 'Your Conch account has been updated',
             body => re(qr/^Your account at Joyent Conch has been updated:\R\R {4}is_admin: false -> true\R {8}name: foo -> FOO\R\R/m),
         });
     $new_user_data->{name} = 'FOO';
@@ -519,7 +519,7 @@ subtest 'modify another user' => sub {
         ->email_cmp_deeply({
             To => '"FOO" <foo@conch.joyent.us>',
             From => 'noreply@conch.joyent.us',
-            Subject => 'Your Conch tokens have been revoked.',
+            Subject => 'Your Conch tokens have been revoked',
             body => re(qr/^The following tokens at Joyent Conch have been reset:\R\R    1 login token\R\R/m),
         });
 
@@ -538,7 +538,7 @@ subtest 'modify another user' => sub {
         ->email_cmp_deeply({
             To => '"FOO" <foo@conch.joyent.us>',
             From => 'noreply@conch.joyent.us',
-            Subject => 'Your Conch tokens have been revoked.',
+            Subject => 'Your Conch tokens have been revoked',
             body => re(qr/^The following tokens at Joyent Conch have been reset:\R\R    my api token\R    my second api token\R/m),
         });
 
@@ -585,7 +585,7 @@ subtest 'modify another user' => sub {
         ->email_cmp_deeply({
             To => '"FOO" <foo@conch.joyent.us>',
             From => 'noreply@conch.joyent.us',
-            Subject => 'Your Conch password has changed.',
+            Subject => 'Your Conch password has changed',
             body => re(qr/^Your password at Joyent Conch has been reset..*\R\R    Username: FOO\R    Email:    foo\@conch.joyent.us\R    Password: .*\R/ms),
         });
 
@@ -594,7 +594,7 @@ subtest 'modify another user' => sub {
         ->email_cmp_deeply({
             To => '"FOO" <foo@conch.joyent.us>',
             From => 'noreply@conch.joyent.us',
-            Subject => 'Your Conch password has changed.',
+            Subject => 'Your Conch password has changed',
             body => re(qr/^Your password at Joyent Conch has been reset..*\R\R    Username: FOO\R    Email:    foo\@conch.joyent.us\R    Password: .*\R\R/ms),
         });
     my $insecure_password = $_new_password;
@@ -957,7 +957,7 @@ subtest 'user tokens (someone else\'s)' => sub {
         ->email_cmp_deeply({
             To => '"FOO" <'.$email.'>',
             From => 'noreply@conch.joyent.us',
-            Subject => 'Your Conch tokens have been revoked.',
+            Subject => 'Your Conch tokens have been revoked',
             body => re(qr/^The following tokens at Joyent Conch have been reset:\R\R    my second token\R    1 login token\R\R/m),
         });
 

--- a/templates/email/workspace_subworkspace_create_admins.txt.ep
+++ b/templates/email/workspace_subworkspace_create_admins.txt.ep
@@ -1,0 +1,8 @@
+Hello,
+
+<%# TODO: we should specify the conch URL here %>\
+<%= $user->name %> (<%= $user->email %>) has created the "<%= $workspace %>" child workspace
+beneath the "<%= $parent_workspace %>" workspace at Joyent Conch.
+
+Thank you,
+Joyent Build Ops Team


### PR DESCRIPTION
More fixes for role checks all over the system.

- always allow sysadmin users when doing rack auth checks
- log when a role check fails
- let users with the "rw" role create a subworkspace (and they are given the "admin" role on it, if they did not have it already through some other means)
- fix conflation of superusers and workspace-admin users everywhere (side effect: "role_via" fields will no longer appear for results regarding system admin users)
- fix: do not show parent_workspace_ids to users who cannot access them

