### PR TITLE
v3: endpoint proxy caching

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -51,6 +51,8 @@ requires 'Session::Token';
 requires 'Sys::Hostname';
 requires 'Sub::Install';
 requires 'WebService::Rollbar::Notifier';
+requires 'Digest::SHA';
+requires 'Digest::MD5';
 
 # debugging aids
 requires 'Data::Printer', '0.99_019', dist => 'GARU/Data-Printer-0.99_019.tar.gz';

--- a/docs/modules/Conch.md
+++ b/docs/modules/Conch.md
@@ -24,6 +24,10 @@ and therefore other helpers).
 
 Helper method for setting the response status code and json content.
 
+## startup\_time
+
+Stores a [Conch::Time](../modules/Conch::Time) instance representing the time the server started accepting requests.
+
 # LICENSING
 
 Copyright Joyent, Inc.

--- a/docs/modules/Conch::Controller::Device.md
+++ b/docs/modules/Conch::Controller::Device.md
@@ -16,6 +16,12 @@ continue.
 
 Retrieves details about a single device. Response uses the DetailedDevice json schema.
 
+**Note:** The results of this endpoint can be cached, but since the checksum is based only on
+the device's last updated time, and not on any other components associated with it (disks,
+network interfaces, location etc) it is only suitable for using to determine if a subsequent
+device report has been submitted for this device. Updates to the device through other means may
+not be reflected in the checksum.
+
 ## lookup\_by\_other\_attribute
 
 Looks up one or more devices by query parameter. Supports:

--- a/lib/Conch.pm
+++ b/lib/Conch.pm
@@ -151,6 +151,15 @@ Helper method for setting the response status code and json content.
     $self->plugin(NYTProf => $self->config) if $self->feature('nytprof');
     $self->plugin('Conch::Plugin::Rollbar', $self->config) if $self->feature('rollbar');
 
+=head2 startup_time
+
+Stores a L<Conch::Time> instance representing the time the server started accepting requests.
+
+=cut
+
+    my $startup_time = Conch::Time->now;
+    $self->helper(startup_time => sub ($c) { $startup_time });
+
     push $self->commands->namespaces->@*, 'Conch::Command';
 
     Conch::ValidationSystem->new(log => $self->log, schema => $self->ro_schema)

--- a/lib/Conch/Controller/Login.pm
+++ b/lib/Conch/Controller/Login.pm
@@ -55,6 +55,10 @@ subsequent routes and actions.
 =cut
 
 sub authenticate ($c) {
+    # ensure that responses from authenticated endpoints are not cached by a proxy without
+    # first verifying their contents (and the user's authentication!) with the api
+    $c->tx->res->headers->cache_control('no-cache');
+
     if (my $user = $c->stash('user')) {
         $c->log->debug('already authenticated (user '.$user->name.')');
         return 1;

--- a/lib/Conch/Controller/Schema.pm
+++ b/lib/Conch/Controller/Schema.pm
@@ -19,6 +19,12 @@ Get the json-schema in JSON format.
 =cut
 
 sub get ($c) {
+    # set Last-Modified header; return 304 if If-Modified-Since is recent enough.
+    # For now, just use the server start time. We could do something more sophisticated with
+    # the timestamps on the schema file(s), but this is fiddly and involves following all $refs
+    # to see what files they came from.
+    return $c->status(304) if $c->is_fresh(last_modified => $c->startup_time->epoch);
+
     my $type = $c->stash('schema_type');
     my $name = camelize $c->stash('name');
 

--- a/lib/Conch/Route.pm
+++ b/lib/Conch/Route.pm
@@ -66,7 +66,10 @@ sub all_routes (
     $root->get('/ping', sub ($c) { $c->status(200, { status => 'ok' }) });
 
     # GET /version
-    $root->get('/version', sub ($c) { $c->status(200, { version => $c->version_tag }) });
+    $root->get('/version', sub ($c) {
+        $c->res->headers->last_modified(Mojo::Date->new($c->startup_time->epoch));
+        $c->status(200, { version => $c->version_tag })
+    });
 
     # POST /login
     $root->post('/login')->to('login#session_login');

--- a/t/integration/unsecured-endpoints.t
+++ b/t/integration/unsecured-endpoints.t
@@ -21,6 +21,7 @@ $t->get_ok('/me')->status_is(401);
 
 $t->get_ok('/version')
     ->status_is(200)
+    ->header_is('Last-Modified', $t->app->startup_time->strftime('%a, %d %b %Y %T GMT'))
     ->json_schema_is('Version')
     ->json_cmp_deeply({ version => re(qr/^v/) });
 

--- a/t/schema.t
+++ b/t/schema.t
@@ -292,6 +292,24 @@ $t->get_ok('/schema/REQUEST/hello')
 $t->get_ok('/schema/request/hello')
     ->status_is(404);
 
+$t->get_ok('/schema/response/Ping' => { 'If-Modified-Since' => 'Sun, 01 Jan 2040 00:00:00 GMT' })
+    ->header_is('Last-Modified', $t->app->startup_time->strftime('%a, %d %b %Y %T GMT'))
+    ->status_is(304);
+
+$t->get_ok('/schema/response/Ping' => { 'If-Modified-Since' => 'Sun, 01 Jan 2006 00:00:00 GMT' })
+    ->header_is('Last-Modified', $t->app->startup_time->strftime('%a, %d %b %Y %T GMT'))
+    ->status_is(200)
+    ->json_schema_is($json_spec_schema)
+    ->json_cmp_deeply({
+        '$schema' => 'http://json-schema.org/draft-07/schema#',
+        '$id' => 'urn:response.Ping.schema.json',
+        title => 'Ping',
+        type => 'object',
+        additionalProperties => bool(0),
+        required => ['status'],
+        properties => { status => { const => 'ok' } },
+    });
+
 $t->get_ok('/schema/response/Login')
     ->status_is(200)
     ->json_schema_is($json_spec_schema)


### PR DESCRIPTION
Adds basic caching support for some endpoints:

* `GET /version` and `GET /schema/*` endpoint responses include a `Last-Modified` header (and check `If-Modified-Since` to allow for nginx to cache these responses)
*  `GET /device/:id_or_serial` responses include an `ETag` header (and check `If-None-Match` to allow for repeated polling while waiting for updates from reports -- see https://github.com/joyent/conch-ui/issues/146 and https://github.com/joyent/buildops-infra/issues/103)