### PR TITLE
v3: use device report sku to determine intended hardware

### DIFF
--- a/docs/json-schema/device_report.json
+++ b/docs/json-schema/device_report.json
@@ -205,6 +205,9 @@
         "serial_number" : {
           "$ref" : "common.json#/definitions/device_serial_number"
         },
+        "sku" : {
+          "type" : "string"
+        },
         "system_uuid" : {
           "$ref" : "common.json#/definitions/non_zero_uuid"
         },
@@ -236,6 +239,7 @@
       "required" : [
         "bios_version",
         "product_name",
+        "sku",
         "serial_number",
         "system_uuid"
       ],

--- a/docs/json-schema/request.json
+++ b/docs/json-schema/request.json
@@ -315,6 +315,7 @@
             "name",
             "alias",
             "hardware_vendor_id",
+            "sku",
             "rack_unit_size"
           ]
         },

--- a/docs/json-schema/request.json
+++ b/docs/json-schema/request.json
@@ -93,6 +93,58 @@
       ],
       "type" : "object"
     },
+    "BuildCreateDevice" : {
+      "items" : {
+        "additionalProperties" : false,
+        "anyOf" : [
+          {
+            "required" : [
+              "id"
+            ]
+          },
+          {
+            "required" : [
+              "serial_number"
+            ]
+          }
+        ],
+        "properties" : {
+          "asset_tag" : {
+            "oneOf" : [
+              {
+                "$ref" : "common.json#/definitions/device_asset_tag"
+              },
+              {
+                "type" : "null"
+              }
+            ]
+          },
+          "id" : {
+            "$ref" : "common.json#/definitions/uuid"
+          },
+          "links" : {
+            "items" : {
+              "format" : "uri",
+              "type" : "string"
+            },
+            "type" : "array",
+            "uniqueItems" : true
+          },
+          "serial_number" : {
+            "$ref" : "common.json#/definitions/device_serial_number"
+          },
+          "sku" : {
+            "type" : "string"
+          }
+        },
+        "required" : [
+          "sku"
+        ],
+        "type" : "object"
+      },
+      "type" : "array",
+      "uniqueItems" : true
+    },
     "BuildUpdate" : {
       "additionalProperties" : false,
       "minProperties" : 1,

--- a/docs/json-schema/response.json
+++ b/docs/json-schema/response.json
@@ -1126,6 +1126,26 @@
       },
       "type" : "object"
     },
+    "DeviceSku" : {
+      "additionalProperties" : false,
+      "properties" : {
+        "hardware_product_id" : {
+          "$ref" : "common.json#/definitions/uuid"
+        },
+        "id" : {
+          "$ref" : "common.json#/definitions/uuid"
+        },
+        "sku" : {
+          "type" : "string"
+        }
+      },
+      "required" : [
+        "id",
+        "hardware_product_id",
+        "sku"
+      ],
+      "type" : "object"
+    },
     "DeviceTotals" : {
       "additionalProperties" : {
         "items" : {

--- a/docs/modules/Conch::Controller::Build.md
+++ b/docs/modules/Conch::Controller::Build.md
@@ -95,6 +95,14 @@ Requires the 'read-only' role on the build.
 
 Response uses the Devices json schema.
 
+## create\_and\_add\_devices
+
+Adds the specified device to the build (as long as it isn't in another build, or located in a
+rack in another build).  The device is created if necessary with all data provided (or updated
+with the data if it already exists, so the endpoint is idempotent).
+
+Requires the 'read/write' role on the build.
+
 ## add\_device
 
 Adds the specified device to the build (as long as it isn't in another build, or located in a

--- a/docs/modules/Conch::Controller::Device.md
+++ b/docs/modules/Conch::Controller::Device.md
@@ -48,6 +48,10 @@ Sets the `validated` field on a device unless that field has already been set
 
 Gets just the device's phase. Response uses the DevicePhase json schema.
 
+## get\_sku
+
+Gets just the device's hardware\_product\_id and sku. Response uses the DeviceSku json schema.
+
 ## set\_phase
 
 ## add\_links

--- a/docs/modules/Conch::Controller::DeviceReport.md
+++ b/docs/modules/Conch::Controller::DeviceReport.md
@@ -40,10 +40,6 @@ Process a device report without writing anything to the database; otherwise beha
 
 Response uses the ReportValidationResults json schema.
 
-## \_get\_hardware\_product
-
-Find the hardware product for the device referenced by the report.
-
 ## \_get\_validation\_plan
 
 Find the validation plan that should be used to validate the device referenced by the

--- a/docs/modules/Conch::DB::Result::HardwareProduct.md
+++ b/docs/modules/Conch::DB::Result::HardwareProduct.md
@@ -83,7 +83,7 @@ is_nullable: 1
 
 ```
 data_type: 'text'
-is_nullable: 1
+is_nullable: 0
 ```
 
 ## generation\_name

--- a/docs/modules/Conch::Route::Build.md
+++ b/docs/modules/Conch::Route::Build.md
@@ -80,6 +80,12 @@ an email to the organization members and build admins.
 - Requires system admin authorization or the read-only role on the build
 - Response: response.yaml#/Devices
 
+### `POST /build/:build_id_or_name/device`
+
+- Requires system admin authorization, or the read/write role on the build.
+- Request: [request.json#/definitions/BuildCreateDevice](../json-schema/request.json#/definitions/BuildCreateDevice)
+- Response: `204 NO CONTENT`
+
 ### `POST /build/:build_id_or_name/device/:device_id_or_serial_number`
 
 - Requires system admin authorization, or the read/write role on the build and the

--- a/docs/modules/Conch::Route::Build.md
+++ b/docs/modules/Conch::Route::Build.md
@@ -51,7 +51,7 @@ Takes one optional query parameter `send_mail=<1|0>` (defaults to 1) to send
 an email to the user.
 
 - Requires system admin authorization or the admin role on the build
-- Returns `204 NO CONTENT`
+- Response: `204 NO CONTENT`
 
 ### `GET /build/:build_id_or_name/organization`
 
@@ -73,7 +73,7 @@ Takes one optional query parameter `send_mail=<1|0>` (defaults to 1) to send
 an email to the organization members and build admins.
 
 - User requires the admin role
-- Returns `204 NO CONTENT`
+- Response: `204 NO CONTENT`
 
 ### `GET /build/:build_id_or_name/device`
 
@@ -85,10 +85,12 @@ an email to the organization members and build admins.
 - Requires system admin authorization, or the read/write role on the build and the
 read-only role on the device (via a workspace or a relay registration, see
 ["routes" in Conch::Route::Device](../modules/Conch::Route::Device#routes))
+- Response: `204 NO CONTENT`
 
 ### `DELETE /build/:build_id_or_name/device/:device_id_or_serial_number`
 
 - Requires system admin authorization, or the read/write role on the build
+- Response: `204 NO CONTENT`
 
 ### `GET /build/:build_id_or_name/rack`
 
@@ -99,10 +101,12 @@ read-only role on the device (via a workspace or a relay registration, see
 
 - Requires system admin authorization, or the read/write role on the build and the
 read-only role on a workspace that contains the rack
+- Response: `204 NO CONTENT`
 
 ### `DELETE /build/:build_id_or_name/rack/:rack_id`
 
 - Requires system admin authorization, or the read/write role on the build
+- Response: `204 NO CONTENT`
 
 # LICENSING
 

--- a/docs/modules/Conch::Route::Device.md
+++ b/docs/modules/Conch::Route::Device.md
@@ -52,6 +52,11 @@ below.
 - User requires the read-only role
 - Response: [response.json#/definitions/DevicePhase](../json-schema/response.json#/definitions/DevicePhase)
 
+### `GET /device/:device_id_or_serial_number/sku`
+
+- User requires the read-only role
+- Response: [response.json#/definitions/DeviceSku](../json-schema/response.json#/definitions/DeviceSku)
+
 ### `POST /device/:device_id_or_serial_number/asset_tag`
 
 - User requires the read/write role

--- a/docs/modules/Conch::Route::Organization.md
+++ b/docs/modules/Conch::Route::Organization.md
@@ -45,7 +45,7 @@ Takes one optional query parameter `send_mail=<1|0>` (defaults to 1) to send
 an email to the user.
 
 - Requires system admin authorization or the admin role on the organization
-- Returns `204 NO CONTENT`
+- Response: `204 NO CONTENT`
 
 # LICENSING
 

--- a/docs/modules/Conch::Route::Workspace.md
+++ b/docs/modules/Conch::Route::Workspace.md
@@ -106,7 +106,7 @@ Takes one optional query parameter `send_mail=<1|0>` (defaults to `1`) to send
 an email to the user and workspace admins.
 
 - User requires the admin role
-- Returns `204 NO CONTENT`
+- Response: `204 NO CONTENT`
 
 ### `GET /workspace/:workspace_id_or_name/organization`
 
@@ -128,7 +128,7 @@ Takes one optional query parameter `send_mail=<1|0>` (defaults to 1) to send
 an email to the organization members and workspace admins.
 
 - User requires the admin role
-- Returns `204 NO CONTENT`
+- Response: `204 NO CONTENT`
 
 # LICENSING
 

--- a/json-schema/device_report.yaml
+++ b/json-schema/device_report.yaml
@@ -14,6 +14,7 @@ definitions:
     required:
       - bios_version
       - product_name
+      - sku
       - serial_number
       - system_uuid
     properties:
@@ -125,6 +126,8 @@ definitions:
             type: string
       product_name:
         # TODO: required for switches, and also for non-switches when 'sku' is not present.
+        type: string
+      sku:
         type: string
       relay:
         type: object

--- a/json-schema/request.yaml
+++ b/json-schema/request.yaml
@@ -232,6 +232,7 @@ definitions:
         - name
         - alias
         - hardware_vendor_id
+        - sku
         - rack_unit_size
       - type: object
         properties:

--- a/json-schema/request.yaml
+++ b/json-schema/request.yaml
@@ -679,5 +679,35 @@ definitions:
         $ref: common.yaml#/definitions/uuid
       role:
         $ref: common.yaml#/definitions/role
+  BuildCreateDevice:
+    type: array
+    uniqueItems: true
+    items:
+      type: object
+      additionalProperties: false
+      required:
+        - sku
+      anyOf:
+        - required:
+          - id
+        - required:
+          - serial_number
+      properties:
+        id:
+          $ref: common.yaml#/definitions/uuid
+        serial_number:
+          $ref: common.yaml#/definitions/device_serial_number
+        asset_tag:
+          oneOf:
+            - $ref: common.yaml#/definitions/device_asset_tag
+            - type: 'null'
+        sku:
+          type: string
+        links:
+          type: array
+          uniqueItems: true
+          items:
+            type: string
+            format: uri
 
 # vim: set sts=2 sw=2 et :

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -519,6 +519,20 @@ definitions:
         $ref: common.yaml#/definitions/uuid
       phase:
         $ref: common.yaml#/definitions/device_phase
+  DeviceSku:
+    type: object
+    additionalProperties: false
+    required:
+      - id
+      - hardware_product_id
+      - sku
+    properties:
+      id:
+        $ref: common.yaml#/definitions/uuid
+      hardware_product_id:
+        $ref: common.yaml#/definitions/uuid
+      sku:
+        type: string
   WorkspaceDevicePXEs:
     type: array
     uniqueItems: true

--- a/lib/Conch/Controller/Device.pm
+++ b/lib/Conch/Controller/Device.pm
@@ -209,12 +209,13 @@ sub lookup_by_other_attribute ($c) {
     # Now filter the results by what the user is permitted to see. Depending on the size of the
     # initial resultset, this could be slow!
     if (not $c->is_system_admin) {
-        my $device_in_workspace_rs = $device_rs
+        my $device_in_workspace_or_build_rs = $device_rs
             ->with_user_role($c->stash('user_id'), 'ro');
+
         my $device_via_relay_rs = $device_rs
             ->devices_without_location
             ->devices_reported_by_user_relay($c->stash('user_id'));
-        $device_rs = $device_in_workspace_rs->union_all($device_via_relay_rs);
+        $device_rs = $device_in_workspace_or_build_rs->union($device_via_relay_rs);
     }
 
     my @devices = $device_rs

--- a/lib/Conch/Controller/Device.pm
+++ b/lib/Conch/Controller/Device.pm
@@ -314,6 +314,23 @@ sub get_phase ($c) {
     return $c->status(200, $c->stash('device_rs')->columns([qw(id phase)])->hri->single);
 }
 
+=head2 get_sku
+
+Gets just the device's hardware_product_id and sku. Response uses the DeviceSku json schema.
+
+=cut
+
+sub get_sku($c) {
+    my $rs = $c->stash('device_rs')
+        ->search(undef, { join => 'hardware_product' })
+        ->columns({
+            id => 'device.id',
+            hardware_product_id => 'hardware_product.id',
+            sku => 'hardware_product.sku',
+        });
+    return $c->status(200, $rs->hri->single);
+}
+
 =head2 set_phase
 
 =cut

--- a/lib/Conch/Controller/HardwareProduct.pm
+++ b/lib/Conch/Controller/HardwareProduct.pm
@@ -134,7 +134,7 @@ sub update ($c) {
 
     for my $key (qw(name alias sku)) {
         next if not defined $input->{$key};
-        next if $hardware_product->$key and $input->{$key} eq $hardware_product->$key;
+        next if $input->{$key} eq $hardware_product->$key;
 
         if ($c->db_hardware_products->active->search({ $input->%{$key} })->exists) {
             $c->log->debug('Failed to create hardware product: unique constraint violation for '.$key);

--- a/lib/Conch/DB/Result/HardwareProduct.pm
+++ b/lib/Conch/DB/Result/HardwareProduct.pm
@@ -84,7 +84,7 @@ __PACKAGE__->table("hardware_product");
 =head2 sku
 
   data_type: 'text'
-  is_nullable: 1
+  is_nullable: 0
 
 =head2 generation_name
 
@@ -138,7 +138,7 @@ __PACKAGE__->add_columns(
   "specification",
   { data_type => "jsonb", is_nullable => 1 },
   "sku",
-  { data_type => "text", is_nullable => 1 },
+  { data_type => "text", is_nullable => 0 },
   "generation_name",
   { data_type => "text", is_nullable => 1 },
   "legacy_product_name",
@@ -238,7 +238,7 @@ __PACKAGE__->has_many(
 
 
 # Created by DBIx::Class::Schema::Loader v0.07049
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:uAGpzIKHGyPai0IfNRmrRg
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:m2umWpjs1iSUxb8ry8FKDg
 
 use experimental 'signatures';
 

--- a/lib/Conch/DB/ResultSet/Device.pm
+++ b/lib/Conch/DB/ResultSet/Device.pm
@@ -57,9 +57,7 @@ sub with_user_role ($self, $user_id, $role) {
         { join => { device_location => 'rack' } },
     );
 
-    return $devices_in_ws
-        ->union_all($devices_in_builds)
-        ->distinct;
+    return $devices_in_ws->union($devices_in_builds);
 }
 
 =head2 user_has_role

--- a/lib/Conch/Route/Build.pm
+++ b/lib/Conch/Route/Build.pm
@@ -71,6 +71,9 @@ sub routes {
         # GET /build/:build_id_or_name/device
         $with_build_ro->get('/device')->to('#get_devices');
 
+        # POST /build/:build_id_or_name/device
+        $with_build_rw->post('/device')->to('#create_and_add_devices', require_role => 'rw');
+
         # POST /build/:build_id_or_name/device/:device_id_or_serial_number
         $with_build_rw->under('/device/:device_id_or_serial_number')
             ->to('device#find_device', require_role => 'ro')
@@ -228,6 +231,18 @@ an email to the organization members and build admins.
 =item * Requires system admin authorization or the read-only role on the build
 
 =item * Response: response.yaml#/Devices
+
+=back
+
+=head3 C<POST /build/:build_id_or_name/device>
+
+=over 4
+
+=item * Requires system admin authorization, or the read/write role on the build.
+
+=item * Request: F<request.yaml#/definitions/BuildCreateDevice>
+
+=item * Response: C<204 NO CONTENT>
 
 =back
 

--- a/lib/Conch/Route/Build.pm
+++ b/lib/Conch/Route/Build.pm
@@ -179,7 +179,7 @@ an email to the user.
 
 =item * Requires system admin authorization or the admin role on the build
 
-=item * Returns C<204 NO CONTENT>
+=item * Response: C<204 NO CONTENT>
 
 =back
 
@@ -217,7 +217,7 @@ an email to the organization members and build admins.
 
 =item * User requires the admin role
 
-=item * Returns C<204 NO CONTENT>
+=item * Response: C<204 NO CONTENT>
 
 =back
 
@@ -239,6 +239,8 @@ an email to the organization members and build admins.
 read-only role on the device (via a workspace or a relay registration, see
 L<Conch::Route::Device/routes>)
 
+=item * Response: C<204 NO CONTENT>
+
 =back
 
 =head3 C<DELETE /build/:build_id_or_name/device/:device_id_or_serial_number>
@@ -246,6 +248,8 @@ L<Conch::Route::Device/routes>)
 =over 4
 
 =item * Requires system admin authorization, or the read/write role on the build
+
+=item * Response: C<204 NO CONTENT>
 
 =back
 
@@ -266,6 +270,8 @@ L<Conch::Route::Device/routes>)
 =item * Requires system admin authorization, or the read/write role on the build and the
 read-only role on a workspace that contains the rack
 
+=item * Response: C<204 NO CONTENT>
+
 =back
 
 =head3 C<DELETE /build/:build_id_or_name/rack/:rack_id>
@@ -273,6 +279,8 @@ read-only role on a workspace that contains the rack
 =over 4
 
 =item * Requires system admin authorization, or the read/write role on the build
+
+=item * Response: C<204 NO CONTENT>
 
 =back
 

--- a/lib/Conch/Route/Device.pm
+++ b/lib/Conch/Route/Device.pm
@@ -39,9 +39,10 @@ sub routes {
 
         # GET /device/:device_id_or_serial_number/pxe
         $with_device->get('/pxe')->to('device#get_pxe');
-
         # GET /device/:device_id_or_serial_number/phase
         $with_device->get('/phase')->to('device#get_phase');
+        # GET /device/:device_id_or_serial_number/sku
+        $with_device->get('/sku')->to('device#get_sku');
 
         # POST /device/:device_id_or_serial_number/asset_tag
         $with_device->post('/asset_tag')->to('device#set_asset_tag');
@@ -188,6 +189,16 @@ below.
 =item * User requires the read-only role
 
 =item * Response: F<response.yaml#/definitions/DevicePhase>
+
+=back
+
+=head3 C<GET /device/:device_id_or_serial_number/sku>
+
+=over 4
+
+=item * User requires the read-only role
+
+=item * Response: F<response.yaml#/definitions/DeviceSku>
 
 =back
 

--- a/lib/Conch/Route/Organization.pm
+++ b/lib/Conch/Route/Organization.pm
@@ -120,7 +120,7 @@ an email to the user.
 
 =item * Requires system admin authorization or the admin role on the organization
 
-=item * Returns C<204 NO CONTENT>
+=item * Response: C<204 NO CONTENT>
 
 =back
 

--- a/lib/Conch/Route/Workspace.pm
+++ b/lib/Conch/Route/Workspace.pm
@@ -267,7 +267,7 @@ an email to the user and workspace admins.
 
 =item * User requires the admin role
 
-=item * Returns C<204 NO CONTENT>
+=item * Response: C<204 NO CONTENT>
 
 =back
 
@@ -305,7 +305,7 @@ an email to the organization members and workspace admins.
 
 =item * User requires the admin role
 
-=item * Returns C<204 NO CONTENT>
+=item * Response: C<204 NO CONTENT>
 
 =back
 

--- a/lib/Test/Conch/Fixtures.pm
+++ b/lib/Test/Conch/Fixtures.pm
@@ -166,6 +166,7 @@ my %canned_definitions = (
             prefix => 'F10',
             legacy_product_name => 'FuerzaDiaz',
             rack_unit_size => 1,
+            sku => 'switch_sku',
         },
         requires => {
             hardware_vendor_0 => { our => 'hardware_vendor_id', their => 'id' },
@@ -570,7 +571,8 @@ sub _generate_definition ($self, $fixture_type, $num, $specification) {
                 new => 'hardware_product',
                 using => {
                     name => "hardware_product_$num",
-                    alias => "hardware_product_$num",
+                    alias => "hardware_product_alias_$num",
+                    sku => "hardware_product_sku_$num",
                     rack_unit_size => 42,
                     ($specification // {})->%*,
                 },

--- a/sql/migrations/0132-hardware_product-sku.sql
+++ b/sql/migrations/0132-hardware_product-sku.sql
@@ -1,0 +1,9 @@
+SELECT run_migration(132, $$
+
+    update hardware_product
+        set sku = 'placeholder-missing-sku-' || legacy_product_name
+        where sku is null or sku = '';
+
+    alter table hardware_product alter column sku set not null;
+
+$$);

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -372,7 +372,7 @@ CREATE TABLE public.hardware_product (
     created timestamp with time zone DEFAULT now() NOT NULL,
     updated timestamp with time zone DEFAULT now() NOT NULL,
     specification jsonb,
-    sku text,
+    sku text NOT NULL,
     generation_name text,
     legacy_product_name text,
     rack_unit_size integer NOT NULL,

--- a/t/integration/crud/devices.t
+++ b/t/integration/crud/devices.t
@@ -595,7 +595,16 @@ subtest 'mutate device attributes' => sub {
         ->json_schema_is('DevicePhase')
         ->json_is({ id => $test_device_id, phase => 'decommissioned' });
 
-    my $device = $t->app->db_devices->find({ serial_number => 'TEST' });
+    my $device = $t->app->db_devices->find({ serial_number => 'TEST' }, { prefetch => 'hardware_product' });
+
+    $t->get_ok('/device/TEST/sku')
+        ->status_is(200)
+        ->json_schema_is('DeviceSku')
+        ->json_is({
+            id => $test_device_id,
+            hardware_product_id => $hardware_product_id,
+            sku => $device->hardware_product->sku,
+        });
 
     $t->delete_ok('/device/TEST/links')
         ->status_is(204);

--- a/t/integration/crud/devices.t
+++ b/t/integration/crud/devices.t
@@ -19,7 +19,7 @@ $t->load_validation_plans([{
 
 my $rack = $t->load_fixture('rack_0a');
 my $rack_id = $rack->id;
-my $hardware_product_id = $t->load_fixture('hardware_product_compute')->id;
+my $hardware_product = $t->load_fixture('hardware_product_compute');
 my $global_ws = $t->load_fixture('global_workspace');
 
 # perform most tests as a user with read only access to the GLOBAL workspace
@@ -32,6 +32,11 @@ $t->authenticate(email => $ro_user->email);
 
 $t->get_ok('/device/nonexistent')
     ->status_is(404);
+
+my $build = $t->generate_fixtures('build');
+$build->create_related('user_build_roles', { user_id => $ro_user->id, role => 'admin' });
+$t->post_ok('/build/'.$build->id.'/device', json => [ { serial_number => 'TEST', sku => $hardware_product->sku } ])
+    ->status_is(204);
 
 my $test_device_id;
 
@@ -113,10 +118,10 @@ subtest 'unlocated device with a registered relay' => sub {
             system_uuid => ignore,
             phase => 'integration',
             links => [],
-            build_id => undef,
+            build_id => $build->id,
             (map +($_ => undef), qw(asset_tag uptime_since validated)),
             (map +($_ => re(qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/)), qw(created updated last_seen)),
-            hardware_product_id => $hardware_product_id,
+            hardware_product_id => $hardware_product->id,
             location => undef,
             latest_report => from_json($report),
             nics => supersetof(),
@@ -135,10 +140,10 @@ subtest 'unlocated device with a registered relay' => sub {
             system_uuid => ignore,
             phase => 'integration',
             links => [],
-            build_id => undef,
+            build_id => $build->id,
             (map +($_ => undef), qw(asset_tag uptime_since validated)),
             (map +($_ => re(qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/)), qw(created updated last_seen)),
-            hardware_product_id => $hardware_product_id,
+            hardware_product_id => $hardware_product->id,
             location => undef,
             latest_report => superhashof({ product_name => 'Joyent-G1' }),
             nics => supersetof(),
@@ -297,7 +302,7 @@ subtest 'located device' => sub {
             build_id => undef,
             (map +($_ => undef), qw(asset_tag hostname last_seen system_uuid uptime_since validated)),
             (map +($_ => re(qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/)), qw(created updated)),
-            hardware_product_id => $hardware_product_id,
+            hardware_product_id => $hardware_product->id,
             location => {
                 rack => {
                     (map +($_ => $rack->$_), qw(id name datacenter_room_id serial_number asset_tag phase)),
@@ -602,7 +607,7 @@ subtest 'mutate device attributes' => sub {
         ->json_schema_is('DeviceSku')
         ->json_is({
             id => $test_device_id,
-            hardware_product_id => $hardware_product_id,
+            hardware_product_id => $hardware_product->id,
             sku => $device->hardware_product->sku,
         });
 

--- a/t/integration/crud/hardware-product.t
+++ b/t/integration/crud/hardware-product.t
@@ -43,6 +43,7 @@ $t->post_ok('/hardware_product', json => {
         hardware_vendor_id => $vendor_id,
         alias => 'sungo',
         rack_unit_size => 2,
+        sku => 'my sku',
     })
     ->status_is(303)
     ->location_like(qr!^/hardware_product/${\Conch::UUID::UUID_FORMAT}$!);
@@ -59,7 +60,7 @@ $t->get_ok($t->tx->res->headers->location)
         created => re(qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/),
         updated => re(qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/),
         specification => undef,
-        sku => undef,
+        sku => 'my sku',
         generation_name => undef,
         legacy_product_name => undef,
         rack_unit_size => 2,
@@ -78,6 +79,7 @@ $t->post_ok('/hardware_product', json => {
         name => 'sungo',
         hardware_vendor_id => $vendor_id,
         alias => 'sungo',
+        sku => 'another sku',
         rack_unit_size => 1,
     })
     ->status_is(409)
@@ -233,6 +235,7 @@ subtest 'create a hardware product and hardware product profile all together' =>
             name => 'ether2',
             hardware_vendor_id => $vendor_id,
             alias => 'ether',
+            sku => 'another sku',
             rack_unit_size => 1,
             hardware_product_profile => { dimms_num => 2 },
         })
@@ -256,6 +259,7 @@ subtest 'create a hardware product and hardware product profile all together' =>
             name => 'ether2',
             hardware_vendor_id => $vendor_id,
             alias => 'ether',
+            sku => 'another sku',
             rack_unit_size => 2,
             hardware_product_profile => $new_hw_profile,
         })
@@ -274,7 +278,7 @@ subtest 'create a hardware product and hardware product profile all together' =>
             created => re(qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/),
             updated => re(qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/),
             specification => undef,
-            sku => undef,
+            sku => 'another sku',
             generation_name => undef,
             legacy_product_name => undef,
             rack_unit_size => 2,

--- a/t/integration/crud/hardware-product.t
+++ b/t/integration/crud/hardware-product.t
@@ -5,6 +5,7 @@ use Test::More;
 use Test::Warnings;
 use Test::Deep;
 use Test::Conch;
+use Conch::UUID 'create_uuid_str';
 
 my $t = Test::Conch->new;
 $t->load_fixture('super_user');
@@ -83,6 +84,17 @@ $t->post_ok('/hardware_product', json => {
     ->json_schema_is('Error')
     ->json_is({ error => 'Unique constraint violated on \'name\'' });
 
+$t->post_ok('/hardware_product', json => {
+        name => 'another name',
+        hardware_vendor_id => create_uuid_str(),
+        alias => 'another alias',
+        sku => 'another sku',
+        rack_unit_size => 1,
+    })
+    ->status_is(409)
+    ->json_schema_is('Error')
+    ->json_is({ error => 'hardware_vendor_id does not exist' });
+
 $t->post_ok("/hardware_product/$new_hw_id", json => { name => 'sungo2' })
     ->status_is(303)
     ->location_is('/hardware_product/'.$new_hw_id);
@@ -147,6 +159,25 @@ subtest 'create profile on existing product' => sub {
 };
 
 subtest 'update some fields in an existing profile and product' => sub {
+    $t->post_ok("/hardware_product/$new_hw_id", json => { name => 'Switch' })
+        ->status_is(409)
+        ->json_schema_is('Error')
+        ->json_is({ error => 'Unique constraint violated on \'name\'' });
+
+    $t->post_ok("/hardware_product/$new_hw_id", json => { alias => 'Switch Vendor' })
+        ->status_is(409)
+        ->json_schema_is('Error')
+        ->json_is({ error => 'Unique constraint violated on \'alias\'' });
+
+    $t->post_ok("/hardware_product/$new_hw_id", json => { sku => '550-551-001' })
+        ->status_is(409)
+        ->json_schema_is('Error')
+        ->json_is({ error => 'Unique constraint violated on \'sku\'' });
+
+    $t->post_ok("/hardware_product/$new_hw_id", json => { hardware_vendor_id => create_uuid_str() })
+        ->status_is(409)
+        ->json_schema_is('Error')
+        ->json_is({ error => 'hardware_vendor_id does not exist' });
 
     $t->post_ok("/hardware_product/$new_hw_id", json => {
             name => 'ether1',


### PR DESCRIPTION
- hardware_product.sku is now required (existing entries that lack it get an obviously-placeholder value until that can be corrected - see #805).
- the sku in the incoming device report is now used as the sole mechanism to determine a device's hardware_product
- reject a device report if it references a device that is not yet known to conch
- new endpoints to match the new device lifecycle:
  - `POST /build/:id_or_name/device` (create device with sku as part of a build)
  - `GET /device/:id_or_serial/sku`

closes #893, #807.