### PR TITLE
v3: more validation_result improvements

### DIFF
--- a/docs/json-schema/response.json
+++ b/docs/json-schema/response.json
@@ -2392,9 +2392,6 @@
         "message" : {
           "type" : "string"
         },
-        "order" : {
-          "$ref" : "common.json#/definitions/non_negative_integer"
-        },
         "status" : {
           "$ref" : "common.json#/definitions/validation_status"
         },
@@ -2409,7 +2406,6 @@
         "hardware_product_id",
         "hint",
         "message",
-        "order",
         "status",
         "validation_id"
       ],

--- a/docs/modules/Conch::DB::Result::ValidationResult.md
+++ b/docs/modules/Conch::DB::Result::ValidationResult.md
@@ -71,13 +71,6 @@ data_type: 'text'
 is_nullable: 1
 ```
 
-## result\_order
-
-```
-data_type: 'integer'
-is_nullable: 0
-```
-
 ## created
 
 ```

--- a/docs/modules/Conch::DB::Result::ValidationStateMember.md
+++ b/docs/modules/Conch::DB::Result::ValidationStateMember.md
@@ -26,6 +26,13 @@ is_nullable: 0
 size: 16
 ```
 
+## result\_order
+
+```
+data_type: 'integer'
+is_nullable: 0
+```
+
 # PRIMARY KEY
 
 - ["validation\_state\_id"](#validation_state_id)

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -925,7 +925,6 @@ definitions:
       - hardware_product_id
       - hint
       - message
-      - order
       - status
       - validation_id
     properties:
@@ -947,8 +946,6 @@ definitions:
           - type: string
       message:
         type: string
-      order:
-        $ref: common.yaml#/definitions/non_negative_integer
       status:
         $ref: common.yaml#/definitions/validation_status
       validation_id:

--- a/lib/Conch/Command/merge_validation_results.pm
+++ b/lib/Conch/Command/merge_validation_results.pm
@@ -96,7 +96,7 @@ sub run ($self, @opts) {
 sub _process_device ($self, $device) {
     print 'device id ', $device->id, ': ';
 
-    my @grouping_cols = qw(device_id hardware_product_id validation_id message hint status category component result_order);
+    my @grouping_cols = qw(device_id hardware_product_id validation_id message hint status category component);
 
     my $schema = $self->app->schema;
     my ($group_count, $results_deleted) = (0)x2;

--- a/lib/Conch/Controller/DeviceValidation.pm
+++ b/lib/Conch/Controller/DeviceValidation.pm
@@ -31,7 +31,7 @@ sub list_validation_states ($c) {
             $params->{status} ? { 'validation_states.status' => $params->{status} } : ())
         ->latest_completed_state_per_plan
         ->prefetch({ validation_state_members => 'validation_result' })
-        ->order_by([ qw(validation_states.completed validation_result.result_order) ])
+        ->order_by([ qw(validation_states.completed validation_state_members.result_order) ])
         ->all;
 
     $c->log->debug('Found '.scalar(@validation_states).' records');

--- a/lib/Conch/Controller/ValidationState.pm
+++ b/lib/Conch/Controller/ValidationState.pm
@@ -26,6 +26,7 @@ sub get ($c) {
     my ($validation_state) = $c->db_validation_states
         ->search({ 'validation_state.id' => $c->stash('validation_state_id') })
         ->prefetch({ validation_state_members => 'validation_result' })
+        ->order_by('validation_state_members.result_order')
         ->all;
 
     if (not $validation_state) {

--- a/lib/Conch/DB/Result/ValidationResult.pm
+++ b/lib/Conch/DB/Result/ValidationResult.pm
@@ -75,11 +75,6 @@ __PACKAGE__->table("validation_result");
   data_type: 'text'
   is_nullable: 1
 
-=head2 result_order
-
-  data_type: 'integer'
-  is_nullable: 0
-
 =head2 created
 
   data_type: 'timestamp with time zone'
@@ -125,8 +120,6 @@ __PACKAGE__->add_columns(
   { data_type => "text", is_nullable => 0 },
   "component",
   { data_type => "text", is_nullable => 1 },
-  "result_order",
-  { data_type => "integer", is_nullable => 0 },
   "created",
   {
     data_type     => "timestamp with time zone",
@@ -228,21 +221,12 @@ __PACKAGE__->many_to_many(
 
 
 # Created by DBIx::Class::Schema::Loader v0.07049
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:plpoY5p27ah5uepmndhPyA
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:+l8wIgJwgE/xE72CF/Dr4Q
 
 __PACKAGE__->add_columns(
     '+created' => { is_serializable => 0 },
     '+device_id' => { is_serializable => 0 },
 );
-
-use experimental 'signatures';
-
-sub TO_JSON ($self) {
-    my $data = $self->next::method(@_);
-    $data->{order} = delete $data->{result_order};
-
-    return $data;
-}
 
 1;
 __END__

--- a/lib/Conch/DB/Result/ValidationStateMember.pm
+++ b/lib/Conch/DB/Result/ValidationStateMember.pm
@@ -86,7 +86,7 @@ __PACKAGE__->belongs_to(
   "validation_result",
   "Conch::DB::Result::ValidationResult",
   { id => "validation_result_id" },
-  { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
+  { is_deferrable => 0, on_delete => "CASCADE", on_update => "NO ACTION" },
 );
 
 =head2 validation_state
@@ -106,7 +106,7 @@ __PACKAGE__->belongs_to(
 
 
 # Created by DBIx::Class::Schema::Loader v0.07049
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:4os448NsLGQiC9wCPSeH4w
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:uqNRvm7JRcN3eZg57CJEUg
 
 1;
 __END__

--- a/lib/Conch/DB/Result/ValidationStateMember.pm
+++ b/lib/Conch/DB/Result/ValidationStateMember.pm
@@ -42,6 +42,11 @@ __PACKAGE__->table("validation_state_member");
   is_nullable: 0
   size: 16
 
+=head2 result_order
+
+  data_type: 'integer'
+  is_nullable: 0
+
 =cut
 
 __PACKAGE__->add_columns(
@@ -49,6 +54,8 @@ __PACKAGE__->add_columns(
   { data_type => "uuid", is_foreign_key => 1, is_nullable => 0, size => 16 },
   "validation_result_id",
   { data_type => "uuid", is_foreign_key => 1, is_nullable => 0, size => 16 },
+  "result_order",
+  { data_type => "integer", is_nullable => 0 },
 );
 
 =head1 PRIMARY KEY
@@ -99,7 +106,7 @@ __PACKAGE__->belongs_to(
 
 
 # Created by DBIx::Class::Schema::Loader v0.07049
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:oyv7vkacCgqNUCAun454Wg
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:4os448NsLGQiC9wCPSeH4w
 
 1;
 __END__

--- a/lib/Conch/Validation/CpuTemperature.pm
+++ b/lib/Conch/Validation/CpuTemperature.pm
@@ -26,7 +26,8 @@ sub validate {
             type     => 'CPU',
             expected => $MAX_TEMP,
             cmp      => '<',
-            got      => $data->{temp}->{$cpu}
+            got      => $data->{temp}->{$cpu},
+            component => $cpu,
         );
     }
 }

--- a/lib/Conch/Validation/SwitchPeers.pm
+++ b/lib/Conch/Validation/SwitchPeers.pm
@@ -97,7 +97,8 @@ sub validate {
         $self->register_result(
             expected => 2,
             got      => $num_ports,
-            name     => 'num_ports'
+            name     => 'num_ports',
+            component => $switch_name,
         );
     }
 }

--- a/sql/migrations/0129-validation_result-result_order.sql
+++ b/sql/migrations/0129-validation_result-result_order.sql
@@ -1,0 +1,18 @@
+SELECT run_migration(129, $$
+
+    alter table validation_state_member
+        add column result_order integer default 0 not null check (result_order >= 0);
+
+    update validation_state_member
+        set result_order = validation_result.result_order
+        from validation_result
+        where validation_state_member.validation_result_id = validation_result.id;
+
+    alter table validation_state_member alter column result_order drop default;
+    alter table validation_result drop column result_order;
+
+    drop index if exists validation_result_all_columns_idx;
+    create index validation_result_all_columns_idx on validation_result
+        (device_id, hardware_product_id, validation_id, message, hint, status, category, component);
+
+$$);

--- a/sql/migrations/0130-validation_result-cascade-delete.sql
+++ b/sql/migrations/0130-validation_result-cascade-delete.sql
@@ -1,0 +1,8 @@
+SELECT run_migration(130, $$
+
+   alter table validation_state_member
+        drop constraint validation_state_member_validation_result_id_fkey,
+        add constraint validation_state_member_validation_result_id_fkey
+            foreign key (validation_result_id) references validation_result (id) on delete cascade;
+
+$$);

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -686,10 +686,8 @@ CREATE TABLE public.validation_result (
     status public.validation_status_enum NOT NULL,
     category text NOT NULL,
     component text,
-    result_order integer NOT NULL,
     created timestamp with time zone DEFAULT now() NOT NULL,
-    device_id uuid NOT NULL,
-    CONSTRAINT validation_result_result_order_check CHECK ((result_order >= 0))
+    device_id uuid NOT NULL
 );
 
 
@@ -718,7 +716,9 @@ ALTER TABLE public.validation_state OWNER TO conch;
 
 CREATE TABLE public.validation_state_member (
     validation_state_id uuid NOT NULL,
-    validation_result_id uuid NOT NULL
+    validation_result_id uuid NOT NULL,
+    result_order integer NOT NULL,
+    CONSTRAINT validation_state_member_result_order_check CHECK ((result_order >= 0))
 );
 
 
@@ -1416,7 +1416,7 @@ CREATE UNIQUE INDEX validation_plan_name_idx ON public.validation_plan USING btr
 -- Name: validation_result_all_columns_idx; Type: INDEX; Schema: public; Owner: conch
 --
 
-CREATE INDEX validation_result_all_columns_idx ON public.validation_result USING btree (device_id, hardware_product_id, validation_id, message, hint, status, category, component, result_order);
+CREATE INDEX validation_result_all_columns_idx ON public.validation_result USING btree (device_id, hardware_product_id, validation_id, message, hint, status, category, component);
 
 
 --

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1816,7 +1816,7 @@ ALTER TABLE ONLY public.validation_state
 --
 
 ALTER TABLE ONLY public.validation_state_member
-    ADD CONSTRAINT validation_state_member_validation_result_id_fkey FOREIGN KEY (validation_result_id) REFERENCES public.validation_result(id);
+    ADD CONSTRAINT validation_state_member_validation_result_id_fkey FOREIGN KEY (validation_result_id) REFERENCES public.validation_result(id) ON DELETE CASCADE;
 
 
 --

--- a/t/integration/device-reports.t
+++ b/t/integration/device-reports.t
@@ -84,7 +84,6 @@ subtest 'run report without an existing device' => sub {
                 hardware_product_id => $hardware_product->id,
                 hint => ignore,
                 message => ignore,
-                order => ignore,
                 status => any(qw(error fail pass)),
             }, @validations)),
         });
@@ -128,7 +127,6 @@ subtest 'create device via report' => sub {
             completed => re(qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/),
             results => [
                 superhashof({
-                    order => 0,
                     status => 'pass',
                 }),
             ],

--- a/t/integration/device-validations.t
+++ b/t/integration/device-validations.t
@@ -88,6 +88,7 @@ my (@fail_validation_state_id) = $t->app->db_validation_states->create({
     status => 'fail',
     completed => \'now()',
     validation_state_members => [{
+        result_order => 0,
         validation_result => {
             device_id => $device->id,
             hardware_product_id => $device->hardware_product_id,
@@ -96,7 +97,6 @@ my (@fail_validation_state_id) = $t->app->db_validation_states->create({
             hint => 'boo',
             status => 'fail',
             category => 'test',
-            result_order => 0,
         },
     }],
 })->id;
@@ -109,6 +109,7 @@ push @fail_validation_state_id, $t->app->db_validation_states->create({
     status => 'fail',
     completed => '2001-01-01',
     validation_state_members => [{
+        result_order => 0,
         validation_result => {
             created => '2001-01-01',
             device_id => $device->id,
@@ -118,7 +119,6 @@ push @fail_validation_state_id, $t->app->db_validation_states->create({
             hint => 'boo',
             status => 'fail',
             category => 'test',
-            result_order => 0,
         },
     }],
 })->id;
@@ -154,7 +154,6 @@ $t->get_ok('/device/TEST/validation_state')
                 hint => 'boo',
                 status => 'fail',
                 category => 'test',
-                order => 0,
             }],
         },
     ]);
@@ -196,7 +195,6 @@ $t->get_ok('/device/TEST/validation_state?status=error')
                 hint => ignore,
                 status => 'error',
                 category => 'BIOS',
-                order => 0,
             }],
         },
     ]);

--- a/t/validation-system/run_validations.t
+++ b/t/validation-system/run_validations.t
@@ -91,9 +91,6 @@ subtest 'run_validation_plan, without saving state' => sub {
                     hardware_product_id => $device->hardware_product_id,
                     category => 'BIOS',
                     status => 'pass',
-                    # each validator only issues one result. we do not increment results
-                    # across the entire plan, but only across each validator module.
-                    result_order => 0,
                 ),
             ),
             bag(
@@ -139,9 +136,6 @@ subtest 'run_validation_plan, with saving state' => sub {
                             hardware_product_id => $device->hardware_product_id,
                             category => 'BIOS',
                             status => 'pass',
-                            # each validator only issues one result. we do not increment results
-                            # across the entire plan, but only across each validator module.
-                            result_order => 0,
                         ),
                     ),
                     bag(
@@ -183,7 +177,6 @@ subtest run_validation => sub {
             ),
             [
                 methods(
-                    result_order => 0,
                     status => 'pass',
                     message => "Expected eq 'hi'. Got 'hi'.",
                     category => 'multi',
@@ -191,7 +184,6 @@ subtest run_validation => sub {
                     hint => undef,
                 ),
                 methods(
-                    result_order => 1,
                     status => 'fail',
                     message => 'new message',   # override
                     category => 'new category', # override


### PR DESCRIPTION
Move `result_order` from the `validation_result` table to `validation_state_member`, which allows even more re-use of validation_result rows.

After deploying this migration, you should re-run `bin/conch merge_validation_results` and we should see another 10x reduction in rows in the `validation_result` table.  After that is done, it should be possible to make `validation_result_all_columns_idx` a unique index.

Minor adjustments are also made to response payloads that include validation results.