### PR TITLE
v3: a6 small refactoring

### DIFF
--- a/bin/conch-db
+++ b/bin/conch-db
@@ -88,6 +88,13 @@ print($usage->text), exit if $opt->help or not @ARGV;
 
 # order matters, so we don't just shove the handlers into a dispatch hash table.
 
+foreach my $cmd (@ARGV) {
+    next if any { $cmd eq $_ }
+        qw(all initialize create-validations create-global-workspace create-admin-user migrate apply-dump-migration);
+    die 'unrecognized command '.$cmd;
+}
+
+
 if (any { $_ eq 'all' } @ARGV) {
      unshift @ARGV, qw(initialize create-validations create-admin-user);
 }

--- a/docs/modules/Conch::Controller::WorkspaceRack.md
+++ b/docs/modules/Conch::Controller::WorkspaceRack.md
@@ -10,10 +10,16 @@ Get a list of racks for the indicated workspace.
 
 Response uses the WorkspaceRackSummary json schema.
 
-## find\_rack
+## find\_workspace\_rack
 
-Chainable action that takes the `rack_id` provided in the path and looks it up in the
-database, stashing a resultset to access it as `rack_rs`.
+Chainable action that uses the `workspace_rs` and `rack_id` stash values and confirms the
+rack is a (direct or indirect) member of the workspace.
+
+Relies on ["find\_workspace" in Conch::Controller::Workspace](../modules/Conch::Controller::Workspace#find_workspace) and
+["find\_rack" in Conch::Controller::Rack](../modules/Conch::Controller::Rack#find_rack) to have already run, verified user roles, and populated
+the stash values.
+
+Saves `workspace_rack_rs` to the stash.
 
 ## add
 

--- a/lib/Conch/Controller/Organization.pm
+++ b/lib/Conch/Controller/Organization.pm
@@ -330,8 +330,6 @@ sub remove_user ($c) {
     return if not $params;
 
     my $user = $c->stash('target_user');
-    return $c->status(403) if $user->id eq $c->stash('user_id');
-
     my $rs = $c->stash('organization_rs')
         ->search_related('user_organization_roles', { user_id => $user->id });
     return $c->status(204) if not $rs->exists;

--- a/lib/Conch/Controller/WorkspaceOrganization.pm
+++ b/lib/Conch/Controller/WorkspaceOrganization.pm
@@ -216,13 +216,12 @@ sub remove_workspace_organization ($c) {
     return $c->status(204) if not $num_rows;
 
     my $workspace_name = $c->stash('workspace_name') // $c->stash('workspace_rs')->get_column('name')->single;
-
     $c->log->debug('removing organization '.$organization->name.' from workspace '
         .$workspace_name.' and all sub-workspaces ('.$num_rows.'rows in total)');
 
-    my $deleted = $rs->delete;
+    $rs->delete;
 
-    if ($deleted > 0 and $params->{send_mail} // 1) {
+    if ($params->{send_mail} // 1) {
         $c->send_mail(
             template_file => 'workspace_organization_remove_members',
             To => $c->construct_address_list($organization->user_accounts->order_by('user_account.name')),

--- a/lib/Conch/Plugin/Database.pm
+++ b/lib/Conch/Plugin/Database.pm
@@ -162,7 +162,7 @@ line of the exception.
     $app->log->info("Running $pgsql_version");
 
     use constant POSTGRES_MINIMUM_VERSION_MAJOR => 10;
-    use constant POSTGRES_MINIMUM_VERSION_MINOR => 9;
+    use constant POSTGRES_MINIMUM_VERSION_MINOR => 10;
 
     # at present we do all testing on 10.x so that is the most preferred configuration, but we
     # are not aware of any issues on PostgreSQL 11.x.

--- a/lib/Conch/Plugin/Logging.pm
+++ b/lib/Conch/Plugin/Logging.pm
@@ -74,10 +74,12 @@ sub register ($self, $app, $config) {
           : 'NOT AUTHED';
 
         my $req_headers = $c->req->headers->to_hash(1);
-        delete $req_headers->@{qw(Authorization Cookie jwt_token)};
+        $req_headers->{$_} = '--REDACTED--'
+            foreach grep exists $req_headers->{$_}, qw(Authorization Cookie jwt_token);
 
         my $res_headers = $c->res->headers->to_hash(1);
-        delete $res_headers->@{qw(Set-Cookie)};
+        $res_headers->{$_} = '--REDACTED--'
+            foreach grep exists $res_headers->{$_}, qw(Set-Cookie);
 
         my $req_json = $c->req->json;
         my $res_json = $c->res->json;

--- a/lib/Conch/Plugin/Logging.pm
+++ b/lib/Conch/Plugin/Logging.pm
@@ -54,7 +54,9 @@ sub register ($self, $app, $config) {
 
     $app->log(Conch::Log->new(%log_args));
 
-    $app->helper(log => sub ($c) { $c->app->log });
+    $app->helper(log => sub ($c) {
+        return $c->stash->{'mojo.log'} //= $c->app->log;
+    });
 
     $app->hook(around_dispatch => sub ($next, $c) {
         local $Conch::Log::REQUEST_ID = $c->req->request_id;

--- a/lib/Conch/Plugin/Logging.pm
+++ b/lib/Conch/Plugin/Logging.pm
@@ -25,6 +25,10 @@ sub register ($self, $app, $config) {
     my $plugin_config = $config->{logging} // {};
     my $log_dir = $plugin_config->{dir} // 'log';
 
+    my %LEVEL = (debug => 1, info => 2, warn => 3, error => 4, fatal => 5);
+    die 'unrecognized log level '.$plugin_config->{level}
+        if $plugin_config->{level} and not exists $LEVEL{$plugin_config->{level}};
+
     my %log_args = (
         level => 'debug',
         bunyan => 1,

--- a/lib/Conch/Route/Workspace.pm
+++ b/lib/Conch/Route/Workspace.pm
@@ -55,7 +55,8 @@ sub routes {
 
         {
             my $with_workspace_rack =
-                $with_workspace->under('/rack/<rack_id:uuid>')->to('workspace_rack#find_rack');
+                $with_workspace->under('/rack/<rack_id:uuid>')->to('rack#find_rack')
+                    ->under('/')->to('workspace_rack#find_workspace_rack');
 
             # DELETE /workspace/:workspace_id_or_name/rack/:rack_id
             $with_workspace_rack->delete('/')->to('workspace_rack#remove');

--- a/misc/get-api-token
+++ b/misc/get-api-token
@@ -1,0 +1,97 @@
+#!/bin/env perl
+
+use strict;
+use warnings;
+use open ':std', ':encoding(UTF-8)'; # force stdin, stdout, stderr into utf8
+use v5.26;
+use experimental 'signatures';
+
+use Getopt::Long;
+use Pod::Usage;
+use HTTP::Tiny;
+use IO::Socket::SSL;
+use JSON::PP;
+
+my $base_url = 'https://edge.conch.joyent.us';
+
+GetOptions(
+    'base_url|u:s'  => \$base_url,
+    'email|e:s'     => \my $email,
+    'help|h'        => \my $help,
+);
+
+pod2usage(1) if $help;
+pod2usage(1) if not $email;
+
+require Term::ReadKey;
+Term::ReadKey::ReadMode('noecho');
+print 'password: ';
+chomp(my $password = Term::ReadKey::ReadLine(0));
+Term::ReadKey::ReadMode('normal');
+
+my $login_content = do_post('/login', { email => $email, password => $password });
+my $login_token = $login_content->{jwt_token};
+
+my $token_content = do_post(
+    '/user/me/token',
+    { name => 'get-api-token-'.time() },
+    { 'Authorization' => 'Bearer '.$login_token },
+);
+
+my $api_token = $token_content->{token};
+
+say 'here is your api token (keep it in a safe place!)';
+say $api_token;
+say '';
+say 'Hint: you can put "Authorization: Bearer <token>" in ~/.conch-client.json,';
+say 'and then in the future you can do:   curl -H @~/.conch-token ...';
+
+exit;
+
+sub do_get ($path, $headers = {}) {
+    my $http = HTTP::Tiny->new;
+    my $response = $http->request('GET', $base_url.$path, { headers => $headers });
+
+    die $path, ' failed: ', $response->{content} if not $response->{success};
+    return decode_json($response->{content});
+}
+
+sub do_post ($path, $payload, $headers = {}) {
+    my $http = HTTP::Tiny->new(default_headers => { 'Content-Type' => 'application/json' });
+    my $response = $http->request('POST',
+        $base_url . $path,
+        { headers => $headers, content => encode_json($payload) },
+    );
+
+    die $path, ' failed: ', $response->{content} if not $response->{success};
+    return decode_json($response->{content});
+}
+__END__
+
+=pod
+
+=head1 NAME
+
+get-api-token - obtain a long-lived API authentication token from conch.
+
+=head1 SYNOPSIS
+
+    get-api-token --email EMAIL [--url BASE URL ]
+
+=head1 OPTIONS
+
+=over 4
+
+=item --url BASE URL
+
+The base url to use for the conch api. Defaults to L<https://edge.conch.joyent.us>.
+
+=item --email EMAIL
+
+The user's email address.
+
+=back
+
+The password is prompted for, and cannot be supplied as an argument.
+
+=cut

--- a/t/conch-log.t
+++ b/t/conch-log.t
@@ -759,7 +759,7 @@ sub add_test_routes ($t) {
                 url         => '/user/me/password',
                 remoteAddress => '127.0.0.1',
                 remotePort  => ignore,
-                headers     => notexists('Authorization'),
+                headers     => superhashof({ Authorization => '--REDACTED--' }),
                 query_params => {},
                 # no body! that contains the password!!!
             },
@@ -771,19 +771,6 @@ sub add_test_routes ($t) {
         },
         'dispatch line for changing password in audit mode does not contain the password',
     );
-}
-
-# TODO: replace with Test::Deep::notexists($key)
-sub notexists
-{
-    my @keys = @_;
-    Test::Deep::code(sub {
-        return (0, 'not a HASH') if ref $_[0] ne 'HASH';
-        foreach my $key (@keys) {
-            return (0, "'$key' key exists") if exists $_[0]->{$key};
-        }
-        return 1;
-    });
 }
 
 done_testing;

--- a/t/conch-log.t
+++ b/t/conch-log.t
@@ -9,6 +9,7 @@ use Test::More;
 use Test::Warnings ':all';
 use Test::Deep;
 use Test::Deep::NumberTolerant;
+use Test::Fatal;
 use Conch::Log;
 use Test::Conch;
 use Time::HiRes 'time'; # time() now has µs precision
@@ -23,6 +24,14 @@ open my $log_fh, '>:raw', \my $fake_log_file or die "cannot open to scalarref: $
 sub reset_log { $fake_log_file = ''; seek $log_fh, 0, 0; }
 
 my $api_version_re = qr/^v\d+\.\d+\.\d+(-a\d+)?-\d+-g[[:xdigit:]]+$/;
+
+{
+    like(
+        exception { Test::Conch->new(config => { logging => { level => 'whargarbl' } }) },
+        qr/unrecognized log level whargarbl/,
+        'reject bad log levels',
+    );
+}
 
 {
     my $regular_log = Conch::Log->new(handle => $log_fh);

--- a/t/integration/crud/organization.t
+++ b/t/integration/crud/organization.t
@@ -219,7 +219,7 @@ $t2->post_ok('/organization/'.$organization->{id}.'/user', json => {
     ->status_is(403)
     ->log_debug_is('User lacks the required role (admin) for organization '.$organization->{id});
 
-$t2->delete_ok('/organization/my first organization/user/'.$new_user->email)
+$t2->delete_ok('/organization/my first organization/user/'.$admin_user->email)
     ->status_is(403)
     ->log_debug_is('User lacks the required role (admin) for organization my first organization');
 
@@ -264,7 +264,7 @@ $t2->post_ok('/organization/'.$organization->{id}.'/user', json => {
     ->status_is(403)
     ->log_debug_is('User lacks the required role (admin) for organization '.$organization->{id});
 
-$t2->delete_ok('/organization/my first organization/user/'.$new_user->email)
+$t2->delete_ok('/organization/my first organization/user/'.$admin_user->email)
     ->status_is(403)
     ->log_debug_is('User lacks the required role (admin) for organization my first organization');
 
@@ -890,10 +890,6 @@ $t->get_ok('/organization')
     ->status_is(200)
     ->json_schema_is('Organizations')
     ->json_is([ $organization, $organization2 ]);
-
-# cannot remove self from organization
-$t2->delete_ok('/organization/my first organization/user/'.$new_user->email)
-    ->status_is(403);
 
 $t->delete_ok('/organization/my first organization/user/foo@bar.com')
     ->status_is(404);

--- a/t/integration/crud/organization.t
+++ b/t/integration/crud/organization.t
@@ -131,16 +131,19 @@ $t2->get_ok('/organization')
     ->json_is([]);
 
 $t2->get_ok('/organization/'.$organization->{id})
-    ->status_is(403);
+    ->status_is(403)
+    ->log_debug_is('User lacks the required role (admin) for organization '.$organization->{id});
 
 $t2->get_ok('/organization/my first organization')
-    ->status_is(403);
+    ->status_is(403)
+    ->log_debug_is('User lacks the required role (admin) for organization my first organization');
 
 $t2->delete_ok('/organization/foo')
     ->status_is(404);
 
 $t2->delete_ok('/organization/my first organization')
-    ->status_is(403);
+    ->status_is(403)
+    ->log_debug_is('User lacks the required role (admin) for organization my first organization');
 
 
 $t->get_ok('/organization/my first organization/user')
@@ -201,20 +204,24 @@ $t->get_ok('/organization/my first organization')
     ->json_is($organization);
 
 $t2->delete_ok('/organization/my first organization')
-    ->status_is(403);
+    ->status_is(403)
+    ->log_debug_is('User lacks the required role (admin) for organization my first organization');
 
 $t2->get_ok('/organization/my first organization/user')
-    ->status_is(403);
+    ->status_is(403)
+    ->log_debug_is('User lacks the required role (admin) for organization my first organization');
 
 my $new_user2 = $t->generate_fixtures('user_account');
 $t2->post_ok('/organization/'.$organization->{id}.'/user', json => {
         email => $new_user2->email,
         role => 'ro',
     })
-    ->status_is(403);
+    ->status_is(403)
+    ->log_debug_is('User lacks the required role (admin) for organization '.$organization->{id});
 
 $t2->delete_ok('/organization/my first organization/user/'.$new_user->email)
-    ->status_is(403);
+    ->status_is(403)
+    ->log_debug_is('User lacks the required role (admin) for organization my first organization');
 
 
 $t->post_ok('/organization/my first organization/user', json => {
@@ -247,16 +254,19 @@ $t->get_ok('/organization/my first organization/user')
     ]);
 
 $t2->get_ok('/organization/my first organization/user')
-    ->status_is(403);
+    ->status_is(403)
+    ->log_debug_is('User lacks the required role (admin) for organization my first organization');
 
 $t2->post_ok('/organization/'.$organization->{id}.'/user', json => {
         email => $new_user2->email,
         role => 'ro',
     })
-    ->status_is(403);
+    ->status_is(403)
+    ->log_debug_is('User lacks the required role (admin) for organization '.$organization->{id});
 
 $t2->delete_ok('/organization/my first organization/user/'.$new_user->email)
-    ->status_is(403);
+    ->status_is(403)
+    ->log_debug_is('User lacks the required role (admin) for organization my first organization');
 
 
 $t->post_ok('/organization/'.$organization->{id}.'/user', json => {
@@ -775,7 +785,8 @@ $t->post_ok('/workspace/'.$grandchild_ws->id.'/user', json => {
     ->email_not_sent;
 
 $t2->delete_ok('/workspace/grandchild ws/organization/my first organization')
-    ->status_is(403);
+    ->status_is(403)
+    ->log_debug_is('User lacks the required role (admin) for workspace grandchild ws');
 
 
 my $t_admin_user = Test::Conch->new(pg => $t->pg);
@@ -786,7 +797,8 @@ $t_admin_user->delete_ok('/workspace/'.$grandchild_ws->id.'/organization/'.$orga
     ->log_debug_is('User lacks the required role (admin) for workspace '.$grandchild_ws->id);
 
 $t_admin_user->delete_ok('/workspace/'.$sub_ws->id.'/organization/'.$organization->{id})
-    ->status_is(403);
+    ->status_is(403)
+    ->log_debug_is('User lacks the required role (admin) for workspace '.$sub_ws->id);
 
 $t->delete_ok('/workspace/'.$grandchild_ws->id.'/organization/'.$organization->{id})
     ->status_is(204)
@@ -879,6 +891,7 @@ $t->get_ok('/organization')
     ->json_schema_is('Organizations')
     ->json_is([ $organization, $organization2 ]);
 
+# cannot remove self from organization
 $t2->delete_ok('/organization/my first organization/user/'.$new_user->email)
     ->status_is(403);
 

--- a/t/integration/crud/workspace-rack.t
+++ b/t/integration/crud/workspace-rack.t
@@ -165,7 +165,12 @@ subtest 'Assign device to a location' => sub {
 
 subtest 'Remove rack from workspace' => sub {
     $t->delete_ok("/workspace/$sub_ws_id/rack/$rack_id")
-        ->status_is(204);
+        ->status_is(204)
+        ->log_debug_is('deleted workspace_rack entry for workspace_id '.$sub_ws_id.' and rack_id '.$rack_id);
+
+    $t->delete_ok("/workspace/$sub_ws_id/rack/$rack_id")
+        ->status_is(404)
+        ->log_debug_is('Could not find rack '.$rack_id.' in or beneath workspace '.$sub_ws_id);
 
     $t->get_ok("/workspace/$sub_ws_id/rack")
         ->status_is(200)


### PR DESCRIPTION
Some small refactoring and functionality improvements:

- refactored the route flow for the workspace-rack endpoint
- command line helper script for fetching an api token
- when logging requests, do not redact sensitive headers entirely from the log, but just their contents (e.g. to verify that a certain header was indeed present)
- raise minimum requires postgres version to 10.10
- log something when an organization role check fails
- allow removing oneself from an organization
- cache the contextual logger across the entire request
- bail out earlier on erroneous input in a few places (bad log level in config file; unrecognized subcommand passed to conch-db)