### PR TITLE
v3: small fixes for device reports

### DIFF
--- a/docs/json-schema/common.json
+++ b/docs/json-schema/common.json
@@ -101,6 +101,18 @@
       "minimum" : 0,
       "type" : "integer"
     },
+    "non_zero_uuid" : {
+      "allOf" : [
+        {
+          "$ref" : "/definitions/uuid"
+        },
+        {
+          "not" : {
+            "const" : "00000000-0000-0000-0000-000000000000"
+          }
+        }
+      ]
+    },
     "positive_integer" : {
       "minimum" : 1,
       "type" : "integer"

--- a/docs/json-schema/device_report.json
+++ b/docs/json-schema/device_report.json
@@ -206,7 +206,7 @@
           "$ref" : "common.json#/definitions/device_serial_number"
         },
         "system_uuid" : {
-          "$ref" : "common.json#/definitions/uuid"
+          "$ref" : "common.json#/definitions/non_zero_uuid"
         },
         "temp" : {
           "properties" : {

--- a/docs/modules/Conch::Controller::Rack.md
+++ b/docs/modules/Conch::Controller::Rack.md
@@ -51,8 +51,8 @@ Response uses the RackAssignments json schema.
 
 ## set\_assignment
 
-Assigns devices to rack layouts, also optionally updating serial\_numbers and asset\_tags.
-Existing devices in referenced slots will be removed as needed.
+Assigns devices to rack layouts, also optionally updating serial\_numbers and asset\_tags (and
+creating the device if needed). Existing devices in referenced slots will be unassigned as needed.
 
 Note: the assignment is still performed even if there is no physical room in the rack
 for the new hardware (its rack\_unit\_size overlaps into a subsequent layout), or that

--- a/docs/modules/Conch::Plugin::GitVersion.md
+++ b/docs/modules/Conch::Plugin::GitVersion.md
@@ -12,7 +12,7 @@ Mojo plugin registering the git version tag and hash for the repository
 
 Provides a string that uniquely describes the version and commit of the currently-running code.
 
-## version\_tag
+## version\_hash
 
 Provides the exact git SHA of the currently-running code.
 

--- a/docs/modules/Conch::Time.md
+++ b/docs/modules/Conch::Time.md
@@ -31,7 +31,7 @@ Conch::Time->new($pg_timestamptz);
 my $t = Conch::Time->now;
 ```
 
-Return an object based on the current time.
+Return an object based on the current time, using the UTC timezone.
 
 Time are high resolution and will generate unique timestamps to the
 nanosecond.
@@ -52,7 +52,7 @@ See also ["from\_epoch" in Time::Moment](https://metacpan.org/pod/Time::Moment#f
 
 ### rfc3339
 
-Return an RFC3339 compatible string.
+Return an RFC3339 compatible string as UTC.
 Sub-second precision will use 3, 6 or 9 digits as necessary.
 
 ### timestamp

--- a/json-schema/common.yaml
+++ b/json-schema/common.yaml
@@ -4,6 +4,11 @@ definitions:
   uuid:
     type: string
     pattern: "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+  non_zero_uuid:
+    allOf:
+      - $ref: /definitions/uuid
+      - not:
+          const: 00000000-0000-0000-0000-000000000000
   ipaddr:
     oneOf:
       - type: string

--- a/json-schema/device_report.yaml
+++ b/json-schema/device_report.yaml
@@ -136,7 +136,7 @@ definitions:
       serial_number:
         $ref: common.yaml#/definitions/device_serial_number
       system_uuid:
-        $ref: common.yaml#/definitions/uuid
+        $ref: common.yaml#/definitions/non_zero_uuid
       temp:
         type: object
         required:

--- a/lib/Conch/Controller/Rack.pm
+++ b/lib/Conch/Controller/Rack.pm
@@ -289,8 +289,8 @@ sub get_assignment ($c) {
 
 =head2 set_assignment
 
-Assigns devices to rack layouts, also optionally updating serial_numbers and asset_tags.
-Existing devices in referenced slots will be removed as needed.
+Assigns devices to rack layouts, also optionally updating serial_numbers and asset_tags (and
+creating the device if needed). Existing devices in referenced slots will be unassigned as needed.
 
 Note: the assignment is still performed even if there is no physical room in the rack
 for the new hardware (its rack_unit_size overlaps into a subsequent layout), or that

--- a/lib/Conch/Plugin/AuthHelpers.pm
+++ b/lib/Conch/Plugin/AuthHelpers.pm
@@ -27,11 +27,9 @@ Verifies that the currently stashed user has the C<is_admin> flag set.
 
 =cut
 
-    $app->helper(
-        is_system_admin => sub ($c) {
-            $c->stash('user') && $c->stash('user')->is_admin;
-        },
-    );
+    $app->helper(is_system_admin => sub ($c) {
+        $c->stash('user') && $c->stash('user')->is_admin;
+    });
 
 
 =head2 generate_jwt
@@ -43,21 +41,19 @@ C<expires> is an epoch time.
 
 =cut
 
-    $app->helper(
-        generate_jwt => sub ($c, $user_id, $expires_abs, $token_name) {
-            return $c->status(409, { error => 'name "'.$token_name.'" is already in use' })
-                if $c->db_user_session_tokens
-                    ->search({ user_id => $user_id, name => $token_name })->exists;
+    $app->helper(generate_jwt => sub ($c, $user_id, $expires_abs, $token_name) {
+        return $c->status(409, { error => 'name "'.$token_name.'" is already in use' })
+            if $c->db_user_session_tokens
+                ->search({ user_id => $user_id, name => $token_name })->exists;
 
-            my $session_token = $c->db_user_session_tokens->create({
-                user_id => $user_id,
-                name => $token_name,
-                expires => \[ q{to_timestamp(?)::timestamptz}, $expires_abs ],
-            });
+        my $session_token = $c->db_user_session_tokens->create({
+            user_id => $user_id,
+            name => $token_name,
+            expires => \[ q{to_timestamp(?)::timestamptz}, $expires_abs ],
+        });
 
-            return ($session_token, $c->generate_jwt_from_token($session_token));
-        },
-    );
+        return ($session_token, $c->generate_jwt_from_token($session_token));
+    });
 
 =head2 generate_jwt_from_token
 
@@ -65,15 +61,13 @@ Given a session token, generate a JWT for it.
 
 =cut
 
-    $app->helper(
-        generate_jwt_from_token => sub ($c, $session_token) {
-            return Mojo::JWT->new(
-                claims => { user_id => $session_token->user_id, token_id => $session_token->id },
-                secret => $c->app->secrets->[0],
-                expires => $session_token->expires->epoch,
-            )->encode;
-        },
-    );
+    $app->helper(generate_jwt_from_token => sub ($c, $session_token) {
+        return Mojo::JWT->new(
+            claims => { user_id => $session_token->user_id, token_id => $session_token->id },
+            secret => $c->app->secrets->[0],
+            expires => $session_token->expires->epoch,
+        )->encode;
+    });
 }
 
 1;

--- a/lib/Conch/Plugin/Database.pm
+++ b/lib/Conch/Plugin/Database.pm
@@ -6,6 +6,7 @@ use Conch::DB ();
 use Lingua::EN::Inflexion 'noun';
 use Try::Tiny;
 use Conch::DB::Util;
+use Safe::Isa;
 
 =pod
 
@@ -146,6 +147,9 @@ line of the exception.
             my $exception = $_;
             $c->log->debug('rolled back transaction');
             if ($exception !~ /^rollback/) {
+                $c->stash('exception',
+                    ($exception->$_isa('Mojo::Exception') ? $exception
+                        : Mojo::Exception->new($exception))->inspect);
                 my ($error) = split(/\n/, $exception, 2);
                 $c->log->error($c->log->is_level('debug') ? $exception : $error);
                 $c->status($c->res->code // 400, { error => $error });

--- a/lib/Conch/Plugin/GitVersion.pm
+++ b/lib/Conch/Plugin/GitVersion.pm
@@ -31,7 +31,7 @@ Provides a string that uniquely describes the version and commit of the currentl
     $app->log->fatal('git error') and die 'git error' if not $git_tag;
     $app->helper(version_tag => sub ($) { $git_tag });
 
-=head2 version_tag
+=head2 version_hash
 
 Provides the exact git SHA of the currently-running code.
 

--- a/lib/Conch/Time.pm
+++ b/lib/Conch/Time.pm
@@ -49,10 +49,14 @@ sub new {
 
     my $t = Conch::Time->now;
 
-Return an object based on the current time.
+Return an object based on the current time, using the UTC timezone.
 
 Time are high resolution and will generate unique timestamps to the
 nanosecond.
+
+=cut
+
+sub now { return shift->now_utc }
 
 =head2 from_epoch
 
@@ -68,13 +72,13 @@ See also L<Time::Moment/from_epoch>.
 
 =head3 rfc3339
 
-Return an RFC3339 compatible string.
+Return an RFC3339 compatible string as UTC.
 Sub-second precision will use 3, 6 or 9 digits as necessary.
 
 =cut
 
 sub rfc3339 {
-    return shift->strftime('%Y-%m-%dT%H:%M:%S.%N%Z');
+    return shift->at_utc->strftime('%Y-%m-%dT%H:%M:%S.%N%Z');
 }
 
 =head3 timestamp

--- a/t/conch-time.t
+++ b/t/conch-time.t
@@ -69,23 +69,28 @@ subtest 'Test parsing of timestamps' => sub {
         },
         {
             input    => '2018-01-02 00:00:00+01',
-            expected => '2018-01-02T00:00:00.000+01:00',
-            message  => 'Appends :00 to positive timezones that do not specify minutes'
+            expected => '2018-01-01T23:00:00.000Z',
+            message  => 'Positive timezone converted to UTC with positive offset',
         },
         {
             input    => '2018-01-02 00:00:00-01',
-            expected => '2018-01-02T00:00:00.000-01:00',
-            message  => 'Appends :00 to negative timezones that do not specify minutes'
+            expected => '2018-01-02T01:00:00.000Z',
+            message  => 'Negative timezone converted to UTC with negative offset',
         },
         {
             input    => '2018-01-02 00:00:00+01:20',
-            expected => '2018-01-02T00:00:00.000+01:20',
-            message  => 'Does not modify timezones that specify minutes'
+            expected => '2018-01-01T22:40:00.000Z',
+            message  => 'Positive timezone with minutes converted to UTC with positive offset',
         },
         {
             input    => '2018-01-02 00:00:00+00:20',
-            expected => '2018-01-02T00:00:00.000+00:20',
-            message  => 'Does not modify 00 timezones that specify minutes'
+            expected => '2018-01-01T23:40:00.000Z',
+            message  => 'Positive timezone with minutes converted to UTC with positive offset',
+        },
+        {
+            input    => '2018-01-02 00:00:00-01:20',
+            expected => '2018-01-02T01:20:00.000Z',
+            message  => 'Negative timezone with minutes converted to UTC with negative offset',
         },
     );
 

--- a/t/integration/device-reports.t
+++ b/t/integration/device-reports.t
@@ -394,5 +394,19 @@ subtest 'create device via report' => sub {
     );
 };
 
+subtest 'system_uuid collisions' => sub {
+    my $report_data = from_json($report);
+    $report_data->{serial_number} = 'i_was_here_first';
+
+    my $existing_device = $t->generate_fixtures('device', { serial_number => 'i_was_here_first' });
+
+    $t->post_ok('/device_report', json => $report_data)
+        ->status_is(400)
+        ->json_cmp_deeply({ error => re(qr/no validations ran: .*duplicate key value violates unique constraint "device_system_uuid_key"/) });
+
+    $t->post_ok('/device/i_was_here_first', json => $report_data)
+        ->json_cmp_deeply({ error => re(qr/could not process report for device i_was_here_first.*duplicate key value violates unique constraint "device_system_uuid_key"/) });
+};
+
 done_testing;
 # vim: set ts=4 sts=4 sw=4 et :

--- a/t/integration/device-reports.t
+++ b/t/integration/device-reports.t
@@ -66,6 +66,20 @@ my ($full_validation_plan) = $t->load_validation_plans([{
 
 subtest 'run report without an existing device' => sub {
     my $report_data = from_json($report);
+
+    $t->post_ok('/device_report', json => { $report_data->%*, device_type => 'switch', product_name => '2-ssds-1-cpu' })
+        ->status_is(422)
+        ->json_is({ error => 'failed to find validation plan' });
+
+    $t->post_ok('/device_report', json => { $report_data->%*, sku => 'ugh' })
+        ->status_is(409)
+        ->json_is({ error => 'Could not locate hardware product' });
+
+    $t->generate_fixtures('hardware_product', { sku => 'ugh' });
+    $t->post_ok('/device_report', json => { $report_data->%*, sku => 'ugh' })
+        ->status_is(409)
+        ->json_is({ error => 'Hardware product does not contain a profile' });
+
     $report_data->{serial_number} = 'different_device';
     $report_data->{system_uuid} = create_uuid_str();
     $t->post_ok('/device_report', json => $report_data)

--- a/t/json-validation.t
+++ b/t/json-validation.t
@@ -122,4 +122,21 @@ subtest 'GET /workspace/:workspace_id_or_name/rack validation' => sub {
     );
 };
 
+subtest 'device report validation' => sub {
+    my $validator = JSON::Validator->new
+        ->load_and_validate_schema('json-schema/device_report.yaml',
+            { schema => 'http://json-schema.org/draft-07/schema#' });
+
+    my $schema = $validator->get('/definitions/DeviceReport_v3.0.0/properties/system_uuid');
+
+    cmp_deeply(
+        [ $validator->validate('00000000-0000-0000-0000-000000000000', $schema) ],
+        [ methods(
+            path => '/',
+            message => re(qr/should not match/i),
+        ) ],
+        'all-zero system_uuids are rejected',
+    );
+};
+
 done_testing;


### PR DESCRIPTION
misc small fixes in advance of some new feature changes.

- fix timestamp serialization (tests in master were broken in certain timezones and locales)
- small documentation fixes
- properly handle device reports that contain conflicting system_uuids
- disallow "placeholder" system_uuids
- set device health to error when processing a bad report
- log exceptions even when they are caught in `txn_wrapper`, for better problem diagnosis