### PR TITLE
compare semver versions properly

### DIFF
--- a/lib/Conch/Plugin/Database.pm
+++ b/lib/Conch/Plugin/Database.pm
@@ -156,15 +156,23 @@ line of the exception.
 
     return if $app->feature('no_db');
 
+
     # verify that we are running the version of postgres we expect...
     my $pgsql_version = Conch::DB::Util::get_postgres_version($app->schema);
     $app->log->info("Running $pgsql_version");
 
-    # at present we do all testing on 9.6 so that is the most preferred configuration, but we
-    # are not aware of any issues on PostgreSQL 10.x.
+    use constant POSTGRES_MINIMUM_VERSION_MAJOR => 10;
+    use constant POSTGRES_MINIMUM_VERSION_MINOR => 9;
+
+    # at present we do all testing on 10.x so that is the most preferred configuration, but we
+    # are not aware of any issues on PostgreSQL 11.x.
     my ($major, $minor, $rest) = $pgsql_version =~ /PostgreSQL (\d+)\.(\d+)(\.\d+)?\b/;
     $minor //= 0;
-    $app->log->warn("Running $major.$minor$rest, expected at least 10.9!") if "$major.$minor" < 10.9;
+    $rest //= '';
+    $app->log->warn('Running '.$major.'.'.$minor.$rest.', expected at least '
+            .POSTGRES_MINIMUM_VERSION_MAJOR.'.'.POSTGRES_MINIMUM_VERSION_MINOR.'!')
+        if $major < POSTGRES_MINIMUM_VERSION_MAJOR
+            or $major == POSTGRES_MINIMUM_VERSION_MAJOR and $minor < POSTGRES_MINIMUM_VERSION_MINOR;
 
 
     my ($latest_migration, $expected_latest_migration) = Conch::DB::Util::get_migration_level($app->schema);

--- a/t/database.t
+++ b/t/database.t
@@ -10,6 +10,22 @@ use Conch::UUID 'create_uuid_str';
 use Conch::DB::Util;
 use Crypt::Eksblowfish::Bcrypt 'bcrypt';
 
+subtest 'assert db version' => sub {
+    my ($pgsql, $schema) = Test::Conch->init_db;
+    my $pgsql_version = Conch::DB::Util::get_postgres_version($schema);
+    diag 'Running '.$pgsql_version;
+    my ($major, $minor, $rest) = $pgsql_version =~ /PostgreSQL (\d+)\.(\d+)(\.\d+)?\b/;
+    $minor //= 0;
+    $rest //= '';
+    require Conch::Plugin::Database;
+    is($major, Conch::Plugin::Database->POSTGRES_MINIMUM_VERSION_MAJOR,
+        'running postgres '.Conch::Plugin::Database->POSTGRES_MINIMUM_VERSION_MAJOR.'.x')
+        and
+    cmp_ok($minor, '>=', Conch::Plugin::Database->POSTGRES_MINIMUM_VERSION_MINOR,
+        'running at least postgres '.Conch::Plugin::Database->POSTGRES_MINIMUM_VERSION_MAJOR
+        .'.'.Conch::Plugin::Database->POSTGRES_MINIMUM_VERSION_MINOR);
+};
+
 subtest 'db connection without Conch, and data preservation' => sub {
     my ($pgsql, $schema) = Test::Conch->init_db;
 


### PR DESCRIPTION
also fix undef value where 10.x does not have a third version component
and check the version in tests also, with a visible diagnostic line.