### PR TITLE
v3: resource access fixes

### DIFF
--- a/docs/modules/Conch::Controller::Build.md
+++ b/docs/modules/Conch::Controller::Build.md
@@ -101,14 +101,14 @@ Adds the specified device to the build (as long as it isn't in another build, or
 rack in another build).  The device is created if necessary with all data provided (or updated
 with the data if it already exists, so the endpoint is idempotent).
 
-Requires the 'read/write' role on the build.
+Requires the 'read/write' role on the build, and the 'read-only' role on the device.
 
 ## add\_device
 
 Adds the specified device to the build (as long as it isn't in another build, or located in a
 rack in another build).
 
-Requires the 'read/write' role on the build.
+Requires the 'read/write' role on the build, and the 'read-only' role on the device.
 
 ## remove\_device
 

--- a/docs/modules/Conch::Route::Build.md
+++ b/docs/modules/Conch::Route::Build.md
@@ -82,7 +82,8 @@ an email to the organization members and build admins.
 
 ### `POST /build/:build_id_or_name/device`
 
-- Requires system admin authorization, or the read/write role on the build.
+- Requires system admin authorization, or the read/write role on the build and the
+read-only role on the device.
 - Request: [request.json#/definitions/BuildCreateDevice](../json-schema/request.json#/definitions/BuildCreateDevice)
 - Response: `204 NO CONTENT`
 

--- a/lib/Conch/Controller/Build.pm
+++ b/lib/Conch/Controller/Build.pm
@@ -97,9 +97,18 @@ sub find_build ($c) {
 
     return $c->status(404) if not $rs->exists;
 
-    my $requires_role = $c->stash('require_role') // 'admin';
-    if (not $c->is_system_admin
-            and not $rs->user_has_role($c->stash('user_id'), $requires_role)) {
+    CHECK_ACCESS: {
+        if ($c->is_system_admin) {
+            $c->log->debug('User has system admin access to build '.$identifier);
+            last CHECK_ACCESS;
+        }
+
+        my $requires_role = $c->stash('require_role') // 'admin';
+        if ($rs->user_has_role($c->stash('user_id'), $requires_role)) {
+            $c->log->debug('User has '.$requires_role.' access to build '.$identifier.' via role entry');
+            last CHECK_ACCESS;
+        }
+
         $c->log->debug('User lacks the required role ('.$requires_role.') for build '.$identifier);
         return $c->status(403);
     }

--- a/lib/Conch/Controller/Build.pm
+++ b/lib/Conch/Controller/Build.pm
@@ -592,7 +592,7 @@ Adds the specified device to the build (as long as it isn't in another build, or
 rack in another build).  The device is created if necessary with all data provided (or updated
 with the data if it already exists, so the endpoint is idempotent).
 
-Requires the 'read/write' role on the build.
+Requires the 'read/write' role on the build, and the 'read-only' role on the device.
 
 =cut
 
@@ -692,7 +692,7 @@ sub create_and_add_devices ($c) {
 Adds the specified device to the build (as long as it isn't in another build, or located in a
 rack in another build).
 
-Requires the 'read/write' role on the build.
+Requires the 'read/write' role on the build, and the 'read-only' role on the device.
 
 =cut
 

--- a/lib/Conch/Controller/DeviceSettings.pm
+++ b/lib/Conch/Controller/DeviceSettings.pm
@@ -34,7 +34,7 @@ sub set_all ($c) {
     # 'rw' already checked by find_device
     if ($requires_role eq 'admin'
             and not $c->is_system_admin
-            and not $c->stash('device_rs')->devices_without_location->exists
+            and not $c->stash('device_rs')->devices_reported_by_user_relay($c->stash('user_id'))->exists
             and not $c->stash('device_rs')->user_has_role($c->stash('user_id'), $requires_role)) {
         $c->log->debug('User lacks the required role ('.$requires_role.') for device '.$c->stash('device_id'));
         return $c->status(403);
@@ -82,7 +82,7 @@ sub set_single ($c) {
     # 'rw' already checked by find_device
     if ($requires_role eq 'admin'
             and not $c->is_system_admin
-            and not $c->stash('device_rs')->devices_without_location->exists
+            and not $c->stash('device_rs')->devices_reported_by_user_relay($c->stash('user_id'))->exists
             and not $c->stash('device_rs')->user_has_role($c->stash('user_id'), $requires_role)) {
         $c->log->debug('User lacks the required role ('.$requires_role.') for device '.$c->stash('device_id'));
         return $c->status(403);
@@ -143,7 +143,7 @@ sub delete_single ($c) {
     # 'rw' already checked by find_device
     if ($requires_role eq 'admin'
             and not $c->is_system_admin
-            and not $c->stash('device_rs')->devices_without_location->exists
+            and not $c->stash('device_rs')->devices_reported_by_user_relay($c->stash('user_id'))->exists
             and not $c->stash('device_rs')->user_has_role($c->stash('user_id'), $requires_role)) {
         $c->log->debug('User lacks the required role ('.$requires_role.') for device '.$c->stash('device_id'));
         return $c->status(403);

--- a/lib/Conch/DB/ResultSet/Device.pm
+++ b/lib/Conch/DB/ResultSet/Device.pm
@@ -89,8 +89,7 @@ sub user_has_role ($self, $user_id, $role) {
         ->search_related('user_organization_roles', { user_id => $user_id })
         ->related_resultset('user_account');
 
-    my $has_rack_role = $via_user_rs->union_all($via_org_rs)->exists;
-    return $has_rack_role if $has_rack_role;
+    return 1 if $via_user_rs->union_all($via_org_rs)->exists;
 
     # this checks:
     # device -> rack -> workspace -> user_workspace_role -> user

--- a/lib/Conch/Route/Build.pm
+++ b/lib/Conch/Route/Build.pm
@@ -238,7 +238,8 @@ an email to the organization members and build admins.
 
 =over 4
 
-=item * Requires system admin authorization, or the read/write role on the build.
+=item * Requires system admin authorization, or the read/write role on the build and the
+read-only role on the device.
 
 =item * Request: F<request.yaml#/definitions/BuildCreateDevice>
 

--- a/t/integration/crud/build.t
+++ b/t/integration/crud/build.t
@@ -77,13 +77,15 @@ $t->get_ok($t->tx->res->headers->location)
             { map +($_ => $admin_user->$_), qw(id name email) },
         ],
         completed_user => undef,
-    });
+    })
+    ->log_debug_is('User has system admin access to build '.$t->tx->res->json->{id});
 my $build = $t->tx->res->json;
 
 $t->get_ok('/build/my first build')
     ->status_is(200)
     ->json_schema_is('Build')
-    ->json_is($build);
+    ->json_is($build)
+    ->log_debug_is('User has system admin access to build my first build');
 
 $t->get_ok('/build')
     ->status_is(200)
@@ -253,10 +255,11 @@ $t2->get_ok('/build')
     ->json_schema_is('Builds')
     ->json_is([ $build ]);
 
-$t->get_ok('/build/my first build')
+$t2->get_ok('/build/my first build')
     ->status_is(200)
     ->json_schema_is('Build')
-    ->json_is($build);
+    ->json_is($build)
+    ->log_debug_is('User has ro access to build my first build via role entry');
 
 $t2->post_ok('/build/my first build', json => { description => 'I hate this build' })
     ->status_is(403)
@@ -363,6 +366,7 @@ $t_build_admin->post_ok('/build/'.$build->{id}.'/user', json => {
         role => 'ro',
     })
     ->status_is(204)
+    ->log_debug_is('User has admin access to build '.$build->{id}.' via role entry')
     ->log_info_is('Added user '.$new_user2->id.' ('.$new_user2->name.') to build '.$build->{id}.' with the ro role')
     ->email_cmp_deeply([
         {


### PR DESCRIPTION
fix: permission checks for unlocated devices in a build
    
It used to be that we could only do a specific role check for devices that had
a location, but now devices can be location-less and still allow a user to
have a specific role, via user -> build -> device.