### PR TITLE
add a X-Conch-API header to every response

### DIFF
--- a/lib/Conch.pm
+++ b/lib/Conch.pm
@@ -60,6 +60,9 @@ sub startup {
         }
     );
 
+    $self->hook(after_render => sub ($c, @args) {
+        $c->tx->res->headers->add('X-Conch-API', $c->version_tag);
+    });
 
     $self->helper(
         status => sub ($c, $code, $payload = undef) {

--- a/t/integration/crud/unsecured-endpoints.t
+++ b/t/integration/crud/unsecured-endpoints.t
@@ -11,7 +11,8 @@ $t->load_fixture('legacy_datacenter');
 
 $t->get_ok('/ping')
     ->status_is(200)
-    ->json_is({ status => 'ok' });
+    ->json_is({ status => 'ok' })
+    ->header_is('X-Conch-API', $t->app->version_tag);
 
 $t->get_ok('/version')
     ->status_is(200)


### PR DESCRIPTION
This way, clients can check the version even when their client is not
compatible with the api.