### PR TITLE
backfill some validation_results to ensure uniqueness

### DIFF
--- a/sql/migrations/0129-validation_result-result_order.sql
+++ b/sql/migrations/0129-validation_result-result_order.sql
@@ -1,5 +1,26 @@
 SELECT run_migration(129, $$
 
+    -- these are the two validation modules that can produce duplicate
+    -- results, with the exception of the result_order.  For cpu_temperature
+    -- at least, we can infer the component value; for switch_peers we cannot
+    -- as there are multiple sections of result generation, which can fire in
+    -- an unpredictable order due to hash ordering of the 'interface' section
+    -- of the device report.
+    update validation_result
+        set component='cpu'||result_order
+        from validation
+        where validation_result.validation_id = validation.id
+            and validation.name = 'cpu_temperature'
+            and validation_result.component is null;
+
+    update validation_result
+        set component='unknown'||result_order
+        from validation
+        where validation_result.validation_id = validation.id
+            and validation.name = 'switch_peers'
+            and validation_result.component is null;
+
+
     alter table validation_state_member
         add column result_order integer default 0 not null check (result_order >= 0);
 


### PR DESCRIPTION
...otherwise merge_validation_results will experience unique constraint
violatiosn when collapsing multiple validation_result rows together in the
same validation_state, because CpuTemperature and SwitchPeers did not store
sufficient unique data in their results.

These new update queries should be run manually on existing conch-v3 systems
before running merge_validation_results; otherwise (on v2->v3 migrations) the
update will happen at the right time, even though it will make this migration
run even longer than before (18+hrs on edge)

this should fix #901.