### PR TITLE
v3: associate hardware_product with validation_plan

### DIFF
--- a/docs/json-schema/request.json
+++ b/docs/json-schema/request.json
@@ -368,7 +368,8 @@
             "alias",
             "hardware_vendor_id",
             "sku",
-            "rack_unit_size"
+            "rack_unit_size",
+            "validation_plan_id"
           ]
         },
         {
@@ -666,6 +667,9 @@
               "type" : "null"
             }
           ]
+        },
+        "validation_plan_id" : {
+          "$ref" : "common.json#/definitions/uuid"
         }
       },
       "type" : "object"

--- a/docs/json-schema/response.json
+++ b/docs/json-schema/response.json
@@ -1344,6 +1344,9 @@
         "updated" : {
           "format" : "date-time",
           "type" : "string"
+        },
+        "validation_plan_id" : {
+          "$ref" : "common.json#/definitions/uuid"
         }
       },
       "required" : [
@@ -1359,7 +1362,8 @@
         "rack_unit_size",
         "hardware_product_profile",
         "created",
-        "updated"
+        "updated",
+        "validation_plan_id"
       ],
       "type" : "object"
     },

--- a/docs/modules/Conch::Controller::DeviceReport.md
+++ b/docs/modules/Conch::Controller::DeviceReport.md
@@ -40,11 +40,6 @@ Process a device report without writing anything to the database; otherwise beha
 
 Response uses the ReportValidationResults json schema.
 
-## \_get\_validation\_plan
-
-Find the validation plan that should be used to validate the device referenced by the
-report.
-
 # LICENSING
 
 Copyright Joyent, Inc.

--- a/docs/modules/Conch::DB::Result::HardwareProduct.md
+++ b/docs/modules/Conch::DB::Result::HardwareProduct.md
@@ -107,6 +107,15 @@ data_type: 'integer'
 is_nullable: 0
 ```
 
+## validation\_plan\_id
+
+```
+data_type: 'uuid'
+is_foreign_key: 1
+is_nullable: 0
+size: 16
+```
+
 # PRIMARY KEY
 
 - ["id"](#id)
@@ -136,6 +145,12 @@ Related object: [Conch::DB::Result::HardwareVendor](../modules/Conch::DB::Result
 Type: has\_many
 
 Related object: [Conch::DB::Result::RackLayout](../modules/Conch::DB::Result::RackLayout)
+
+## validation\_plan
+
+Type: belongs\_to
+
+Related object: [Conch::DB::Result::ValidationPlan](../modules/Conch::DB::Result::ValidationPlan)
 
 ## validation\_results
 

--- a/docs/modules/Conch::DB::Result::ValidationPlan.md
+++ b/docs/modules/Conch::DB::Result::ValidationPlan.md
@@ -53,6 +53,12 @@ is_nullable: 1
 
 # RELATIONS
 
+## hardware\_products
+
+Type: has\_many
+
+Related object: [Conch::DB::Result::HardwareProduct](../modules/Conch::DB::Result::HardwareProduct)
+
 ## validation\_plan\_members
 
 Type: has\_many

--- a/docs/modules/Conch::Validation.md
+++ b/docs/modules/Conch::Validation.md
@@ -112,10 +112,8 @@ location.
 
 ## hardware\_product
 
-The expected [Conch::DB::Result::HardwareProduct](../modules/Conch::DB::Result::HardwareProduct) object for the device being validated.
-Note that this is **either** the hardware\_product associated with the rack and slot the device
-is located in, **or** the hardware\_product associated with the device itself (when the device is
-not located in a rack yet). When this distinction is important, check ["has\_device\_location"](#has_device_location).
+The [Conch::DB::Result::HardwareProduct](../modules/Conch::DB::Result::HardwareProduct) object for the device being validated
+(originally determined by the sku reported for the device).
 
 Any additional data related to hardware\_products may be read as normal using [DBIx::Class](https://metacpan.org/pod/DBIx::Class)
 interfaces.  The result object is built using a read-only database handle, so attempts to alter

--- a/docs/modules/Conch::ValidationSystem.md
+++ b/docs/modules/Conch::ValidationSystem.md
@@ -31,12 +31,12 @@ This method is poorly-named: it should be 'create\_validations'.
 
 ## update\_validation\_plans
 
-Deactivate and/or create validation records for all validation modules currently present,
-then deactivates and creates new validation plans to reference the newest versions of the
-validations it already had as members.
+Deactivate and/or create validation records for all validation modules currently present, then
+updates validation plan membership to reference the newest versions of the validations it
+previously had as members.
 
 That is: does whatever is necessary after a code deployment to ensure that validation plans
-of the same name continue to run validations pointing to the same code modules.
+continue to run validations pointing to the same code modules.
 
 ## run\_validation\_plan
 

--- a/docs/modules/Test::Conch.md
+++ b/docs/modules/Test::Conch.md
@@ -90,12 +90,14 @@ data.
 ## load\_validation\_plans
 
 Takes an array ref of structured hash refs and creates a validation plan (if it doesn't
-exist) and adds specified validation plans for each of the structured hashes.
+exist, or updates an existing entry otherwise) and adds specified validation plans for each of
+the structured hashes.
 
 Each hash has the structure:
 
 ```
 {
+    id          => optional, if existing row should be updated
     name        => 'Validation plan name',
     description => 'Validation plan description',
     validations => [
@@ -105,7 +107,7 @@ Each hash has the structure:
 }
 ```
 
-If a validation plan by the name already exists, all associations to
+If a validation plan by the same id or name already exists, all associations to
 validations are dropped before the specified validations are added. This allows
 modifying the membership of the validation plans.
 

--- a/json-schema/request.yaml
+++ b/json-schema/request.yaml
@@ -234,6 +234,7 @@ definitions:
         - hardware_vendor_id
         - sku
         - rack_unit_size
+        - validation_plan_id
       - type: object
         properties:
           hardware_product_profile:
@@ -363,6 +364,8 @@ definitions:
         $ref: common.yaml#/definitions/positive_integer
       hardware_product_profile:
         $ref: /definitions/HardwareProductProfileUpdate
+      validation_plan_id:
+        $ref: common.yaml#/definitions/uuid
   HardwareProductProfileCreate:
     allOf:
       - $ref: /definitions/HardwareProductProfileUpdate

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -679,6 +679,7 @@ definitions:
       - hardware_product_profile
       - created
       - updated
+      - validation_plan_id
     properties:
       id:
         $ref: common.yaml#/definitions/uuid
@@ -721,6 +722,8 @@ definitions:
       updated:
         type: string
         format: date-time
+      validation_plan_id:
+        $ref: common.yaml#/definitions/uuid
   HardwareProductProfile:
     type: object
     additionalProperties: false

--- a/lib/Conch/Controller/DeviceReport.pm
+++ b/lib/Conch/Controller/DeviceReport.pm
@@ -389,6 +389,11 @@ sub validate_report ($c) {
     return $c->status(409, { error => 'Hardware product does not contain a profile' })
         if not $c->db_hardware_product_profiles->active->search({ hardware_product_id => $hardware_product_id })->exists;
 
+    if (my $current_hardware_product_id = $c->db_devices->search({ serial_number => $unserialized_report->{serial_number} })->get_column('hardware_product_id')->single) {
+        return $c->status(409, { error => 'Report sku does not match expected hardware_product for device '.$unserialized_report->{serial_number} })
+            if $current_hardware_product_id ne $hardware_product_id;
+    }
+
     my $validation_plan = $c->_get_validation_plan($unserialized_report);
     return $c->status(422, { error => 'failed to find validation plan' }) if not $validation_plan;
     $c->log->debug('Running validation plan '.$validation_plan->id.': '.$validation_plan->name.'"');

--- a/lib/Conch/DB/Result/HardwareProduct.pm
+++ b/lib/Conch/DB/Result/HardwareProduct.pm
@@ -101,6 +101,13 @@ __PACKAGE__->table("hardware_product");
   data_type: 'integer'
   is_nullable: 0
 
+=head2 validation_plan_id
+
+  data_type: 'uuid'
+  is_foreign_key: 1
+  is_nullable: 0
+  size: 16
+
 =cut
 
 __PACKAGE__->add_columns(
@@ -145,6 +152,8 @@ __PACKAGE__->add_columns(
   { data_type => "text", is_nullable => 1 },
   "rack_unit_size",
   { data_type => "integer", is_nullable => 0 },
+  "validation_plan_id",
+  { data_type => "uuid", is_foreign_key => 1, is_nullable => 0, size => 16 },
 );
 
 =head1 PRIMARY KEY
@@ -221,6 +230,21 @@ __PACKAGE__->has_many(
   { cascade_copy => 0, cascade_delete => 0 },
 );
 
+=head2 validation_plan
+
+Type: belongs_to
+
+Related object: L<Conch::DB::Result::ValidationPlan>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "validation_plan",
+  "Conch::DB::Result::ValidationPlan",
+  { id => "validation_plan_id" },
+  { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
+);
+
 =head2 validation_results
 
 Type: has_many
@@ -238,7 +262,7 @@ __PACKAGE__->has_many(
 
 
 # Created by DBIx::Class::Schema::Loader v0.07049
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:m2umWpjs1iSUxb8ry8FKDg
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:XBj+kJeR/2QEgJOvSdhMHw
 
 use experimental 'signatures';
 

--- a/lib/Conch/DB/Result/ValidationPlan.pm
+++ b/lib/Conch/DB/Result/ValidationPlan.pm
@@ -96,6 +96,21 @@ __PACKAGE__->set_primary_key("id");
 
 =head1 RELATIONS
 
+=head2 hardware_products
+
+Type: has_many
+
+Related object: L<Conch::DB::Result::HardwareProduct>
+
+=cut
+
+__PACKAGE__->has_many(
+  "hardware_products",
+  "Conch::DB::Result::HardwareProduct",
+  { "foreign.validation_plan_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
 =head2 validation_plan_members
 
 Type: has_many
@@ -138,7 +153,7 @@ __PACKAGE__->many_to_many("validations", "validation_plan_members", "validation"
 
 
 # Created by DBIx::Class::Schema::Loader v0.07049
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:pY3RQbK9VIIedyEO0h1hnw
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:8Va+mP/1Ujni4L+AHcEtfA
 
 __PACKAGE__->add_columns(
     '+deactivated' => { is_serializable => 0 },

--- a/lib/Conch/Validation.pm
+++ b/lib/Conch/Validation.pm
@@ -172,10 +172,8 @@ sub has_device_location ($self) {
 
 =head2 hardware_product
 
-The expected L<Conch::DB::Result::HardwareProduct> object for the device being validated.
-Note that this is B<either> the hardware_product associated with the rack and slot the device
-is located in, B<or> the hardware_product associated with the device itself (when the device is
-not located in a rack yet). When this distinction is important, check L</has_device_location>.
+The L<Conch::DB::Result::HardwareProduct> object for the device being validated
+(originally determined by the sku reported for the device).
 
 Any additional data related to hardware_products may be read as normal using L<DBIx::Class>
 interfaces.  The result object is built using a read-only database handle, so attempts to alter
@@ -233,11 +231,7 @@ has hardware_product => (
     isa => InstanceOf['Conch::DB::Result::HardwareProduct'],
     lazy => 1,
     default => sub ($self) {
-        my $device = $self->device;
-        my $device_location = $device->device_location;
-        $device_location
-          ? $device_location->rack_layout->hardware_product
-          : $device->hardware_product;
+        $self->device->hardware_product;
     },
     handles => {
         hardware_product_name => 'name',

--- a/lib/Conch/ValidationSystem.pm
+++ b/lib/Conch/ValidationSystem.pm
@@ -64,7 +64,8 @@ sub check_validation_plan ($self, $validation_plan) {
     foreach my $validation ($validation_plan->validations) {
         if ($validation->deactivated) {
             $self->log->warn('validation id '.$validation->id
-                .' "'.$validation->name.'" is inactive but is referenced by an active plan ("'
+                .' "'.$validation->name.'" version '.$validation->version
+                .' is inactive but is referenced by an active plan ("'
                 .$validation_plan->name.'")');
             next;
         }

--- a/lib/Conch/ValidationSystem.pm
+++ b/lib/Conch/ValidationSystem.pm
@@ -215,82 +215,56 @@ sub load_validations ($self) {
 
 =head2 update_validation_plans
 
-Deactivate and/or create validation records for all validation modules currently present,
-then deactivates and creates new validation plans to reference the newest versions of the
-validations it already had as members.
+Deactivate and/or create validation records for all validation modules currently present, then
+updates validation plan membership to reference the newest versions of the validations it
+previously had as members.
 
 That is: does whatever is necessary after a code deployment to ensure that validation plans
-of the same name continue to run validations pointing to the same code modules.
+continue to run validations pointing to the same code modules.
 
 =cut
 
 sub update_validation_plans ($self) {
     my $validation_plan_rs = $self->schema->resultset('validation_plan');
 
-    my %validation_plans_and_active_validations = map +(
-        $_->name => {
-            description => $_->description,
-            validation_modules => [
-                map $_->module,
-                grep !$_->deactivated,
-                map $_->validation,
-                $_->validation_plan_members
-            ],
-        },
-    ),
-    $validation_plan_rs->active
-        ->search({ 'validation.deactivated' => undef })
-        ->prefetch({ validation_plan_members => 'validation' });
-
     # deactivates old validation rows; creates new ones in their place
     # note that if a conflict is found, this sub will die.
     my ($num_deactivated, $num_created) = $self->load_validations;
 
-    # we don't care about new modules here, as no plans need to update unless there were also
-    # validations deactivated.
-    return unless $num_deactivated;
-
     # now get the updated list of all active validations by module name...
     my %validations = map +($_->module => $_), $self->schema->resultset('validation')->active->all;
 
-    foreach my $validation_plan_name (keys %validation_plans_and_active_validations) {
-        # these are the active validation modules that were in the plan
-        my @had_modules = $validation_plans_and_active_validations{$validation_plan_name}{validation_modules}->@*;
-        next if not @had_modules;
+    $validation_plan_rs = $validation_plan_rs
+        ->active
+        ->prefetch({ validation_plan_members => 'validation' });
 
-        my @active_modules = $validation_plan_rs
-            ->search({ 'validation_plan.name' => $validation_plan_name }, { alias => 'validation_plan' })
-            ->active
-            ->related_resultset('validation_plan_members')
-            ->related_resultset('validation')
-            ->active
-            ->distinct
-            ->get_column('module')->all;
+    while (my $plan = $validation_plan_rs->next) {
+        my (%existing_active_validations, @add_active_validations);
+        foreach my $member ($plan->validation_plan_members) {
+            my $existing_validation = $member->validation;
 
-        if (@had_modules == @active_modules) {
-            $self->log->debug('plan '.$validation_plan_name.' had '.scalar(@had_modules)
-                .' active validations and that has not changed: no updates needed');
-            next;
+            if ($existing_validation->deactivated) {
+                $self->log->info('validation plan '.$plan->name.' has a deactivated validation ('
+                    .$existing_validation->name.' version '.$existing_validation->version
+                    .'): removing');
+                $member->delete;
+
+                if (my $new_validation = $validations{$existing_validation->module}) {
+                    push @add_active_validations, $new_validation;
+                }
+            }
+            else {
+                $existing_active_validations{$existing_validation->module} = $existing_validation;
+            }
         }
 
-        $self->log->info('plan '.$validation_plan_name.' had '.scalar(@had_modules)
-            .' active validations and now has '.scalar(@active_modules).': '
-            .'deactivating the plan and replacing it with a new one containing updated validations');
-
-        $validation_plan_rs->search({
-            name => $validation_plan_name,
-            deactivated => undef,
-        })->update({ deactivated => \'now()' });
-
-        # create a new plan containing the active versions of all validations it had before
-        $validation_plan_rs->create({
-            name => $validation_plan_name,
-            description => $validation_plans_and_active_validations{$validation_plan_name}{description},
-            validation_plan_members => [
-                map +{ validation => $validations{$_} },
-                    grep exists $validations{$_}, @had_modules,
-            ],
-        });
+        # now we have a list of active validations we want.  add any that aren't already present.
+        foreach my $want_validation (@add_active_validations) {
+            next if $existing_active_validations{$want_validation->module};
+            $self->log->info('adding '.$want_validation->name.' version '
+                .$want_validation->version.' to validation plan '.$plan->name);
+            $plan->add_to_validations($want_validation);
+        }
     }
 }
 

--- a/lib/Test/Conch/Fixtures.pm
+++ b/lib/Test/Conch/Fixtures.pm
@@ -170,6 +170,7 @@ my %canned_definitions = (
         },
         requires => {
             hardware_vendor_0 => { our => 'hardware_vendor_id', their => 'id' },
+            validation_plan_basic => { our => 'validation_plan_id', their => 'id' },
         },
     },
     # this is a server, not a switch.
@@ -186,6 +187,7 @@ my %canned_definitions = (
         },
         requires => {
             hardware_vendor_0 => { our => 'hardware_vendor_id', their => 'id' },
+            validation_plan_basic => { our => 'validation_plan_id', their => 'id' },
         },
     },
     # this is a server, not a switch.
@@ -202,6 +204,7 @@ my %canned_definitions = (
         },
         requires => {
             hardware_vendor_1 => { our => 'hardware_vendor_id', their => 'id' },
+            validation_plan_basic => { our => 'validation_plan_id', their => 'id' },
         },
     },
 
@@ -275,6 +278,14 @@ my %canned_definitions = (
             # copy hardware_product_profile_compute.hardware_product_id to me.hardware_product_id
             # (this ensures we get a hardware_product_profile as well as a hardware_product)
             hardware_product_id => \'hardware_product_profile_compute',
+        },
+    },
+
+    validation_plan_basic => {
+        new => 'validation_plan',
+        using => {
+            name => 'basic validation plan',
+            description => 'whee',
         },
     },
 );
@@ -578,10 +589,11 @@ sub _generate_definition ($self, $fixture_type, $num, $specification) {
                 },
                 requires => {
                     "hardware_vendor_$num" => { our => 'hardware_vendor_id', their => 'id' },
+                    "validation_plan_$num" => { our => 'validation_plan_id', their => 'id' },
                 },
             },
         },
-        'hardware_vendor';
+        'hardware_vendor', 'validation_plan';
     }
     elsif ($fixture_type eq 'hardware_product_profile') {
         return +{
@@ -610,8 +622,8 @@ sub _generate_definition ($self, $fixture_type, $num, $specification) {
             "datacenter_room_$num" => {
                 new => 'datacenter_room',
                 using => {
-                    az => "datacenter_room_$num",
-                    alias => "room $num",
+                    az => "datacenter_room_az_$num",
+                    alias => "room alias $num",
                     ($specification // {})->%*,
                 },
                 requires => {
@@ -698,6 +710,18 @@ sub _generate_definition ($self, $fixture_type, $num, $specification) {
                 new => 'build',
                 using => {
                     name => "build_$num",
+                    ($specification // {})->%*,
+                },
+            },
+        };
+    }
+    elsif ($fixture_type eq 'validation_plan') {
+        return +{
+            "validation_plan_$num" => {
+                new => 'validation_plan',
+                using => {
+                    name => "validation_plan_$num",
+                    description => "validation_plan_$num description",
                     ($specification // {})->%*,
                 },
             },

--- a/sql/migrations/0133-hardware_product-validation_plan_id.sql
+++ b/sql/migrations/0133-hardware_product-validation_plan_id.sql
@@ -1,0 +1,60 @@
+SELECT run_migration(133, $$
+
+    alter table hardware_product add column validation_plan_id uuid
+        default null references validation_plan (id);
+
+    -- first, assert that we're not going to get into trouble later on...
+    do $inner$ begin
+        assert
+            (select count(*) from (
+                select
+                    hardware_product_id,
+                    count(distinct validation_plan_id) as count
+                    from validation_state
+                    left join device on device.id = validation_state.device_id
+                    left join validation_plan on validation_plan.id = validation_state.validation_plan_id
+                    where validation_plan.name != 'Conch device_validate results placeholder'
+                    group by hardware_product_id
+                ) tmp1
+                where count > 1)
+            = 0,
+        'validation_plan_id <-> hardware_product correlation is not 1:1';
+    end; $inner$;
+
+    -- first, backfill validation_plan_id using historical results using the
+    -- common hardware_products and the two validation_plans
+    update hardware_product
+        set validation_plan_id = validation_state.validation_plan_id
+        from device
+        inner join validation_state on validation_state.device_id = device.id
+        inner join validation_plan on validation_plan.id = validation_state.validation_plan_id
+        where device.hardware_product_id = hardware_product.id
+            and validation_plan.name != 'Conch device_validate results placeholder';
+
+    -- now fill in the remaining hardware_products, associated with devices
+    -- that only have representation in the old device_validate records that
+    -- were backfilled in the v2.24.0 release (see PR#669)
+    update hardware_product
+        set validation_plan_id = validation_state.validation_plan_id
+        from device
+        inner join validation_state on validation_state.device_id = device.id
+        where device.hardware_product_id = hardware_product.id
+            and hardware_product.validation_plan_id is null;
+
+    -- now create a placeholder validation_plan to use in all the remaining
+    -- hardware_products that have no historical validation results at all
+    with new_plan as (
+        insert into validation_plan (name, description)
+        values (
+            'Conch hardware_product.validation_plan_id placeholder',
+            'plan to link to legacy hardware_product entries (conch v2->v3 update)'
+        ) returning id
+    )
+    update hardware_product
+        set validation_plan_id = (select id from new_plan)
+        where hardware_product.validation_plan_id is null;
+
+    -- now that all rows have their validation_plan_id populated, we can set this not-nullable!
+    alter table hardware_product alter column validation_plan_id set not null;
+
+$$);

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -376,6 +376,7 @@ CREATE TABLE public.hardware_product (
     generation_name text,
     legacy_product_name text,
     rack_unit_size integer NOT NULL,
+    validation_plan_id uuid NOT NULL,
     CONSTRAINT hardware_product_rack_unit_size_check CHECK ((rack_unit_size > 0))
 );
 
@@ -1718,6 +1719,14 @@ ALTER TABLE ONLY public.device_setting
 
 ALTER TABLE ONLY public.hardware_product_profile
     ADD CONSTRAINT hardware_product_profile_product_id_fkey FOREIGN KEY (hardware_product_id) REFERENCES public.hardware_product(id) ON DELETE CASCADE;
+
+
+--
+-- Name: hardware_product hardware_product_validation_plan_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: conch
+--
+
+ALTER TABLE ONLY public.hardware_product
+    ADD CONSTRAINT hardware_product_validation_plan_id_fkey FOREIGN KEY (validation_plan_id) REFERENCES public.validation_plan(id);
 
 
 --

--- a/t/fixtures.t
+++ b/t/fixtures.t
@@ -34,6 +34,7 @@ subtest 'generate_definition' => sub {
             'datacenter_room_99',
             'hardware_product_99',
             'hardware_vendor_99',
+            'validation_plan_99',
         ),
         'generated requested fixtures, and for many supporting tables as well',
     );
@@ -73,6 +74,7 @@ subtest 'generate_fixture_definitions wrapper' => sub {
                 DatacenterRoom
                 HardwareProduct
                 HardwareVendor
+                ValidationPlan
             )
         ),
         'loaded requested fixtures into the database (and for many supporting tables as well)',

--- a/t/integration/crud/devices.t
+++ b/t/integration/crud/devices.t
@@ -11,16 +11,17 @@ use Mojo::JSON 'from_json';
 my $t = Test::Conch->new;
 $t->load_fixture_set('workspace_room_rack_layout', 0);
 
-$t->load_validation_plans([{
-    name        => 'Conch v1 Legacy Plan: Server',
-    description => 'Test Plan',
-    validations => [ 'Conch::Validation::DeviceProductName' ],
-}]);
-
 my $rack = $t->load_fixture('rack_0a');
 my $rack_id = $rack->id;
 my $hardware_product = $t->load_fixture('hardware_product_compute');
 my $global_ws = $t->load_fixture('global_workspace');
+
+$t->load_validation_plans([{
+    id          => $hardware_product->validation_plan_id,
+    name        => 'our plan',
+    description => 'Test Plan',
+    validations => [ 'Conch::Validation::DeviceProductName' ],
+}]);
 
 # perform most tests as a user with read only access to the GLOBAL workspace
 my $null_user = $t->generate_fixtures('user_account');

--- a/t/integration/crud/workspace-devices.t
+++ b/t/integration/crud/workspace-devices.t
@@ -11,7 +11,8 @@ my $t = Test::Conch->new;
 
 $t->load_fixture_set('workspace_room_rack_layout', 0);
 $t->load_validation_plans([{
-    name        => 'Conch v1 Legacy Plan: Server',
+    id          => $t->load_fixture('hardware_product_compute')->validation_plan_id,
+    name        => 'our plan',
     description => 'Test Plan',
     validations => [ 'Conch::Validation::DeviceProductName' ],
 }]);

--- a/t/integration/device-reports.t
+++ b/t/integration/device-reports.t
@@ -76,6 +76,10 @@ subtest preliminaries => sub {
         ->status_is(409)
         ->json_is({ error => 'Report sku does not match expected hardware_product for device TEST' });
 
+    $t->post_ok('/device_report', json => $report_data)
+        ->status_is(409)
+        ->json_is({ error => 'Report sku does not match expected hardware_product for device TEST' });
+
     $device->discard_changes;
     is($device->health, 'error', 'bad reports flip device health to error');
 

--- a/t/integration/device-validations.t
+++ b/t/integration/device-validations.t
@@ -25,9 +25,9 @@ my $good_report = path('t/integration/resource/passing-device-report.json')->slu
 my $error_report = path('t/integration/resource/error-device-report.json')->slurp_utf8;
 my $good_report_data = from_json($good_report);
 
-$t->load_fixture('hardware_product_profile_compute');
+my $hardware_product_profile = $t->load_fixture('hardware_product_profile_compute');
 my ($server_validation_plan) = $t->load_validation_plans([{
-    name        => 'Conch v1 Legacy Plan: Server',
+    id => $hardware_product_profile->hardware_product->validation_plan_id,
     description => 'Test Plan',
     validations => [ 'Conch::Validation::DeviceProductName' ],
 }]);

--- a/t/validation-system/check_validations.t
+++ b/t/validation-system/check_validations.t
@@ -39,7 +39,7 @@ subtest 'inactive validation in an active plan' => sub {
     is(scalar @modules, 0, 'no valid validations in this plan');
 
     $t->log_is(
-        re(qr/validation id $uuid_re "inactive validation" is inactive but is referenced by an active plan \("plan with inactive validation"\)/),
+        re(qr/validation id $uuid_re "inactive validation" version 1 is inactive but is referenced by an active plan \("plan with inactive validation"\)/),
         'logged for inactive validation',
     );
     $t->log_is(


### PR DESCRIPTION
1. look up validation plan by hardware_product, rather than hacky hardcoded heuristic

- add validation_plan_id to hardware_product, using historical validation data to
populate existing rows
- this means that we can no longer deactivate validation plans and create new
ones with the same name, and expect them to be used in place of their former
version.  we need to either update plans in place, or update references to the
plan (i.e.  hardware_product.validation_plan_id).

2. no longer use the rack_layout's hardware_product in validations, but the device's
At least for now, some parameters used in validations are stored in the
hardware_product and hardware_product_profile, and these should be consistent
with the report's sku.
    
closes #806 (see also #807).

