### PR TITLE
v2: collapse validation result more

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,9 +7,10 @@
 
 * @karenetheridge
 /json-schema/ @karenetheridge @sungo @dustinryerson
+/json-schema/common.yaml @karenetheridge @perigrin @sungo @dustinryerson
+/json-schema/device_report.yaml @karenetheridge @perigrin @sungo @dustinryerson
 /docker @sungo
 /Docker* @sungo
 /docker* @sungo
 Makefile @sungo @karenetheridge
 /bin/ @sungo @karenetheridge
-* @sungo

--- a/docs/modules/Conch::DB::Result::Device.md
+++ b/docs/modules/Conch::DB::Result::Device.md
@@ -217,6 +217,12 @@ Type: has\_many
 
 Related object: [Conch::DB::Result::ValidationState](/modules/Conch::DB::Result::ValidationState)
 
+## relays
+
+Type: many\_to\_many
+
+Composing rels: ["device\_relay\_connections"](#device_relay_connections) -> relay
+
 ## latest\_report\_data
 
 Returns the JSON-decoded content from the most recent device report.

--- a/docs/modules/Conch::DB::Result::Relay.md
+++ b/docs/modules/Conch::DB::Result::Relay.md
@@ -86,6 +86,18 @@ Type: has\_many
 
 Related object: [Conch::DB::Result::UserRelayConnection](/modules/Conch::DB::Result::UserRelayConnection)
 
+## devices
+
+Type: many\_to\_many
+
+Composing rels: ["device\_relay\_connections"](#device_relay_connections) -> device
+
+## user\_accounts
+
+Type: many\_to\_many
+
+Composing rels: ["user\_relay\_connections"](#user_relay_connections) -> user\_account
+
 # LICENSING
 
 Copyright Joyent, Inc.

--- a/docs/modules/Conch::DB::Result::UserAccount.md
+++ b/docs/modules/Conch::DB::Result::UserAccount.md
@@ -115,6 +115,18 @@ Type: has\_many
 
 Related object: [Conch::DB::Result::UserWorkspaceRole](/modules/Conch::DB::Result::UserWorkspaceRole)
 
+## relays
+
+Type: many\_to\_many
+
+Composing rels: ["user\_relay\_connections"](#user_relay_connections) -> relay
+
+## workspaces
+
+Type: many\_to\_many
+
+Composing rels: ["user\_workspace\_roles"](#user_workspace_roles) -> workspace
+
 # METHODS
 
 ## TO\_JSON

--- a/docs/modules/Conch::DB::Result::ValidationResult.md
+++ b/docs/modules/Conch::DB::Result::ValidationResult.md
@@ -79,13 +79,6 @@ data_type: 'text'
 is_nullable: 1
 ```
 
-## result\_order
-
-```
-data_type: 'integer'
-is_nullable: 0
-```
-
 ## created
 
 ```perl

--- a/docs/modules/Conch::DB::Result::ValidationStateMember.md
+++ b/docs/modules/Conch::DB::Result::ValidationStateMember.md
@@ -26,6 +26,13 @@ is_nullable: 0
 size: 16
 ```
 
+## result\_order
+
+```
+data_type: 'integer'
+is_nullable: 0
+```
+
 # PRIMARY KEY
 
 - ["validation\_state\_id"](#validation_state_id)

--- a/docs/modules/Conch::DB::Result::Workspace.md
+++ b/docs/modules/Conch::DB::Result::Workspace.md
@@ -82,6 +82,12 @@ Type: many\_to\_many
 
 Composing rels: ["workspace\_racks"](#workspace_racks) -> rack
 
+## user\_accounts
+
+Type: many\_to\_many
+
+Composing rels: ["user\_workspace\_roles"](#user_workspace_roles) -> user\_account
+
 ## TO\_JSON
 
 Include information about the user's permissions, if available.

--- a/lib/Conch/Command/merge_validation_results.pm
+++ b/lib/Conch/Command/merge_validation_results.pm
@@ -96,7 +96,7 @@ sub run ($self, @opts) {
 sub _process_device ($self, $device) {
     print 'device id ', $device->id, ': ';
 
-    my @grouping_cols = qw(device_id hardware_product_id validation_id message hint status category component_id result_order);
+    my @grouping_cols = qw(device_id hardware_product_id validation_id message hint status category component_id);
 
     my $schema = $self->app->schema;
     my ($group_count, $results_deleted) = (0)x2;

--- a/lib/Conch/Controller/DeviceReport.pm
+++ b/lib/Conch/Controller/DeviceReport.pm
@@ -450,11 +450,12 @@ sub validate_report ($c) {
 
     return $c->status(400, { error => 'no validations ran' }) if not @validation_results;
 
+    my $result_order = 0;
     $c->status(200, {
         device_id => $unserialized_report->{serial_number},
         validation_plan_id => $validation_plan->id,
         status => $status,
-        results => \@validation_results,
+        results => [ map +{ $_->TO_JSON->%*, order => $result_order++ }, @validation_results ],
     });
 }
 

--- a/lib/Conch/Controller/DeviceValidation.pm
+++ b/lib/Conch/Controller/DeviceValidation.pm
@@ -79,7 +79,8 @@ sub validate ($c) {
         data => $data,
     );
 
-    $c->status(200, \@validation_results);
+    my $result_order = 0;
+    $c->status(200, [ map +{ $_->TO_JSON->%*, order => $result_order++ }, @validation_results ]);
 }
 
 =head2 run_validation_plan
@@ -119,7 +120,8 @@ sub run_validation_plan ($c) {
         no_save_db => 1,
     );
 
-    $c->status(200, \@validation_results);
+    my $result_order = 0;
+    $c->status(200, [ map +{ $_->TO_JSON->%*, order => $result_order++ }, @validation_results ]);
 }
 
 1;

--- a/lib/Conch/DB/Result/Device.pm
+++ b/lib/Conch/DB/Result/Device.pm
@@ -379,9 +379,19 @@ __PACKAGE__->has_many(
   { cascade_copy => 0, cascade_delete => 0 },
 );
 
+=head2 relays
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2019-04-09 15:03:43
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:vZ2aohKu5fWutuDZPSEitg
+Type: many_to_many
+
+Composing rels: L</device_relay_connections> -> relay
+
+=cut
+
+__PACKAGE__->many_to_many("relays", "device_relay_connections", "relay");
+
+
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2019-08-07 15:04:34
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:1At6DFaLFMxfU1TJQImcaQ
 
 __PACKAGE__->has_many(
   "active_device_disks",

--- a/lib/Conch/DB/Result/Relay.pm
+++ b/lib/Conch/DB/Result/Relay.pm
@@ -147,9 +147,29 @@ __PACKAGE__->has_many(
   { cascade_copy => 0, cascade_delete => 0 },
 );
 
+=head2 devices
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:OI7LN23DmloIV1FBrPHuJQ
+Type: many_to_many
+
+Composing rels: L</device_relay_connections> -> device
+
+=cut
+
+__PACKAGE__->many_to_many("devices", "device_relay_connections", "device");
+
+=head2 user_accounts
+
+Type: many_to_many
+
+Composing rels: L</user_relay_connections> -> user_account
+
+=cut
+
+__PACKAGE__->many_to_many("user_accounts", "user_relay_connections", "user_account");
+
+
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2019-08-07 15:04:34
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:tfbo9GY1rO+VsSV9mdf9/w
 
 __PACKAGE__->add_columns(
     '+deactivated' => { is_serializable => 0 },

--- a/lib/Conch/DB/Result/UserAccount.pm
+++ b/lib/Conch/DB/Result/UserAccount.pm
@@ -194,9 +194,29 @@ __PACKAGE__->has_many(
   { cascade_copy => 0, cascade_delete => 0 },
 );
 
+=head2 relays
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-18 11:14:52
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:iTfN8qDvzBsoGQS162cx9g
+Type: many_to_many
+
+Composing rels: L</user_relay_connections> -> relay
+
+=cut
+
+__PACKAGE__->many_to_many("relays", "user_relay_connections", "relay");
+
+=head2 workspaces
+
+Type: many_to_many
+
+Composing rels: L</user_workspace_roles> -> workspace
+
+=cut
+
+__PACKAGE__->many_to_many("workspaces", "user_workspace_roles", "workspace");
+
+
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2019-08-07 15:04:34
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:ZeVSfBUDX/v+0ACnH1KXrw
 
 __PACKAGE__->add_columns(
     '+password_hash' => { is_serializable => 0 },

--- a/lib/Conch/DB/Result/ValidationResult.pm
+++ b/lib/Conch/DB/Result/ValidationResult.pm
@@ -81,11 +81,6 @@ __PACKAGE__->table("validation_result");
   data_type: 'text'
   is_nullable: 1
 
-=head2 result_order
-
-  data_type: 'integer'
-  is_nullable: 0
-
 =head2 created
 
   data_type: 'timestamp with time zone'
@@ -126,8 +121,6 @@ __PACKAGE__->add_columns(
   { data_type => "text", is_nullable => 0 },
   "component_id",
   { data_type => "text", is_nullable => 1 },
-  "result_order",
-  { data_type => "integer", is_nullable => 0 },
   "created",
   {
     data_type     => "timestamp with time zone",
@@ -226,21 +219,12 @@ __PACKAGE__->many_to_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2019-02-12 15:14:57
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:eM2SDA/xuqdqeJcwvRRj2A
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2019-08-07 15:18:08
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:9zu/UPpSUraFP17fgq2x8A
 
 __PACKAGE__->add_columns(
     '+created' => { is_serializable => 0 },
 );
-
-use experimental 'signatures';
-
-sub TO_JSON ($self) {
-    my $data = $self->next::method(@_);
-    $data->{order} = delete $data->{result_order};
-
-    return $data;
-}
 
 1;
 __END__

--- a/lib/Conch/DB/Result/ValidationState.pm
+++ b/lib/Conch/DB/Result/ValidationState.pm
@@ -217,7 +217,9 @@ sub TO_JSON ($self) {
             map {
                 my $cached_result = $_->related_resultset('validation_result')->get_cache;
                 # cache is always a listref even for a belongs_to relationship
-                $cached_result ? $cached_result->[0]->TO_JSON : ()
+                $cached_result
+                    ? +{ $cached_result->[0]->TO_JSON->%*, order => $_->result_order }
+                    : ()
             }
             $cached_members->@*
         ];

--- a/lib/Conch/DB/Result/ValidationStateMember.pm
+++ b/lib/Conch/DB/Result/ValidationStateMember.pm
@@ -42,6 +42,11 @@ __PACKAGE__->table("validation_state_member");
   is_nullable: 0
   size: 16
 
+=head2 result_order
+
+  data_type: 'integer'
+  is_nullable: 0
+
 =cut
 
 __PACKAGE__->add_columns(
@@ -49,6 +54,8 @@ __PACKAGE__->add_columns(
   { data_type => "uuid", is_foreign_key => 1, is_nullable => 0, size => 16 },
   "validation_result_id",
   { data_type => "uuid", is_foreign_key => 1, is_nullable => 0, size => 16 },
+  "result_order",
+  { data_type => "integer", is_nullable => 0 },
 );
 
 =head1 PRIMARY KEY
@@ -98,8 +105,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-10-16 13:17:28
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:waeVK0lJGoJZbkd640IX7A
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2019-08-07 15:18:08
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:wSfsdnq0/4c54N8Q8R3sUA
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Conch/DB/Result/Workspace.pm
+++ b/lib/Conch/DB/Result/Workspace.pm
@@ -173,9 +173,19 @@ Composing rels: L</workspace_racks> -> rack
 
 __PACKAGE__->many_to_many("racks", "workspace_racks", "rack");
 
+=head2 user_accounts
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2019-03-05 12:50:12
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:XPeRYrFMA7VfFHuKwOS8Sw
+Type: many_to_many
+
+Composing rels: L</user_workspace_roles> -> user_account
+
+=cut
+
+__PACKAGE__->many_to_many("user_accounts", "user_workspace_roles", "user_account");
+
+
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2019-08-07 15:04:34
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:grjgLmZfiUYtsI/oAXzn9A
 
 use experimental 'signatures';
 

--- a/lib/Conch/Validation/CpuTemperature.pm
+++ b/lib/Conch/Validation/CpuTemperature.pm
@@ -26,7 +26,8 @@ sub validate {
             type     => 'CPU',
             expected => $MAX_TEMP,
             cmp      => '<',
-            got      => $data->{temp}->{$cpu}
+            got      => $data->{temp}->{$cpu},
+            component_id => $cpu,
         );
     }
 }

--- a/lib/Conch/Validation/SwitchPeers.pm
+++ b/lib/Conch/Validation/SwitchPeers.pm
@@ -97,7 +97,8 @@ sub validate {
         $self->register_result(
             expected => 2,
             got      => $num_ports,
-            name     => 'num_ports'
+            name     => 'num_ports',
+            component_id => $switch_name,
         );
     }
 }

--- a/lib/Conch/ValidationSystem.pm
+++ b/lib/Conch/ValidationSystem.pm
@@ -341,13 +341,8 @@ sub run_validation_plan ($self, %options) {
 
         $validator->run($data);
 
-        my $result_order = 0;
         push @validation_results, map
             $validation_result_rs->new_result({
-                # each time a ValidationResult is created, increment order value
-                # post-assignment. This allows us to distinguish between multiples
-                # of similar results
-                result_order        => $result_order++,
                 validation_id       => $validation->id,
                 device_id           => $device->id,
                 hardware_product_id => $validator->hardware_product->id,
@@ -377,6 +372,7 @@ sub run_validation_plan ($self, %options) {
     $self->log->debug('recording validation status '.$status.' with '
         .(scalar @validation_results).' results for device id '.$device->id);
 
+    my $result_order = 0;
     return $self->schema->resultset('validation_state')->create({
         device_id => $device->id,
         device_report_id => $device_report->id,
@@ -385,7 +381,10 @@ sub run_validation_plan ($self, %options) {
         completed => \'now()',
         # provided column data is used to determine if these result(s) already exist in the db,
         # and they are reused if so, otherwise they are inserted
-        validation_state_members => [ map +{ validation_result => $_ }, @validation_results ],
+        validation_state_members => [ map +{
+            result_order => $result_order++,
+            validation_result => $_,
+        }, @validation_results ],
     });
 }
 
@@ -415,14 +414,9 @@ sub run_validation ($self, %options) {
     );
     $validator->run($data);
 
-    my $result_order = 0;
     my $validation_result_rs = $self->schema->resultset('validation_result');
     my @validation_results = map
         $validation_result_rs->new_result({
-            # each time a ValidationResult is created, increment order value
-            # post-assignment. This allows us to distinguish between multiples
-            # of similar results
-            result_order        => $result_order++,
             validation_id       => $validation->id,
             device_id           => $device->id,
             hardware_product_id => $validator->hardware_product->id,

--- a/schema-loader.yaml
+++ b/schema-loader.yaml
@@ -15,6 +15,8 @@ loader_options:
 
   result_base_class: Conch::DB::Result
 
+  allow_extra_m2m_cols: 1
+
   rel_name_map:
     user: user_account
     DeviceNeighbor:

--- a/sql/migrations/0093-validation_result-result_order.sql
+++ b/sql/migrations/0093-validation_result-result_order.sql
@@ -1,0 +1,17 @@
+SELECT run_migration(93, $$
+
+    alter table validation_state_member
+        add column result_order integer default 0 not null check (result_order >= 0);
+
+    update validation_state_member
+        set result_order = validation_result.result_order
+        from validation_result
+        where validation_state_member.validation_result_id = validation_result.id;
+
+    alter table validation_state_member alter column result_order drop default;
+    alter table validation_result drop column result_order;
+
+    create index validation_result_all_columns_idx on validation_result
+        (device_id, hardware_product_id, validation_id, message, hint, status, category, component_id);
+
+$$);

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -686,7 +686,6 @@ CREATE TABLE public.validation_result (
     status public.validation_status_enum NOT NULL,
     category text NOT NULL,
     component_id text,
-    result_order integer NOT NULL,
     created timestamp with time zone DEFAULT now() NOT NULL
 );
 
@@ -716,7 +715,9 @@ ALTER TABLE public.validation_state OWNER TO conch;
 
 CREATE TABLE public.validation_state_member (
     validation_state_id uuid NOT NULL,
-    validation_result_id uuid NOT NULL
+    validation_result_id uuid NOT NULL,
+    result_order integer NOT NULL,
+    CONSTRAINT validation_state_member_result_order_check CHECK ((result_order >= 0))
 );
 
 
@@ -1382,7 +1383,7 @@ CREATE UNIQUE INDEX validation_plan_name_idx ON public.validation_plan USING btr
 -- Name: validation_result_all_columns_idx; Type: INDEX; Schema: public; Owner: conch
 --
 
-CREATE INDEX validation_result_all_columns_idx ON public.validation_result USING btree (device_id, hardware_product_id, validation_id, message, hint, status, category, component_id, result_order);
+CREATE INDEX validation_result_all_columns_idx ON public.validation_result USING btree (device_id, hardware_product_id, validation_id, message, hint, status, category, component_id);
 
 
 --

--- a/t/integration/04_test_datacenter_loaded.t
+++ b/t/integration/04_test_datacenter_loaded.t
@@ -443,6 +443,7 @@ subtest 'Validations' => sub {
         status => 'fail',
         completed => \'now()',
         validation_state_members => [{
+            result_order => 0,
             validation_result => {
                 device_id => 'TEST',
                 hardware_product_id => $device->hardware_product_id,
@@ -451,7 +452,6 @@ subtest 'Validations' => sub {
                 hint => 'boo',
                 status => 'fail',
                 category => 'test',
-                result_order => 0,
             },
         }],
     });
@@ -464,6 +464,7 @@ subtest 'Validations' => sub {
         status => 'fail',
         completed => '2001-01-01',
         validation_state_members => [{
+            result_order => 0,
             validation_result => {
                 created => '2001-01-01',
                 device_id => 'TEST',
@@ -473,7 +474,6 @@ subtest 'Validations' => sub {
                 hint => 'boo',
                 status => 'fail',
                 category => 'test',
-                result_order => 0,
             },
         }],
     });

--- a/t/validation-system/run_validations.t
+++ b/t/validation-system/run_validations.t
@@ -91,9 +91,6 @@ subtest 'run_validation_plan, without saving state' => sub {
                     hardware_product_id => $device->hardware_product_id,
                     category => 'BIOS',
                     status => 'pass',
-                    # each validator only issues one result. we do not increment results
-                    # across the entire plan, but only across each validator module.
-                    result_order => 0,
                 ),
             ),
             bag(
@@ -139,9 +136,6 @@ subtest 'run_validation_plan, with saving state' => sub {
                             hardware_product_id => $device->hardware_product_id,
                             category => 'BIOS',
                             status => 'pass',
-                            # each validator only issues one result. we do not increment results
-                            # across the entire plan, but only across each validator module.
-                            result_order => 0,
                         ),
                     ),
                     bag(
@@ -183,7 +177,6 @@ subtest run_validation => sub {
             ),
             bag(
                 methods(
-                    result_order => 0,
                     status => 'pass',
                     message => "Expected eq 'hi'. Got 'hi'.",
                     category => 'multi',
@@ -191,7 +184,6 @@ subtest run_validation => sub {
                     hint => undef,
                 ),
                 methods(
-                    result_order => 1,
                     status => 'fail',
                     message => 'new message',   # override
                     category => 'new category', # override


### PR DESCRIPTION
move result_order to validation_state_result
    
This makes validation_result rows more reusable across multiple validation_states.
Side effect:
- result_order is now incremented across all validation_results for a state,
not just across results for a single validation
    
This will allow `conch merge_validation_results` to collapse even more rows
together than it could before.
