### PR TITLE
v3: organization and build fixes

### DIFF
--- a/docs/json-schema/response.json
+++ b/docs/json-schema/response.json
@@ -1724,6 +1724,41 @@
           "type" : "array",
           "uniqueItems" : true
         },
+        "builds" : {
+          "items" : {
+            "additionalProperties" : false,
+            "properties" : {
+              "description" : {
+                "oneOf" : [
+                  {
+                    "type" : "string"
+                  },
+                  {
+                    "type" : "null"
+                  }
+                ]
+              },
+              "id" : {
+                "$ref" : "common.json#/definitions/uuid"
+              },
+              "name" : {
+                "$ref" : "common.json#/definitions/mojo_standard_placeholder"
+              },
+              "role" : {
+                "$ref" : "common.json#/definitions/role"
+              }
+            },
+            "required" : [
+              "id",
+              "name",
+              "description",
+              "role"
+            ],
+            "type" : "object"
+          },
+          "type" : "array",
+          "uniqueItems" : true
+        },
         "created" : {
           "format" : "date-time",
           "type" : "string"
@@ -1754,7 +1789,8 @@
         "description",
         "created",
         "admins",
-        "workspaces"
+        "workspaces",
+        "builds"
       ],
       "type" : "object"
     },
@@ -2197,6 +2233,44 @@
     "UserDetailed" : {
       "additionalProperties" : false,
       "properties" : {
+        "builds" : {
+          "items" : {
+            "additionalProperties" : false,
+            "properties" : {
+              "description" : {
+                "oneOf" : [
+                  {
+                    "type" : "string"
+                  },
+                  {
+                    "type" : "null"
+                  }
+                ]
+              },
+              "id" : {
+                "$ref" : "common.json#/definitions/uuid"
+              },
+              "name" : {
+                "$ref" : "common.json#/definitions/mojo_standard_placeholder"
+              },
+              "role" : {
+                "$ref" : "common.json#/definitions/role"
+              },
+              "role_via_organization_id" : {
+                "$ref" : "common.json#/definitions/uuid"
+              }
+            },
+            "required" : [
+              "id",
+              "name",
+              "description",
+              "role"
+            ],
+            "type" : "object"
+          },
+          "type" : "array",
+          "uniqueItems" : true
+        },
         "created" : {
           "format" : "date-time",
           "type" : "string"
@@ -2291,7 +2365,8 @@
         "force_password_change",
         "is_admin",
         "workspaces",
-        "organizations"
+        "organizations",
+        "builds"
       ],
       "type" : "object"
     },

--- a/docs/json-schema/response.json
+++ b/docs/json-schema/response.json
@@ -1716,14 +1716,6 @@
     "Organization" : {
       "additionalProperties" : false,
       "properties" : {
-        "admins" : {
-          "items" : {
-            "$ref" : "/definitions/UserTerse"
-          },
-          "minItems" : 1,
-          "type" : "array",
-          "uniqueItems" : true
-        },
         "builds" : {
           "items" : {
             "additionalProperties" : false,
@@ -1779,6 +1771,35 @@
         "name" : {
           "$ref" : "common.json#/definitions/mojo_relaxed_placeholder"
         },
+        "users" : {
+          "items" : {
+            "additionalProperties" : false,
+            "properties" : {
+              "email" : {
+                "$ref" : "common.json#/definitions/email_address"
+              },
+              "id" : {
+                "$ref" : "common.json#/definitions/uuid"
+              },
+              "name" : {
+                "type" : "string"
+              },
+              "role" : {
+                "$ref" : "common.json#/definitions/role"
+              }
+            },
+            "required" : [
+              "id",
+              "name",
+              "email",
+              "role"
+            ],
+            "type" : "object"
+          },
+          "minItems" : 1,
+          "type" : "array",
+          "uniqueItems" : true
+        },
         "workspaces" : {
           "$ref" : "/definitions/WorkspacesAndRoles"
         }
@@ -1788,40 +1809,11 @@
         "name",
         "description",
         "created",
-        "admins",
+        "users",
         "workspaces",
         "builds"
       ],
       "type" : "object"
-    },
-    "OrganizationUsers" : {
-      "items" : {
-        "additionalProperties" : false,
-        "properties" : {
-          "email" : {
-            "$ref" : "common.json#/definitions/email_address"
-          },
-          "id" : {
-            "$ref" : "common.json#/definitions/uuid"
-          },
-          "name" : {
-            "type" : "string"
-          },
-          "role" : {
-            "$ref" : "common.json#/definitions/role"
-          }
-        },
-        "required" : [
-          "id",
-          "name",
-          "email",
-          "role"
-        ],
-        "type" : "object"
-      },
-      "minItems" : 1,
-      "type" : "array",
-      "uniqueItems" : true
     },
     "Organizations" : {
       "items" : {

--- a/docs/modules/Conch::Controller::Organization.md
+++ b/docs/modules/Conch::Controller::Organization.md
@@ -47,13 +47,6 @@ Deactivates the organization, preventing its members from exercising any privile
 
 User must have system admin privileges.
 
-## list\_users
-
-Get a list of members of the current organization.
-Requires the 'admin' role on the organization.
-
-Response uses the OrganizationUsers json schema.
-
 ## add\_user
 
 Adds a user to the current organization, or upgrades an existing role entry to access the

--- a/docs/modules/Conch::DB::Result::Organization.md
+++ b/docs/modules/Conch::DB::Result::Organization.md
@@ -93,7 +93,7 @@ Composing rels: ["organization\_workspace\_roles"](#organization_workspace_roles
 
 ## TO\_JSON
 
-Include information about the organization's admins and workspaces.
+Include information about the organization's admins, workspaces and builds, if available.
 
 # LICENSING
 

--- a/docs/modules/Conch::DB::Result::UserAccount.md
+++ b/docs/modules/Conch::DB::Result::UserAccount.md
@@ -173,7 +173,7 @@ Because hard cryptography is used, this is \*not\* a fast call!
 
 ## TO\_JSON
 
-Include information about the user's workspaces and organizations, if available.
+Include information about the user's workspaces, organizations and builds, if available.
 
 # LICENSING
 

--- a/docs/modules/Conch::Route::Organization.md
+++ b/docs/modules/Conch::Route::Organization.md
@@ -30,11 +30,6 @@ Unless otherwise noted, all routes require authentication.
 - Requires system admin authorization
 - Response: `204 NO CONTENT`
 
-### `GET /organization/:organization_id_or_name/user`
-
-- Requires system admin authorization or the admin role on the organization
-- Response: [response.json#/definitions/OrganizationUsers](../json-schema/response.json#/definitions/OrganizationUsers)
-
 ### `POST /organization/:organization_id_or_name/user?send_mail=<1|0`>
 
 Takes one optional query parameter `send_mail=<1|0>` (defaults to 1) to send

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -1778,7 +1778,7 @@ definitions:
       - name
       - description
       - created
-      - admins
+      - users
       - workspaces
       - builds
     properties:
@@ -1793,12 +1793,27 @@ definitions:
       created:
         type: string
         format: date-time
-      admins:
+      users:
         type: array
         uniqueItems: true
         minItems: 1
         items:
-          $ref: /definitions/UserTerse
+          type: object
+          additionalProperties: false
+          required:
+            - id
+            - name
+            - email
+            - role
+          properties:
+            id:
+              $ref: common.yaml#/definitions/uuid
+            name:
+              type: string
+            email:
+              $ref: common.yaml#/definitions/email_address
+            role:
+              $ref: common.yaml#/definitions/role
       workspaces:
         $ref: /definitions/WorkspacesAndRoles
       builds:
@@ -1828,27 +1843,6 @@ definitions:
     uniqueItems: true
     items:
       $ref: /definitions/Organization
-  OrganizationUsers:
-    type: array
-    uniqueItems: true
-    minItems: 1
-    items:
-      type: object
-      additionalProperties: false
-      required:
-        - id
-        - name
-        - email
-        - role
-      properties:
-        id:
-          $ref: common.yaml#/definitions/uuid
-        name:
-          type: string
-        email:
-          $ref: common.yaml#/definitions/email_address
-        role:
-          $ref: common.yaml#/definitions/role
   WorkspaceOrganizations:
     type: array
     uniqueItems: true

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -1502,6 +1502,7 @@ definitions:
       - is_admin
       - workspaces
       - organizations
+      - builds
     properties:
       id:
         $ref: common.yaml#/definitions/uuid
@@ -1552,6 +1553,30 @@ definitions:
                 - type: string
             role:
               $ref: common.yaml#/definitions/role
+      builds:
+        type: array
+        uniqueItems: true
+        items:
+          type: object
+          additionalProperties: false
+          required:
+            - id
+            - name
+            - description
+            - role
+          properties:
+            id:
+              $ref: common.yaml#/definitions/uuid
+            name:
+              $ref: common.yaml#/definitions/mojo_standard_placeholder
+            description:
+              oneOf:
+                - type: string
+                - type: 'null'
+            role:
+              $ref: common.yaml#/definitions/role
+            role_via_organization_id:
+              $ref: common.yaml#/definitions/uuid
   UsersDetailed:
     type: array
     uniqueItems: true
@@ -1755,6 +1780,7 @@ definitions:
       - created
       - admins
       - workspaces
+      - builds
     properties:
       id:
         $ref: common.yaml#/definitions/uuid
@@ -1775,6 +1801,28 @@ definitions:
           $ref: /definitions/UserTerse
       workspaces:
         $ref: /definitions/WorkspacesAndRoles
+      builds:
+        type: array
+        uniqueItems: true
+        items:
+          type: object
+          additionalProperties: false
+          required:
+            - id
+            - name
+            - description
+            - role
+          properties:
+            id:
+              $ref: common.yaml#/definitions/uuid
+            name:
+              $ref: common.yaml#/definitions/mojo_standard_placeholder
+            description:
+              oneOf:
+                - type: string
+                - type: 'null'
+            role:
+              $ref: common.yaml#/definitions/role
   Organizations:
     type: array
     uniqueItems: true

--- a/lib/Conch/Controller/Organization.pm
+++ b/lib/Conch/Controller/Organization.pm
@@ -192,12 +192,17 @@ sub delete ($c) {
         ->and_workspaces_beneath($direct_workspaces_rs->as_query)
         ->count;
 
+    my $build_count = 0+$c->stash('organization_rs')
+        ->related_resultset('organization_build_roles')
+        ->delete;
+
     $c->stash('organization_rs')->related_resultset('organization_workspace_roles')->delete;
     $c->stash('organization_rs')->deactivate;
 
     $c->log->debug('Deactivated organization '.$c->stash('organization_id_or_name')
-        .', removing '.$user_count.' user memberships and removing from '
-        .$workspace_count.' workspaces');
+        .', removing '.$user_count.' user memberships'
+        .' and removing from '.$workspace_count.' workspaces'
+        .' and '.$build_count.' builds');
     return $c->status(204);
 }
 

--- a/lib/Conch/Controller/Organization.pm
+++ b/lib/Conch/Controller/Organization.pm
@@ -33,8 +33,9 @@ sub list ($c) {
         ->prefetch({
                 user_organization_roles => 'user_account',
                 organization_workspace_roles => 'workspace',
+                organization_build_roles => 'build',
             })
-        ->order_by([qw(organization.name user_account.name)]);
+        ->order_by([ map $_.'.name', qw(organization user_account workspace build) ]);
 
     return $c->status(200, [ $rs->all ]) if $c->is_system_admin;
 
@@ -152,8 +153,9 @@ sub get ($c) {
         ->prefetch({
                 user_organization_roles => 'user_account',
                 organization_workspace_roles => 'workspace',
+                organization_build_roles => 'build',
             })
-        ->order_by('user_account.name');
+        ->order_by([ map $_.'.name', qw(user_account workspace build) ]);
 
     return $c->status(200, ($rs->all)[0]) if $c->is_system_admin;
 

--- a/lib/Conch/Controller/Organization.pm
+++ b/lib/Conch/Controller/Organization.pm
@@ -29,7 +29,6 @@ Response uses the Organizations json schema.
 sub list ($c) {
     my $rs = $c->db_organizations
         ->active
-        ->search({ 'user_organization_roles.role' => 'admin' })
         ->prefetch({
                 user_organization_roles => 'user_account',
                 organization_workspace_roles => 'workspace',
@@ -149,7 +148,6 @@ Response uses the Organization json schema.
 
 sub get ($c) {
     my $rs = $c->stash('organization_rs')
-        ->search({ 'user_organization_roles.role' => 'admin' })
         ->prefetch({
                 user_organization_roles => 'user_account',
                 organization_workspace_roles => 'workspace',
@@ -206,26 +204,6 @@ sub delete ($c) {
         .' and removing from '.$workspace_count.' workspaces'
         .' and '.$build_count.' builds');
     return $c->status(204);
-}
-
-=head2 list_users
-
-Get a list of members of the current organization.
-Requires the 'admin' role on the organization.
-
-Response uses the OrganizationUsers json schema.
-
-=cut
-
-sub list_users ($c) {
-    my $rs = $c->stash('organization_rs')
-        ->related_resultset('user_organization_roles')
-        ->related_resultset('user_account')
-        ->active
-        ->columns([ { role => 'user_organization_roles.role' }, map 'user_account.'.$_, qw(id name email) ])
-        ->order_by([ { -desc => 'role' }, 'name' ]);
-
-    $c->status(200, [ $rs->hri->all ]);
 }
 
 =head2 add_user

--- a/lib/Conch/Controller/User.pm
+++ b/lib/Conch/Controller/User.pm
@@ -330,9 +330,13 @@ sub get ($c) {
         ->search({ 'user_account.id' => $c->stash('target_user')->id })
         ->prefetch({
                 user_workspace_roles => 'workspace',
-                user_organization_roles => { organization => { organization_workspace_roles => 'workspace' } },
+                user_organization_roles => { organization => {
+                        organization_workspace_roles => 'workspace',
+                        organization_build_roles => 'build',
+                    } },
+                user_build_roles => 'build',
             })
-        ->order_by([qw(workspace.name organization.name)])
+        ->order_by([ map $_.'.name', qw(workspace organization build) ])
         ->all;
 
     return $c->status(200, $user) if $c->is_system_admin;
@@ -411,9 +415,13 @@ sub list ($c) {
         ->active
         ->prefetch({
                 user_workspace_roles => 'workspace',
-                user_organization_roles => { organization => { organization_workspace_roles => 'workspace' } },
+                user_organization_roles => { organization => {
+                        organization_workspace_roles => 'workspace',
+                        organization_build_roles => 'build',
+                    } },
+                user_build_roles => 'build',
             })
-        ->order_by([qw(user_account.name workspace.name organization.name)]);
+        ->order_by([ map $_.'.name', qw(user_account workspace organization build) ]);
 
     return $c->status(200, [ $user_rs->all ]);
 }

--- a/lib/Conch/DB/Result/Organization.pm
+++ b/lib/Conch/DB/Result/Organization.pm
@@ -192,10 +192,13 @@ Include information about the organization's admins, workspaces and builds, if a
 sub TO_JSON ($self) {
     my $data = $self->next::method(@_);
 
-    $data->{admins} = [
+    $data->{users} = [
         map {
             my ($user) = $_->related_resultset('user_account')->get_cache->@*;
-            +{ map +($_ => $user->$_), qw(id name email) };
+            +{
+                (map +($_ => $user->$_), qw(id name email)),
+                role => $_->role,
+            };
         }
         $self->related_resultset('user_organization_roles')->get_cache->@*
     ];

--- a/lib/Conch/DB/Result/Organization.pm
+++ b/lib/Conch/DB/Result/Organization.pm
@@ -185,7 +185,7 @@ use experimental 'signatures';
 
 =head2 TO_JSON
 
-Include information about the organization's admins and workspaces.
+Include information about the organization's admins, workspaces and builds, if available.
 
 =cut
 
@@ -226,6 +226,17 @@ sub TO_JSON ($self) {
             ), $self->result_source->schema->resultset('workspace')
                 ->workspaces_beneath($_->workspace_id)
         ), $cached_owrs->@*),
+    ];
+
+    my $cached_obrs = $self->related_resultset('organization_build_roles')->get_cache;
+    $data->{builds} = [
+        (map {
+            my $build = $_->build;
+            +{
+                (map +($_ => $build->$_), qw(id name description)),
+                role => $_->role,
+            },
+        } $cached_obrs->@*),
     ];
 
     return $data;

--- a/lib/Conch/Route/Organization.pm
+++ b/lib/Conch/Route/Organization.pm
@@ -40,9 +40,6 @@ sub routes {
         # DELETE /organization/:organization_id_or_name
         $with_organization->require_system_admin->delete('/')->to('#delete');
 
-        # GET /organization/:organization_id_or_name/user
-        $with_organization->get('/user')->to('#list_users');
-
         # POST /organization/:organization_id_or_name/user?send_mail=<1|0>
         $with_organization->post('/user')->to('#add_user');
 
@@ -96,16 +93,6 @@ Unless otherwise noted, all routes require authentication.
 =item * Requires system admin authorization
 
 =item * Response: C<204 NO CONTENT>
-
-=back
-
-=head3 C<GET /organization/:organization_id_or_name/user>
-
-=over 4
-
-=item * Requires system admin authorization or the admin role on the organization
-
-=item * Response: F<response.yaml#/definitions/OrganizationUsers>
 
 =back
 

--- a/t/integration/crud/build.t
+++ b/t/integration/crud/build.t
@@ -510,6 +510,18 @@ $t->get_ok('/build/'.$build->{id}.'/organization')
             ],
         },
     ]);
+my $organization_data = $t->tx->res->json->[0];
+
+$t->get_ok('/organization/my first organization')
+    ->status_is(200)
+    ->json_schema_is('Organization')
+    ->json_cmp_deeply({
+        (map +($_ => $organization->$_), qw(id name description)),
+        created => $organization->created.'',
+        admins => $organization_data->{admins},
+        workspaces => [],
+        builds => [ +{ $build->%{qw(id name description)}, role => 'ro' } ],
+    });
 
 $t->post_ok('/build/'.$build->{id}.'/organization', json => {
         organization_id => $organization->id,

--- a/t/integration/crud/build.t
+++ b/t/integration/crud/build.t
@@ -510,7 +510,6 @@ $t->get_ok('/build/'.$build->{id}.'/organization')
             ],
         },
     ]);
-my $organization_data = $t->tx->res->json->[0];
 
 $t->get_ok('/organization/my first organization')
     ->status_is(200)
@@ -518,7 +517,10 @@ $t->get_ok('/organization/my first organization')
     ->json_cmp_deeply({
         (map +($_ => $organization->$_), qw(id name description)),
         created => $organization->created.'',
-        admins => $organization_data->{admins},
+        users => [
+            { (map +($_ => $org_admin->$_), qw(id name email)), role => 'admin' },
+            { (map +($_ => $org_member->$_), qw(id name email)), role => 'ro' },
+        ],
         workspaces => [],
         builds => [ +{ $build->%{qw(id name description)}, role => 'ro' } ],
     });

--- a/t/integration/crud/organization.t
+++ b/t/integration/crud/organization.t
@@ -906,7 +906,7 @@ $t->delete_ok('/organization/foo')
 
 $t->delete_ok('/organization/our second organization')
     ->status_is(204)
-    ->log_debug_is('Deactivated organization our second organization, removing 1 user memberships and removing from 0 workspaces');
+    ->log_debug_is('Deactivated organization our second organization, removing 1 user memberships and removing from 0 workspaces and 0 builds');
 
 $t->get_ok('/organization')
     ->status_is(200)
@@ -915,7 +915,7 @@ $t->get_ok('/organization')
 
 $t->delete_ok('/organization/my first organization')
     ->status_is(204)
-    ->log_debug_is('Deactivated organization my first organization, removing 2 user memberships and removing from 2 workspaces');
+    ->log_debug_is('Deactivated organization my first organization, removing 2 user memberships and removing from 2 workspaces and 0 builds');
 
 $t->get_ok('/organization')
     ->status_is(200)

--- a/t/integration/crud/organization.t
+++ b/t/integration/crud/organization.t
@@ -73,6 +73,7 @@ $t->get_ok($t->tx->res->headers->location)
             { map +($_ => $admin_user->$_), qw(id name email) },
         ],
         workspaces => [],
+        builds => [],
     });
 my $organization = $t->tx->res->json;
 
@@ -113,6 +114,7 @@ $t->get_ok('/organization')
                 { map +($_ => $admin_user->$_), qw(id name email) },
             ],
             workspaces => [],
+            builds => [],
         },
     ]);
 my $organization2 = $t->tx->res->json->[1];
@@ -459,6 +461,7 @@ $t2->get_ok('/organization/my first organization')
                 role => 'ro',
             },
         ],
+        builds => [],
     });
 
 $t2->get_ok('/organization')
@@ -474,6 +477,7 @@ $t2->get_ok('/organization')
                     role => 'ro',
                 },
             ],
+            builds => [],
         },
         # user is not a member of organization2
     ]);
@@ -494,6 +498,7 @@ $t->get_ok('/user/'.$admin_user->email)
                 role_via_organization_id => $organization->{id},
             },
         ],
+        builds => [],
     }));
 
 $t->get_ok('/user/'.$new_user->email)
@@ -511,6 +516,7 @@ $t->get_ok('/user/'.$new_user->email)
                 role_via_organization_id => $organization->{id},
             },
         ],
+        builds => [],
     }));
 
 $t2->get_ok('/user/me')
@@ -529,6 +535,7 @@ $t2->get_ok('/user/me')
                 role_via_organization_id => $organization->{id},
             },
         ],
+        builds => [],
     }));
 
 my $grandchild_ws = $t->generate_fixtures('workspace', { parent_workspace_id => $sub_ws->id, name => 'grandchild ws' });
@@ -595,6 +602,7 @@ $t->get_ok('/user/'.$new_user->email)
                 role_via_workspace_id => $sub_ws->id,
             },
         ],
+        builds => [],
     }));
 
 $t2->get_ok('/user/me')
@@ -619,6 +627,7 @@ $t2->get_ok('/user/me')
                 role_via_workspace_id => $sub_ws->id,
             },
         ],
+        builds => [],
     }));
 
 $t->get_ok('/workspace/'.$sub_ws->id.'/user')

--- a/t/integration/crud/workspace.t
+++ b/t/integration/crud/workspace.t
@@ -153,10 +153,13 @@ subtest 'Workspaces' => sub {
         ->json_schema_is('UsersDetailed')
         ->json_is('/0/email' => $admin_user->email)
         ->json_is('/0/workspaces' => [ $workspace_data{admin_user}[0] ])
+        ->json_is('/0/builds' => [])
         ->json_is('/1/email' => $super_user->email)
         ->json_is('/1/workspaces' => [])
+        ->json_is('/1/builds' => [])
         ->json_is('/2/email' => 'test_user@conch.joyent.us')
-        ->json_is('/2/workspaces' => [ $workspace_data{test_user}[0] ]);
+        ->json_is('/2/workspaces' => [ $workspace_data{test_user}[0] ])
+        ->json_is('/2/builds' => []);
 
     push $users{GLOBAL}->@*, {
         id    => re(Conch::UUID::UUID_FORMAT),


### PR DESCRIPTION
fix: add builds to user and organization lists
That is, for:
* GET /user
* GET /user/:identifier
* GET /organization
* GET /organization/:identifier

Return all users with organization data.
That is, in GET /organization and GET /organization/:id_or_name.
GET /organization/:id_or_name/users is now redundant and has been removed.
    
closes #897, #898.
