### PR TITLE
add a X-Conch-API header to every response; skip version check for GET /version

### DIFF
--- a/lib/Conch.pm
+++ b/lib/Conch.pm
@@ -59,6 +59,9 @@ sub startup {
         }
     );
 
+    $self->hook(after_render => sub ($c, @args) {
+        $c->tx->res->headers->add('X-Conch-API', $c->version_tag);
+    });
 
     $self->helper(
         status => sub ($c, $code, $payload = undef) {

--- a/lib/Conch/Plugin/ClientVerification.pm
+++ b/lib/Conch/Plugin/ClientVerification.pm
@@ -21,6 +21,8 @@ but we will log it.
 sub register ($self, $app, $config) {
     $app->hook(
         before_dispatch => sub ($c) {
+            return if $c->req->url->path eq '/version';
+
             my $headers = $c->req->headers;
             my $user_agent = $headers->user_agent;
 

--- a/t/client-verification.t
+++ b/t/client-verification.t
@@ -47,4 +47,7 @@ $t->get_ok('/ping', { 'User-Agent' => 'Conch/0.0.0 ConchShell/blahblah...' })
 $t->get_ok('/ping', { 'User-Agent' => 'Conch/1.12.0 ConchShell/blahblah...' })
     ->status_is(200);
 
+$t->get_ok('/version', { 'User-Agent' => 'Conch/0.0.0 ConchShell/blahblah...' })
+    ->status_is(200);
+
 done_testing;

--- a/t/integration/unsecured-endpoints.t
+++ b/t/integration/unsecured-endpoints.t
@@ -14,7 +14,8 @@ $t->get_ok('/ping')
     ->json_schema_is('Ping')
     ->json_is({ status => 'ok' })
     ->header_exists('Request-Id')
-    ->header_exists('X-Request-ID');
+    ->header_exists('X-Request-ID')
+    ->header_is('X-Conch-API', $t->app->version_tag);
 
 $t->get_ok('/me')->status_is(401);
 


### PR DESCRIPTION
This way, clients can check the version even when their client is not
compatible with the api.