### PR TITLE
drop all uses of the unnecessary uuid-ossp extension

### DIFF
--- a/docs/modules/Conch::DB::Result::Validation.md
+++ b/docs/modules/Conch::DB::Result::Validation.md
@@ -12,7 +12,7 @@ Conch::DB::Result::Validation
 
 ```
 data_type: 'uuid'
-default_value: uuid_generate_v4()
+default_value: gen_random_uuid()
 is_nullable: 0
 size: 16
 ```

--- a/docs/modules/Conch::DB::Result::ValidationPlan.md
+++ b/docs/modules/Conch::DB::Result::ValidationPlan.md
@@ -12,7 +12,7 @@ Conch::DB::Result::ValidationPlan
 
 ```
 data_type: 'uuid'
-default_value: uuid_generate_v4()
+default_value: gen_random_uuid()
 is_nullable: 0
 size: 16
 ```

--- a/docs/modules/Conch::DB::Result::ValidationResult.md
+++ b/docs/modules/Conch::DB::Result::ValidationResult.md
@@ -12,7 +12,7 @@ Conch::DB::Result::ValidationResult
 
 ```
 data_type: 'uuid'
-default_value: uuid_generate_v4()
+default_value: gen_random_uuid()
 is_nullable: 0
 size: 16
 ```

--- a/docs/modules/Conch::DB::Result::ValidationState.md
+++ b/docs/modules/Conch::DB::Result::ValidationState.md
@@ -12,7 +12,7 @@ Conch::DB::Result::ValidationState
 
 ```
 data_type: 'uuid'
-default_value: uuid_generate_v4()
+default_value: gen_random_uuid()
 is_nullable: 0
 size: 16
 ```

--- a/docs/modules/Conch::DB::Result::Workspace.md
+++ b/docs/modules/Conch::DB::Result::Workspace.md
@@ -12,7 +12,7 @@ Conch::DB::Result::Workspace
 
 ```
 data_type: 'uuid'
-default_value: uuid_generate_v4()
+default_value: gen_random_uuid()
 is_nullable: 0
 size: 16
 ```

--- a/lib/Conch/DB/Result/Validation.pm
+++ b/lib/Conch/DB/Result/Validation.pm
@@ -31,7 +31,7 @@ __PACKAGE__->table("validation");
 =head2 id
 
   data_type: 'uuid'
-  default_value: uuid_generate_v4()
+  default_value: gen_random_uuid()
   is_nullable: 0
   size: 16
 
@@ -80,7 +80,7 @@ __PACKAGE__->add_columns(
   "id",
   {
     data_type => "uuid",
-    default_value => \"uuid_generate_v4()",
+    default_value => \"gen_random_uuid()",
     is_nullable => 0,
     size => 16,
   },
@@ -185,8 +185,8 @@ __PACKAGE__->many_to_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:Xi5ASzt2zuwUhj0wjj3a8A
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2019-08-08 10:16:28
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:hF2BcNoTdZFdz+f7ZlRyRg
 
 __PACKAGE__->add_columns(
     '+module' => { is_serializable => 0 },

--- a/lib/Conch/DB/Result/ValidationPlan.pm
+++ b/lib/Conch/DB/Result/ValidationPlan.pm
@@ -31,7 +31,7 @@ __PACKAGE__->table("validation_plan");
 =head2 id
 
   data_type: 'uuid'
-  default_value: uuid_generate_v4()
+  default_value: gen_random_uuid()
   is_nullable: 0
   size: 16
 
@@ -63,7 +63,7 @@ __PACKAGE__->add_columns(
   "id",
   {
     data_type => "uuid",
-    default_value => \"uuid_generate_v4()",
+    default_value => \"gen_random_uuid()",
     is_nullable => 0,
     size => 16,
   },
@@ -137,8 +137,8 @@ Composing rels: L</validation_plan_members> -> validation
 __PACKAGE__->many_to_many("validations", "validation_plan_members", "validation");
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-09-17 14:52:33
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:DJEB3Pqtab0ycOFOSnyg5A
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2019-08-08 10:16:28
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:J9AoRAdJ77oTMNAjvsHPBw
 
 __PACKAGE__->add_columns(
     '+deactivated' => { is_serializable => 0 },

--- a/lib/Conch/DB/Result/ValidationResult.pm
+++ b/lib/Conch/DB/Result/ValidationResult.pm
@@ -31,7 +31,7 @@ __PACKAGE__->table("validation_result");
 =head2 id
 
   data_type: 'uuid'
-  default_value: uuid_generate_v4()
+  default_value: gen_random_uuid()
   is_nullable: 0
   size: 16
 
@@ -94,7 +94,7 @@ __PACKAGE__->add_columns(
   "id",
   {
     data_type => "uuid",
-    default_value => \"uuid_generate_v4()",
+    default_value => \"gen_random_uuid()",
     is_nullable => 0,
     size => 16,
   },
@@ -219,8 +219,8 @@ __PACKAGE__->many_to_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2019-08-07 15:18:08
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:9zu/UPpSUraFP17fgq2x8A
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2019-08-08 10:23:32
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:MDpJfBbPHRVMyTrdrg2CRw
 
 __PACKAGE__->add_columns(
     '+created' => { is_serializable => 0 },

--- a/lib/Conch/DB/Result/ValidationState.pm
+++ b/lib/Conch/DB/Result/ValidationState.pm
@@ -31,7 +31,7 @@ __PACKAGE__->table("validation_state");
 =head2 id
 
   data_type: 'uuid'
-  default_value: uuid_generate_v4()
+  default_value: gen_random_uuid()
   is_nullable: 0
   size: 16
 
@@ -79,7 +79,7 @@ __PACKAGE__->add_columns(
   "id",
   {
     data_type => "uuid",
-    default_value => \"uuid_generate_v4()",
+    default_value => \"gen_random_uuid()",
     is_nullable => 0,
     size => 16,
   },
@@ -198,8 +198,8 @@ __PACKAGE__->many_to_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2019-02-12 15:14:57
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:62AGs6yNbvUQTQWAr0xhCA
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2019-08-08 10:16:28
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:tlHn7VElCr/Bj2mZQMdeHA
 
 __PACKAGE__->add_columns(
     '+created' => { retrieve_on_insert => 1 },

--- a/lib/Conch/DB/Result/Workspace.pm
+++ b/lib/Conch/DB/Result/Workspace.pm
@@ -31,7 +31,7 @@ __PACKAGE__->table("workspace");
 =head2 id
 
   data_type: 'uuid'
-  default_value: uuid_generate_v4()
+  default_value: gen_random_uuid()
   is_nullable: 0
   size: 16
 
@@ -58,7 +58,7 @@ __PACKAGE__->add_columns(
   "id",
   {
     data_type => "uuid",
-    default_value => \"uuid_generate_v4()",
+    default_value => \"gen_random_uuid()",
     is_nullable => 0,
     size => 16,
   },
@@ -184,8 +184,8 @@ Composing rels: L</user_workspace_roles> -> user_account
 __PACKAGE__->many_to_many("user_accounts", "user_workspace_roles", "user_account");
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2019-08-07 15:04:34
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:grjgLmZfiUYtsI/oAXzn9A
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2019-08-08 10:23:32
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:7PPE0ecivO5ZkN8DKv0mXw
 
 use experimental 'signatures';
 

--- a/sql/migrations/0094-drop-uuid-ossp.sql
+++ b/sql/migrations/0094-drop-uuid-ossp.sql
@@ -1,0 +1,11 @@
+SELECT run_migration(94, $$
+
+    alter table validation alter column id set default gen_random_uuid();
+    alter table validation_plan alter column id set default gen_random_uuid();
+    alter table validation_result alter column id set default gen_random_uuid();
+    alter table validation_state alter column id set default gen_random_uuid();
+    alter table workspace alter column id set default gen_random_uuid();
+
+    drop extension "uuid-ossp";
+
+$$);

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -44,20 +44,6 @@ COMMENT ON EXTENSION pgcrypto IS 'cryptographic functions';
 
 
 --
--- Name: uuid-ossp; Type: EXTENSION; Schema: -; Owner: 
---
-
-CREATE EXTENSION IF NOT EXISTS "uuid-ossp" WITH SCHEMA public;
-
-
---
--- Name: EXTENSION "uuid-ossp"; Type: COMMENT; Schema: -; Owner: 
---
-
-COMMENT ON EXTENSION "uuid-ossp" IS 'generate universally unique identifiers (UUIDs)';
-
-
---
 -- Name: device_health_enum; Type: TYPE; Schema: public; Owner: conch
 --
 
@@ -632,7 +618,7 @@ ALTER TABLE public.user_workspace_role OWNER TO conch;
 --
 
 CREATE TABLE public.validation (
-    id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
+    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
     name text NOT NULL,
     version integer NOT NULL,
     description text NOT NULL,
@@ -650,7 +636,7 @@ ALTER TABLE public.validation OWNER TO conch;
 --
 
 CREATE TABLE public.validation_plan (
-    id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
+    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
     name text NOT NULL,
     description text NOT NULL,
     created timestamp with time zone DEFAULT now() NOT NULL,
@@ -677,7 +663,7 @@ ALTER TABLE public.validation_plan_member OWNER TO conch;
 --
 
 CREATE TABLE public.validation_result (
-    id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
+    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
     device_id text NOT NULL,
     hardware_product_id uuid NOT NULL,
     validation_id uuid NOT NULL,
@@ -697,7 +683,7 @@ ALTER TABLE public.validation_result OWNER TO conch;
 --
 
 CREATE TABLE public.validation_state (
-    id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
+    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
     device_id text NOT NULL,
     validation_plan_id uuid NOT NULL,
     created timestamp with time zone DEFAULT now() NOT NULL,
@@ -728,7 +714,7 @@ ALTER TABLE public.validation_state_member OWNER TO conch;
 --
 
 CREATE TABLE public.workspace (
-    id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
+    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
     name text NOT NULL,
     description text,
     parent_workspace_id uuid


### PR DESCRIPTION
See the last section of https://www.postgresql.org/docs/9.6/uuid-ossp.html

(cherry picked from commit 6272a7a1157050e7fbde41149a9f5d67070b71a9, from v3
and migration 102.)