### PR TITLE
fix: log the same response that we are returning

### DIFF
--- a/docs/modules/Conch::Plugin::Database.md
+++ b/docs/modules/Conch::Plugin::Database.md
@@ -39,16 +39,20 @@ my $result = $c->txn_wrapper(sub ($c) {
     # many update, delete queries etc...
 });
 
-# if the result code was already set, we errored and rolled back the db...
-return if $c->res->code;
+# if the result is false, we errored and rolled back the db...
+return $c->status(400) if not $result;
 ```
 
 Wraps the provided subref in a database transaction, rolling back in case of an exception.
 Any provided arguments are passed to the sub, along with the invocant controller.
 
 If the exception is not `'rollback'` (which signals an intentional premature bailout), the
-exception will be logged, and a response will be set up as an error response with the first
-line of the exception.
+exception will be logged and stored in the stash, of which the first line will be included in
+the response if no other response is prepared (see ["status" in Conch](../modules/Conch#status)).
+
+You should **not** render a response in the subref itself, as you will have a difficult time
+figuring out afterwards whether `$c->rendered` still needs to be called or not. Instead,
+use the subref's return value to signal success.
 
 # LICENSING
 

--- a/lib/Conch.pm
+++ b/lib/Conch.pm
@@ -58,10 +58,15 @@ sub startup {
     });
 
     $self->hook(after_render => sub ($c, @args) {
+        warn 'called $c->render twice' if $c->stash->{_rendered}++;
+
         $c->tx->res->headers->add('X-Conch-API', $c->version_tag);
     });
 
     $self->helper(status => sub ($c, $code, $payload = undef) {
+        $payload //= { error => (split(/\n/, $c->stash('exception'), 2))[0] }
+            if $code >= 400 and $code < 500 and $c->stash('exception');
+
         $payload //= { error => 'Unauthorized' } if $code == 401;
         $payload //= { error => 'Forbidden' } if $code == 403;
         $payload //= { error => 'Not Found' } if $code == 404;

--- a/lib/Conch/Controller/DeviceLocation.pm
+++ b/lib/Conch/Controller/DeviceLocation.pm
@@ -85,10 +85,8 @@ sub set ($c) {
             },
             { key => 'primary' },   # only search for conflicts by device_id
         );
-    });
-
-    # if the result code was already set, we errored and rolled back the db...
-    return if $c->res->code;
+    })
+    or return $c->status(400);
 
     $c->status(303, '/device/'.$device_id.'/location');
 }

--- a/lib/Conch/Controller/HardwareProduct.pm
+++ b/lib/Conch/Controller/HardwareProduct.pm
@@ -110,7 +110,7 @@ sub create ($c) {
     });
 
     # if the result code was already set, we errored and rolled back the db..
-    return if $c->res->code;
+    return $c->status(400) if not $hardware_product;
 
     $c->log->debug('Created hardware product id '.$hardware_product->id.
         ($input->{hardware_product_profile}
@@ -154,8 +154,6 @@ sub update ($c) {
     }
 
     $c->txn_wrapper(sub ($c) {
-        $c->log->debug('start of transaction...');
-
         my $profile = delete $input->{hardware_product_profile};
         if ($profile and keys $profile->%*) {
             if (keys $profile->%*) {
@@ -177,12 +175,9 @@ sub update ($c) {
 
         $hardware_product->update({ $input->%*, updated => \'now()' }) if keys $input->%*;
         $c->log->debug('Updated hardware product '.$hardware_product->id);
-
-        $c->log->debug('transaction ended successfully');
-    });
-
-    # if the result code was already set, we errored and rolled back the db..
-    return if $c->res->code;
+        return 1;
+    })
+    or return $c->res->code(400);
 
     $c->status(303, '/hardware_product/'.$hardware_product->id);
 }

--- a/lib/Conch/Controller/Rack.pm
+++ b/lib/Conch/Controller/Rack.pm
@@ -189,10 +189,10 @@ sub overwrite_layouts ($c) {
                 ($deleted_layouts ? ('deleted '.$deleted_layouts.' rack layouts') : ()),
                 (@layouts_to_create ? ('created '.scalar(@layouts_to_create).' rack layouts') : ()),
             ).' for rack '.$c->stash('rack_id'));
-    });
 
-    # if the result code was already set, we errored and rolled back the db...
-    return if $c->res->code;
+        return 1;
+    })
+    or return $c->status(400);
 
     $c->status(303, '/rack/'.$c->stash('rack_id').'/layouts');
 }
@@ -367,7 +367,7 @@ sub set_assignment ($c) {
             }
             elsif ($entry->{device_id}) {
                 $c->log->error('no device corresponding to device id '.$entry->{device_id});
-                $c->status(404);
+                $c->res->code(404);
                 die 'rollback';
             }
             else {
@@ -389,10 +389,10 @@ sub set_assignment ($c) {
                 { key => 'primary' },   # only search for conflicts by device_id
             );
         }
-    });
 
-    # if the result code was already set, we errored and rolled back the db...
-    return if $c->res->code;
+        return 1;
+    })
+    or return $c->status($c->res->code // 400);
 
     $c->log->debug('Updated device assignments for rack '.$c->stash('rack_id'));
     $c->status(303, '/rack/'.$c->stash('rack_id').'/assignment');

--- a/t/database.t
+++ b/t/database.t
@@ -145,15 +145,16 @@ subtest 'transactions' => sub {
     $r->get(
         '/_test_txn_wrapper2',
         sub ($c) {
-            $c->txn_wrapper(sub ($my_c, $id) {
+            my $user = $c->txn_wrapper(sub ($my_c, $id) {
                 $my_c->db_user_accounts->create({
                     id => $id,
                     name => 'new user',
                     email => 'foo@bar',
                     password => 'foo',
                 });
-                $my_c->status(204);
             }, $c->req->query_params->param('id'));
+
+            $c->status($user ? 204 : 400);
         },
     );
 

--- a/t/integration/device-reports.t
+++ b/t/integration/device-reports.t
@@ -444,7 +444,7 @@ subtest 'system_uuid collisions' => sub {
 
     $t->post_ok('/device/i_was_here_first', json => $report_data)
         ->status_is(400)
-        ->json_cmp_deeply({ error => re(qr/could not process report for device i_was_here_first.*duplicate key value violates unique constraint "device_system_uuid_key"/) });
+        ->json_cmp_deeply({ error => re(qr/^could not process report for device i_was_here_first.*duplicate key value violates unique constraint "device_system_uuid_key"/) });
 
     $existing_device->discard_changes;
     is($existing_device->health, 'error', 'bad reports flip device health to error');


### PR DESCRIPTION
This discrepancy occurred in places where $c->status(..) or $c->rendered(..)
was called more than once in a dispatch cycle. The after_dispatch hook is only
called once, for the first call, but what is returned in the response reflects
the last call.

- refactor the txn_wrapper helper to not actually render a response, but just
use the return value to signal the outcome; the inclusion of the first line of
the exception in the response has moved to the status helper

- also added a check in the after_render hook to ensure this does not happen again.