### PR TITLE
device report optimization

### DIFF
--- a/docs/modules/Conch::DB::Result::DeviceReport.md
+++ b/docs/modules/Conch::DB::Result::DeviceReport.md
@@ -21,7 +21,7 @@ size: 16
 
 ```
 data_type: 'jsonb'
-is_nullable: 1
+is_nullable: 0
 ```
 
 ## created

--- a/lib/Conch/DB/Result/DeviceReport.pm
+++ b/lib/Conch/DB/Result/DeviceReport.pm
@@ -38,7 +38,7 @@ __PACKAGE__->table("device_report");
 =head2 report
 
   data_type: 'jsonb'
-  is_nullable: 1
+  is_nullable: 0
 
 =head2 created
 
@@ -70,7 +70,7 @@ __PACKAGE__->add_columns(
     size => 16,
   },
   "report",
-  { data_type => "jsonb", is_nullable => 1 },
+  { data_type => "jsonb", is_nullable => 0 },
   "created",
   {
     data_type     => "timestamp with time zone",
@@ -130,7 +130,7 @@ __PACKAGE__->has_many(
 
 
 # Created by DBIx::Class::Schema::Loader v0.07049
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:rjhHrnB9kuyrsxzUnmgDZw
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:DknxBwVAxO4T5RbebwF/qg
 
 __PACKAGE__->add_columns(
     '+retain' => { is_serializable => 0 },

--- a/sql/migrations/0114-device_report-drop-invalid.sql
+++ b/sql/migrations/0114-device_report-drop-invalid.sql
@@ -1,6 +1,9 @@
 SELECT run_migration(114, $$
 
     delete from device_report where invalid_report is not null;
-    alter table device_report drop column invalid_report;
+
+    alter table device_report
+        drop column invalid_report,
+        alter column report set not null;
 
 $$);

--- a/sql/migrations/0114-device_report-drop-invalid.sql
+++ b/sql/migrations/0114-device_report-drop-invalid.sql
@@ -1,5 +1,6 @@
 SELECT run_migration(114, $$
 
+    delete from device_report where invalid_report is not null;
     alter table device_report drop column invalid_report;
 
 $$);

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 10.9
--- Dumped by pg_dump version 10.9
+-- Dumped from database version 10.10
+-- Dumped by pg_dump version 10.10
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -314,7 +314,7 @@ ALTER TABLE public.device_relay_connection OWNER TO conch;
 
 CREATE TABLE public.device_report (
     id uuid DEFAULT public.gen_random_uuid() NOT NULL,
-    report jsonb,
+    report jsonb NOT NULL,
     created timestamp with time zone DEFAULT now() NOT NULL,
     retain boolean,
     device_id uuid NOT NULL


### PR DESCRIPTION
adjustments to prior sql migrations:
- while dropping `device_report.invalid_report`, drop all rows with this field set (as nothing else of value is contained in this record)
- `device_report.report` can now be made not-nullable