### PR TITLE
v3: respect device phases

### DIFF
--- a/docs/json-schema/response.json
+++ b/docs/json-schema/response.json
@@ -846,7 +846,6 @@
       "uniqueItems" : true
     },
     "DeviceLocation" : {
-      "$comment" : "location should not be considered canonical when device 'phase' is 'production' or later",
       "additionalProperties" : false,
       "properties" : {
         "datacenter" : {

--- a/docs/json-schema/response.json
+++ b/docs/json-schema/response.json
@@ -267,6 +267,38 @@
     },
     "DetailedDevice" : {
       "additionalProperties" : false,
+      "else" : {
+        "not" : {
+          "anyOf" : [
+            {
+              "required" : [
+                "location"
+              ]
+            },
+            {
+              "required" : [
+                "nics"
+              ]
+            },
+            {
+              "required" : [
+                "disks"
+              ]
+            }
+          ]
+        }
+      },
+      "if" : {
+        "properties" : {
+          "phase" : {
+            "enum" : [
+              "integration",
+              "installation"
+            ],
+            "type" : "string"
+          }
+        }
+      },
       "properties" : {
         "asset_tag" : {
           "oneOf" : [
@@ -293,6 +325,7 @@
           "type" : "string"
         },
         "disks" : {
+          "$comment" : "disks is included only when device 'phase' is earlier than 'production'",
           "items" : {
             "additionalProperties" : false,
             "properties" : {
@@ -484,6 +517,7 @@
           "uniqueItems" : true
         },
         "location" : {
+          "$comment" : "location is included only when device 'phase' is earlier than 'production'",
           "oneOf" : [
             {
               "$ref" : "/definitions/DeviceLocation"
@@ -494,6 +528,7 @@
           ]
         },
         "nics" : {
+          "$comment" : "nics is included only when device 'phase' is earlier than 'production'",
           "items" : {
             "additionalProperties" : false,
             "properties" : {
@@ -612,15 +647,46 @@
         "phase",
         "links",
         "build_id",
-        "location",
-        "nics",
-        "disks",
         "latest_report"
       ],
+      "then" : {
+        "required" : [
+          "location",
+          "nics",
+          "disks"
+        ]
+      },
       "type" : "object"
     },
     "Device" : {
       "additionalProperties" : false,
+      "else" : {
+        "not" : {
+          "anyOf" : [
+            {
+              "required" : [
+                "rack_id"
+              ]
+            },
+            {
+              "required" : [
+                "rack_unit_start"
+              ]
+            }
+          ]
+        }
+      },
+      "if" : {
+        "properties" : {
+          "phase" : {
+            "enum" : [
+              "integration",
+              "installation"
+            ],
+            "type" : "string"
+          }
+        }
+      },
       "properties" : {
         "asset_tag" : {
           "oneOf" : [
@@ -762,10 +828,14 @@
         "validated",
         "phase",
         "links",
-        "build_id",
-        "rack_id",
-        "rack_unit_start"
+        "build_id"
       ],
+      "then" : {
+        "required" : [
+          "rack_id",
+          "rack_unit_start"
+        ]
+      },
       "type" : "object"
     },
     "DeviceIds" : {
@@ -776,6 +846,7 @@
       "uniqueItems" : true
     },
     "DeviceLocation" : {
+      "$comment" : "location should not be considered canonical when device 'phase' is 'production' or later",
       "additionalProperties" : false,
       "properties" : {
         "datacenter" : {
@@ -937,6 +1008,24 @@
     },
     "DevicePXE" : {
       "additionalProperties" : false,
+      "else" : {
+        "not" : {
+          "required" : [
+            "location"
+          ]
+        }
+      },
+      "if" : {
+        "properties" : {
+          "phase" : {
+            "enum" : [
+              "integration",
+              "installation"
+            ],
+            "type" : "string"
+          }
+        }
+      },
       "properties" : {
         "id" : {
           "$ref" : "common.json#/definitions/uuid"
@@ -1029,6 +1118,9 @@
             }
           ]
         },
+        "phase" : {
+          "$ref" : "common.json#/definitions/device_phase"
+        },
         "pxe" : {
           "oneOf" : [
             {
@@ -1051,10 +1143,15 @@
       },
       "required" : [
         "id",
-        "location",
+        "phase",
         "ipmi",
         "pxe"
       ],
+      "then" : {
+        "required" : [
+          "location"
+        ]
+      },
       "type" : "object"
     },
     "DevicePhase" : {
@@ -2863,6 +2960,24 @@
     "WorkspaceDevicePXEs" : {
       "items" : {
         "additionalProperties" : false,
+        "else" : {
+          "not" : {
+            "required" : [
+              "location"
+            ]
+          }
+        },
+        "if" : {
+          "properties" : {
+            "phase" : {
+              "enum" : [
+                "integration",
+                "installation"
+              ],
+              "type" : "string"
+            }
+          }
+        },
         "properties" : {
           "id" : {
             "$ref" : "common.json#/definitions/uuid"
@@ -2948,6 +3063,9 @@
             ],
             "type" : "object"
           },
+          "phase" : {
+            "$ref" : "common.json#/definitions/device_phase"
+          },
           "pxe" : {
             "oneOf" : [
               {
@@ -2970,10 +3088,15 @@
         },
         "required" : [
           "id",
-          "location",
+          "phase",
           "ipmi",
           "pxe"
         ],
+        "then" : {
+          "required" : [
+            "location"
+          ]
+        },
         "type" : "object"
       },
       "type" : "array",
@@ -3107,6 +3230,7 @@
             "type" : "string"
           },
           "location" : {
+            "$comment" : "location should not be considered canonical when device 'phase' is 'production' or later",
             "additionalProperties" : false,
             "description" : "Last reported location of the relay",
             "properties" : {

--- a/docs/modules/Conch::Controller::Device.md
+++ b/docs/modules/Conch::Controller::Device.md
@@ -12,6 +12,9 @@ to find the device and verify the user has the required role to operate on it.
 If `require_role` is provided, it is used as the minimum required role for the user to
 continue.
 
+If `phase_earlier_than` is provided, `409 CONFLICT` is returned if the device is in the
+provided phase (or later).
+
 ## get
 
 Retrieves details about a single device. Response uses the DetailedDevice json schema.

--- a/docs/modules/Conch::Controller::DeviceLocation.md
+++ b/docs/modules/Conch::Controller::DeviceLocation.md
@@ -6,7 +6,8 @@ Conch::Controller::DeviceLocation
 
 ## get
 
-Retrieves location data for the current device.
+Retrieves location data for the current device.  **Note:** This information is not considered to
+be canonical if the device is in the 'production' phase or later.
 
 Response uses the DeviceLocation json schema.
 

--- a/docs/modules/Conch::DB::Helper::Row::WithPhase.md
+++ b/docs/modules/Conch::DB::Helper::Row::WithPhase.md
@@ -1,0 +1,34 @@
+# NAME
+
+Conch::DB::Helper::Row::WithPhase
+
+# DESCRIPTION
+
+A component for [Conch::DB::Result](../modules/Conch::DB::Result) classes for database tables with a `phase` column, to
+provide common functionality.
+
+# USAGE
+
+```
+__PACKAGE__->load_components('+Conch::DB::Helper::Row::WithPhase');
+```
+
+# METHODS
+
+## phase\_cmp
+
+Acts like the `cmp` operator, returning -1, 0 or 1 depending on whether the first phase is
+less than, the same as, or greater than the second phase.
+
+If only one phase argument is passed, the phase in the current row is compared to the passed-in
+phase.
+
+Accepts undef for one or both phases, which always compare as less than a defined phase.
+
+# LICENSING
+
+Copyright Joyent, Inc.
+
+This Source Code Form is subject to the terms of the Mozilla Public License,
+v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+one at [http://mozilla.org/MPL/2.0/](http://mozilla.org/MPL/2.0/).

--- a/docs/modules/index.md
+++ b/docs/modules/index.md
@@ -45,6 +45,7 @@
 * [Conch::DB::Helper::ResultSet::ResultsExist](../modules/Conch::DB::Helper::ResultSet::ResultsExist)
 * [Conch::DB::Helper::ResultSet::WithRole](../modules/Conch::DB::Helper::ResultSet::WithRole)
 * [Conch::DB::Helper::Row::ToJSON](../modules/Conch::DB::Helper::Row::ToJSON)
+* [Conch::DB::Helper::Row::WithPhase](../modules/Conch::DB::Helper::Row::WithPhase)
 * [Conch::DB::Helper::Row::WithRole](../modules/Conch::DB::Helper::Row::WithRole)
 * [Conch::DB::InflateColumn::Time](../modules/Conch::DB::InflateColumn::Time)
 * [Conch::DB::Result](../modules/Conch::DB::Result)

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -675,7 +675,6 @@ definitions:
           required:
             - location
   DeviceLocation:
-    $comment: location should not be considered canonical when device 'phase' is 'production' or later
     type: object
     additionalProperties: false
     required:

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -116,9 +116,6 @@ definitions:
       - phase
       - links
       - build_id
-      - location
-      - nics
-      - disks
       - latest_report
     properties:
       id:
@@ -175,10 +172,12 @@ definitions:
           - type: 'null'
           - $ref: common.yaml#/definitions/uuid
       location:
+        $comment: location is included only when device 'phase' is earlier than 'production'
         oneOf:
           - $ref: /definitions/DeviceLocation
           - type: 'null'
       nics: # NOTE: see also DeviceNic
+        $comment: nics is included only when device 'phase' is earlier than 'production'
         type: array
         uniqueItems: true
         items:
@@ -213,6 +212,7 @@ definitions:
                 - type: string
                 - type: 'null'
       disks:
+        $comment: disks is included only when device 'phase' is earlier than 'production'
         type: array
         uniqueItems: true
         items:
@@ -289,6 +289,27 @@ definitions:
           - type: 'null'
           - $ref: device_report.yaml#/definitions/DeviceReport_v3.0.0
           - type: object
+    if:
+      properties:
+        phase:
+          type: string
+          enum:
+            - integration
+            - installation
+    then:
+      required:
+        - location
+        - nics
+        - disks
+    else:
+      not:
+        anyOf:
+          - required:
+            - location
+          - required:
+            - nics
+          - required:
+            - disks
   DeviceIds:
     type: array
     uniqueItems: true
@@ -318,8 +339,6 @@ definitions:
       - phase
       - links
       - build_id
-      - rack_id
-      - rack_unit_start
     properties:
       id:
         $ref: common.yaml#/definitions/uuid
@@ -382,6 +401,24 @@ definitions:
         oneOf:
           - $ref: common.yaml#/definitions/positive_integer
           - type: 'null'
+    if:
+      properties:
+        phase:
+          type: string
+          enum:
+            - integration
+            - installation
+    then:
+      required:
+        - rack_id
+        - rack_unit_start
+    else:
+      not:
+        anyOf:
+          - required:
+            - rack_id
+          - required:
+            - rack_unit_start
   DeviceNics:
     type: array
     uniqueItems: true
@@ -442,12 +479,14 @@ definitions:
     additionalProperties: false
     required:
       - id
-      - location
+      - phase
       - ipmi
       - pxe
     properties:
       id:
         $ref: common.yaml#/definitions/uuid
+      phase:
+        $ref: common.yaml#/definitions/device_phase
       location:
         oneOf:
           - type: 'null'
@@ -508,6 +547,20 @@ definitions:
             properties:
               mac:
                 $ref: common.yaml#/definitions/macaddr
+    if:
+      properties:
+        phase:
+          type: string
+          enum:
+            - integration
+            - installation
+    then:
+      required:
+        - location
+    else:
+      not:
+        required:
+          - location
   DevicePhase:
     type: object
     additionalProperties: false
@@ -541,12 +594,14 @@ definitions:
       additionalProperties: false
       required:
         - id
-        - location
+        - phase
         - ipmi
         - pxe
       properties:
         id:
           $ref: common.yaml#/definitions/uuid
+        phase:
+          $ref: common.yaml#/definitions/device_phase
         location:
           type: object
           additionalProperties: false
@@ -605,7 +660,22 @@ definitions:
               properties:
                 mac:
                   $ref: common.yaml#/definitions/macaddr
+      if:
+        properties:
+          phase:
+            type: string
+            enum:
+              - integration
+              - installation
+      then:
+        required:
+          - location
+      else:
+        not:
+          required:
+            - location
   DeviceLocation:
+    $comment: location should not be considered canonical when device 'phase' is 'production' or later
     type: object
     additionalProperties: false
     required:
@@ -1115,6 +1185,7 @@ definitions:
           type: string
           format: date-time
         location:
+          $comment: location should not be considered canonical when device 'phase' is 'production' or later
           description: Last reported location of the relay
           type: object
           additionalProperties: false

--- a/lib/Conch/Controller/Device.pm
+++ b/lib/Conch/Controller/Device.pm
@@ -219,7 +219,11 @@ sub lookup_by_other_attribute ($c) {
     }
     elsif (any { $key eq $_ } qw(mac ipaddr)) {
         $device_rs = $device_rs->search(
-            { 'device_nics.'.$key => $value },
+            {
+                # production devices do not consider interface data to be canonical
+                $device_rs->current_source_alias.'.phase' => { '<' => \[ '?::device_phase_enum', 'production' ] },
+                'device_nics.'.$key => $value,
+            },
             { join => 'device_nics' },
         );
     }

--- a/lib/Conch/Controller/Device.pm
+++ b/lib/Conch/Controller/Device.pm
@@ -122,43 +122,55 @@ sub get ($c) {
     # TODO: this is really a weak etag. requires https://github.com/mojolicious/mojo/pull/1420
     return $c->status(304) if $c->is_fresh(etag => $etag);
 
-    my ($device) = $c->stash('device_rs')
-        ->prefetch([ { active_device_nics => 'device_neighbor' }, 'active_device_disks' ])
-        ->order_by([ qw(iface_name active_device_disks.serial_number) ])
-        ->all;
-
-    my $device_location_rs = $c->stash('device_rs')
-        ->related_resultset('device_location');
-
-    # fetch rack, room and datacenter in one query
-    my $rack = $device_location_rs
-        ->related_resultset('rack')
-        ->prefetch({ datacenter_room => 'datacenter' })
-        ->add_columns({ rack_unit_start => 'device_location.rack_unit_start' })
-        ->single;
-
+    my $device = $c->stash('device_rs')->single;
     my $latest_report = $c->stash('device_rs')->latest_device_report->get_column('report')->single;
 
     my $detailed_device = +{
         $device->TO_JSON->%*,
         latest_report => $latest_report ? from_json($latest_report) : undef,
-        nics => [ map {
+    };
+
+    if ($device->phase_cmp('production') < 0) {
+        my $device_location_rs = $c->stash('device_rs')
+            ->related_resultset('device_location');
+
+        # fetch rack, room and datacenter in one query
+        my $rack = $device_location_rs
+            ->related_resultset('rack')
+            ->prefetch({ datacenter_room => 'datacenter' })
+            ->add_columns({ rack_unit_start => 'device_location.rack_unit_start' })
+            ->single;
+
+        $detailed_device->{location} = $rack ? +{
+            rack => $rack,
+            rack_unit_start => $rack->get_column('rack_unit_start'),
+            datacenter_room => $rack->datacenter_room,
+            datacenter => $rack->datacenter_room->datacenter,
+            target_hardware_product => $device_location_rs->target_hardware_product->single,
+        } : undef;
+
+        $detailed_device->{nics} = [ map {
             my $device_nic = $_;
             my $device_neighbor = $device_nic->device_neighbor;
             +{
                 (map +($_ => $device_nic->$_), qw(mac iface_name iface_type iface_vendor)),
                 (map +($_ => $device_neighbor && $device_neighbor->$_), qw(peer_mac peer_port peer_switch)),
             }
-        } $device->active_device_nics ],
-        location => $rack ? +{
-            rack => $rack,
-            rack_unit_start => $rack->get_column('rack_unit_start'),
-            datacenter_room => $rack->datacenter_room,
-            datacenter => $rack->datacenter_room->datacenter,
-            target_hardware_product => $device_location_rs->target_hardware_product->single,
-        } : undef,
-        disks => [ $device->active_device_disks ],
-    };
+        }
+            $c->stash('device_rs')
+                ->related_resultset('active_device_nics')
+                ->prefetch('device_neighbor')
+                ->order_by('iface_name')
+                ->all
+        ];
+
+        $detailed_device->{disks} = [
+            $c->stash('device_rs')
+                ->related_resultset('active_device_disks')
+                ->order_by('serial_number')
+                ->all
+        ];
+    }
 
     $c->status(200, $detailed_device);
 }
@@ -252,6 +264,7 @@ sub get_pxe ($c) {
         {
             columns => {
                 id => 'device.id',
+                phase => 'device.phase',
                 'location.datacenter.name' => 'datacenter.region',
                 'location.datacenter.vendor_name' => 'datacenter.vendor_name',
                 'location.rack.name' => 'rack.name',
@@ -265,6 +278,10 @@ sub get_pxe ($c) {
         })
         ->hri
         ->all;
+
+    if (Conch::DB::Result::Device->phase_cmp($device->{phase}, 'production') >= 0) {
+        delete $device->{location};
+    }
 
     my $ipmi = delete $device->{ipmi_mac_ip};
     $device->{ipmi} = $ipmi ? { mac => $ipmi->[0], ip => $ipmi->[1] } : undef;

--- a/lib/Conch/Controller/DeviceLocation.pm
+++ b/lib/Conch/Controller/DeviceLocation.pm
@@ -12,7 +12,8 @@ Conch::Controller::DeviceLocation
 
 =head2 get
 
-Retrieves location data for the current device.
+Retrieves location data for the current device.  B<Note:> This information is not considered to
+be canonical if the device is in the 'production' phase or later.
 
 Response uses the DeviceLocation json schema.
 

--- a/lib/Conch/Controller/DeviceReport.pm
+++ b/lib/Conch/Controller/DeviceReport.pm
@@ -56,6 +56,11 @@ sub process ($c) {
         return $c->status(409, { error => 'Report sku does not match expected hardware_product for device '.$c->stash('device_serial_number') });
     }
 
+    if ($device->phase eq 'decommissioned') {
+        $c->log->error('report submitted for decommissioned device '.$c->stash('device_serial_number'));
+        return $c->status(409, { error => 'device is decommissioned' });
+    }
+
     # capture information about the last report before we store the new one
     # state can be: error, fail, pass, where no validations on a valid report is
     # considered to be a pass.

--- a/lib/Conch/DB/Helper/Row/WithPhase.pm
+++ b/lib/Conch/DB/Helper/Row/WithPhase.pm
@@ -1,0 +1,64 @@
+package Conch::DB::Helper::Row::WithPhase;
+use v5.26;
+use warnings;
+
+use parent 'DBIx::Class::Core';
+
+=head1 NAME
+
+Conch::DB::Helper::Row::WithPhase
+
+=head1 DESCRIPTION
+
+A component for L<Conch::DB::Result> classes for database tables with a C<phase> column, to
+provide common functionality.
+
+=head1 USAGE
+
+    __PACKAGE__->load_components('+Conch::DB::Helper::Row::WithPhase');
+
+=head1 METHODS
+
+=head2 phase_cmp
+
+Acts like the C<cmp> operator, returning -1, 0 or 1 depending on whether the first phase is
+less than, the same as, or greater than the second phase.
+
+If only one phase argument is passed, the phase in the current row is compared to the passed-in
+phase.
+
+Accepts undef for one or both phases, which always compare as less than a defined phase.
+
+=cut
+
+sub phase_cmp {
+    my $self = shift;
+
+    state $phase_to_int = do {
+        my $i = 0;
+        +{ map +($_ => ++$i), $self->column_info('phase')->{extra}{list}->@* };
+    };
+
+    my ($phase1, $phase2) =
+        @_ == 2 ? (shift, shift)
+      : @_ == 1 ? ($self->phase, shift)
+      : die 'insufficient arguments';
+
+    (defined $phase1 ? $phase_to_int->{$phase1} : 0) <=> (defined $phase2 ? $phase_to_int->{$phase2} : 0);
+}
+
+1;
+__END__
+
+=pod
+
+=head1 LICENSING
+
+Copyright Joyent, Inc.
+
+This Source Code Form is subject to the terms of the Mozilla Public License,
+v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+one at L<http://mozilla.org/MPL/2.0/>.
+
+=cut
+# vim: set ts=4 sts=4 sw=4 et :

--- a/lib/Conch/DB/Result/Device.pm
+++ b/lib/Conch/DB/Result/Device.pm
@@ -402,6 +402,8 @@ __PACKAGE__->many_to_many("relays", "device_relay_connections", "relay");
 # Created by DBIx::Class::Schema::Loader v0.07049
 # DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:ygCrs0YElHPOZ3jUN4DWUg
 
+__PACKAGE__->load_components('+Conch::DB::Helper::Row::WithPhase');
+
 __PACKAGE__->has_many(
   "active_device_disks",
   "Conch::DB::Result::DeviceDisk",

--- a/lib/Conch/DB/Result/Device.pm
+++ b/lib/Conch/DB/Result/Device.pm
@@ -435,8 +435,9 @@ use experimental 'signatures';
 sub TO_JSON ($self) {
     my $data = $self->next::method(@_);
 
-    # include location information, when available
-    if (my $cached_location = $self->related_resultset('device_location')->get_cache) {
+    # include location information, when available and still relevant
+    if (my $cached_location = $self->related_resultset('device_location')->get_cache
+            and $self->phase_cmp('production') < 0) {
         # the cache is always a listref, if it was prefetched.
         $data->{rack_id} = @$cached_location ? $cached_location->[0]->rack_id : undef;
         $data->{rack_unit_start} = @$cached_location ? $cached_location->[0]->rack_unit_start : undef;

--- a/lib/Conch/DB/Result/Rack.pm
+++ b/lib/Conch/DB/Result/Rack.pm
@@ -269,6 +269,8 @@ __PACKAGE__->many_to_many("workspaces", "workspace_racks", "workspace");
 # Created by DBIx::Class::Schema::Loader v0.07049
 # DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:QnDbXrOdTyIuHsfOh6+wIw
 
+__PACKAGE__->load_components('+Conch::DB::Helper::Row::WithPhase');
+
 __PACKAGE__->add_columns(
     '+phase' => { retrieve_on_insert => 1 },
 );

--- a/lib/Conch/Route/Device.pm
+++ b/lib/Conch/Route/Device.pm
@@ -58,7 +58,7 @@ sub routes {
         $with_device->delete('/links')->to('device#remove_links');
 
         {
-            my $with_device_location = $with_device->any('/location')
+            my $with_device_location = $with_device_phase_earlier_than_prod->any('/location')
                 ->to({ controller => 'device_location' });
 
             # GET /device/:device_id_or_serial_number/location

--- a/lib/Conch/Route/Device.pm
+++ b/lib/Conch/Route/Device.pm
@@ -40,7 +40,7 @@ sub routes {
         $with_device->get('/')->to('device#get');
 
         # GET /device/:device_id_or_serial_number/pxe
-        $with_device->get('/pxe')->to('device#get_pxe');
+        $with_device_phase_earlier_than_prod->get('/pxe')->to('device#get_pxe');
         # GET /device/:device_id_or_serial_number/phase
         $with_device->get('/phase')->to('device#get_phase');
         # GET /device/:device_id_or_serial_number/sku

--- a/lib/Conch/Route/Device.pm
+++ b/lib/Conch/Route/Device.pm
@@ -33,6 +33,8 @@ sub routes {
         my $with_device = $device->under('/:device_id_or_serial_number')->to('device#find_device');
         my $with_device_ro = $device->under('/:device_id_or_serial_number')
             ->to('device#find_device', require_role => 'ro');
+        my $with_device_phase_earlier_than_prod = $device->under('/:device_id_or_serial_number')
+            ->to('device#find_device', phase_earlier_than => 'production');
 
         # GET /device/:device_id_or_serial_number
         $with_device->get('/')->to('device#get');
@@ -93,8 +95,8 @@ sub routes {
         $with_device->get('/validation_state')->to('device_validation#list_validation_states');
 
         {
-            my $with_device_interface = $with_device->any('/interface')
-                ->to({ controller => 'device_interface' });
+            my $with_device_interface = $with_device_phase_earlier_than_prod
+                ->any('/interface')->to({ controller => 'device_interface' });
 
             # GET /device/:device_id_or_serial_number/interface
             $with_device_interface->get('/')->to('#get_all');

--- a/t/integration/crud/devices.t
+++ b/t/integration/crud/devices.t
@@ -709,6 +709,10 @@ subtest 'get by device attributes' => sub {
             ->json_is([ $undetailed_device ]);
     }
 
+    foreach my $query ('/device?ipaddr=172.17.0.173', "/device?mac=$macs[0]") {
+        $t->get_ok($query)->status_is(404);
+    }
+
     $test_device->update({ links => '{}', phase => 'installation' });
 };
 

--- a/t/integration/crud/devices.t
+++ b/t/integration/crud/devices.t
@@ -176,6 +176,44 @@ subtest 'unlocated device with a registered relay' => sub {
         ->json_schema_is('ValidationStateWithResults')
         ->json_is($validation_state);
 
+    cmp_deeply(
+        [ $t->validator->validate(
+            {
+                do { my %_data = $test_device_data->%*; delete $_data{location}; %_data },
+                phase => 'integration',
+            },
+            $t->validator->get('/definitions/DetailedDevice')) ],
+        [
+            methods(
+                path => '/location',
+                message => re(qr/missing property/i),
+            ),
+        ],
+        'lack of location data is rejected by the response schema when phase=integration',
+    );
+
+    cmp_deeply(
+        [ $t->validator->validate(
+            { $test_device_data->%*, phase => 'production' },
+            $t->validator->get('/definitions/DetailedDevice')) ],
+        [
+            methods(
+                path => '/',
+                message => re(qr/should not match/i),
+            ),
+        ],
+        'location data is rejected by the response schema when phase=production',
+    );
+
+    $t->app->db_devices->search({ id => $test_device_id })->update({ phase => 'production' });
+
+    $test_device_data->{phase} = 'production';
+    delete $test_device_data->@{qw(location nics disks)};
+    $t->get_ok('/device/TEST')
+        ->status_is(200)
+        ->json_schema_is('DetailedDevice')
+        ->json_cmp_deeply($test_device_data);
+
     my @post_queries = (
         [ '/device/TEST/validated' ],
         [ '/device/TEST/phase', json => { phase => 'installation' } ],
@@ -426,6 +464,11 @@ subtest 'located device' => sub {
             ipaddr => '127.0.0.1',
         });
 
+        $t->get_ok('/device/LOCATED_DEVICE')
+            ->status_is(200)
+            ->json_schema_is('DetailedDevice');
+        $device_data = $t->tx->res->json;
+
         my @get_queries = (
             '/device/LOCATED_DEVICE',
             '/device/LOCATED_DEVICE/location',
@@ -488,6 +531,7 @@ subtest 'located device' => sub {
             ->status_is(204);
         $t->delete_ok('/device/LOCATED_DEVICE/links')
             ->status_is(204);
+        $device_data->{links} = [];
 
         $t->authenticate(email => $admin_user->email);
         $t->delete_ok('/device/LOCATED_DEVICE/settings/hello')
@@ -495,6 +539,19 @@ subtest 'located device' => sub {
 
         $t->authenticate(email => $ro_user->email);
     };
+
+
+    $located_device->update({ phase => 'production' });
+    $device_data->{phase} = 'production';
+    delete $device_data->@{qw(location nics disks)};
+
+    $t->get_ok('/device/'.$located_device_id)
+        ->status_is(200)
+        ->json_schema_is('DetailedDevice')
+        ->json_cmp_deeply({
+            $device_data->%*,
+            updated => re(qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/),
+        });
 };
 
 subtest 'device network interfaces' => sub {
@@ -521,6 +578,14 @@ subtest 'device network interfaces' => sub {
         ->status_is(200)
         ->json_schema_is('DeviceNicField')
         ->json_is({ ipaddr => '10.72.160.146' });
+
+    $t->post_ok('/device/TEST/phase', json => { phase => 'production' })
+        ->status_is(303)
+        ->location_is('/device/'.$test_device_id);
+
+    $t->post_ok('/device/TEST/phase', json => { phase => 'installation' })
+        ->status_is(303)
+        ->location_is('/device/'.$test_device_id);
 };
 
 $t->get_ok('/device/TEST')
@@ -595,6 +660,35 @@ subtest 'get by device attributes' => sub {
         ->json_schema_is('Devices')
         ->json_is('', [ $undetailed_device ], 'got device by link');
 
+    $t->get_ok('/device?key=value')
+        ->status_is(404);
+
+    $test_device->create_related('device_settings', { name => 'key', value => 'value' });
+
+    $t->get_ok('/device?key=ugh')
+        ->status_is(404);
+
+    $t->get_ok('/device?key=value')
+        ->status_is(200)
+        ->json_schema_is('Devices')
+        ->json_is([ $undetailed_device ]);
+
+    $test_device->update({ phase => 'production' });
+
+    $undetailed_device->{phase} = 'production';
+    delete $undetailed_device->@{qw(rack_id rack_unit_start)};
+
+    foreach my $query (qw(
+        /device?hostname=elfo
+        /device?link=foo
+        /device?key=value
+    )) {
+        $t->get_ok($query)
+            ->status_is(200)
+            ->json_schema_is('Devices')
+            ->json_is([ $undetailed_device ]);
+    }
+
     $test_device->update({ links => '{}' });
 };
 
@@ -638,6 +732,9 @@ subtest 'mutate device attributes' => sub {
         ->status_is(200)
         ->json_schema_is('DevicePhase')
         ->json_is({ id => $test_device_id, phase => 'decommissioned' });
+
+    $detailed_device->{phase} = 'decommissioned';
+    delete $detailed_device->@{qw(location nics disks)};
 
     my $test_device = $t->app->db_devices->find({ serial_number => 'TEST' }, { prefetch => 'hardware_product' });
 
@@ -811,19 +908,6 @@ subtest 'Device settings' => sub {
         ->status_is(200)
         ->json_schema_is('DetailedDevice');
 
-    my $detailed_device = $t->tx->res->json;
-
-    my $undetailed_device = {
-        $detailed_device->%*,
-        ($t->app->db_device_locations->search({ device_id => $located_device_id })->hri->single // {})->%{qw(rack_id rack_unit_start)},
-    };
-    delete $undetailed_device->@{qw(latest_report location nics disks)};
-
-    $t->get_ok('/device?foo=bar')
-        ->status_is(200)
-        ->json_schema_is('Devices')
-        ->json_is('', [ $undetailed_device ], 'got device by arbitrary setting key');
-
     $t->authenticate(email => $ro_user->email);
 
     $t->post_ok('/device/LOCATED_DEVICE/settings/foo', json => { foo => 'new_value' })
@@ -914,6 +998,7 @@ subtest 'Device PXE' => sub {
         ->json_schema_is('DevicePXE')
         ->json_is({
             id => $device_pxe->id,
+            phase => 'integration',
             location => undef,
             ipmi => {
                 mac => '00:00:00:00:00:cc',
@@ -935,6 +1020,7 @@ subtest 'Device PXE' => sub {
         ->json_schema_is('DevicePXE')
         ->json_is({
             id => $device_pxe->id,
+            phase => 'integration',
             location => {
                 datacenter => {
                     name => $datacenter->region,
@@ -953,8 +1039,17 @@ subtest 'Device PXE' => sub {
                 mac => '00:00:00:00:00:aa',
             },
         });
+    my $pxe_data = $t_ro->tx->res->json;
 
+    $device_pxe->update({ phase => 'production' });
+    delete $pxe_data->{location};
 
+    $t_ro->get_ok('/device/PXE_TEST/pxe')
+        ->status_is(200)
+        ->json_schema_is('DevicePXE')
+        ->json_is({ $pxe_data->%*, phase => 'production' });
+
+    $device_pxe->update({ phase => 'integration' });
     $device_pxe->delete_related('device_location');
     $device_pxe->delete_related('device_nics');
 
@@ -967,6 +1062,7 @@ subtest 'Device PXE' => sub {
         ->json_schema_is('DevicePXE')
         ->json_is({
             id => $device_pxe->id,
+            phase => 'integration',
             location => undef,
             ipmi => undef,
             pxe => undef,

--- a/t/integration/crud/devices.t
+++ b/t/integration/crud/devices.t
@@ -1065,6 +1065,11 @@ subtest 'Device PXE' => sub {
     delete $pxe_data->{location};
 
     $t_ro->get_ok('/device/PXE_TEST/pxe')
+        ->status_is(409)
+        ->location_is('/device/'.$device_pxe->id.'/links')
+        ->json_is({ error => 'device is in the production phase' });
+
+    $t_ro->get_ok('/device/PXE_TEST/pxe?phase_earlier_than=')
         ->status_is(200)
         ->json_schema_is('DevicePXE')
         ->json_is({ $pxe_data->%*, phase => 'production' });

--- a/t/integration/crud/devices.t
+++ b/t/integration/crud/devices.t
@@ -583,6 +583,26 @@ subtest 'device network interfaces' => sub {
         ->status_is(303)
         ->location_is('/device/'.$test_device_id);
 
+    foreach my $query (
+        '/device/TEST/interface',
+        '/device/TEST/interface/ipmi1',
+        map '/device/TEST/interface/ipmi1/'.$_,
+            (qw(mac iface_name iface_type iface_vendor iface_driver state ipaddr mtu)),
+    ) {
+        $t->get_ok($query)
+            ->status_is(409)
+            ->location_is('/device/'.$test_device_id.'/links')
+            ->json_is({ error => 'device is in the production phase' });
+    }
+
+    $t->get_ok('/device/TEST/interface?phase_earlier_than=decommissioned')
+        ->status_is(200)
+        ->json_schema_is('DeviceNics');
+
+    $t->get_ok('/device/TEST/interface?phase_earlier_than=')
+        ->status_is(200)
+        ->json_schema_is('DeviceNics');
+
     $t->post_ok('/device/TEST/phase', json => { phase => 'installation' })
         ->status_is(303)
         ->location_is('/device/'.$test_device_id);

--- a/t/integration/crud/workspace-devices.t
+++ b/t/integration/crud/workspace-devices.t
@@ -219,7 +219,12 @@ subtest 'Devices with PXE data' => sub {
     $t->get_ok('/workspace/'.$global_ws_id.'/device/pxe')
         ->status_is(200)
         ->json_schema_is('WorkspaceDevicePXEs')
-        ->json_cmp_deeply($pxe_data);
+        ->json_is([ $pxe_data->[1] ]);
+
+    $t->get_ok('/workspace/'.$global_ws_id.'/device/pxe?phase_earlier_than=')
+        ->status_is(200)
+        ->json_schema_is('WorkspaceDevicePXEs')
+        ->json_is($pxe_data);
 };
 
 done_testing;

--- a/t/integration/crud/workspace-devices.t
+++ b/t/integration/crud/workspace-devices.t
@@ -174,6 +174,7 @@ subtest 'Devices with PXE data' => sub {
         ->json_cmp_deeply([
             {
                 id => $devices[0]->id,
+                phase => 'integration',
                 location => {
                     datacenter => {
                         name => $datacenter->region,
@@ -194,6 +195,7 @@ subtest 'Devices with PXE data' => sub {
             },
             {
                 id => $devices[1]->id,
+                phase => 'integration',
                 location => {
                     datacenter => {
                         name => $datacenter->region,
@@ -208,6 +210,16 @@ subtest 'Devices with PXE data' => sub {
                 pxe => undef,
             },
         ]);
+    my $pxe_data = $t->tx->res->json;
+
+    $devices[0]->update({ phase => 'production' });
+    delete $pxe_data->[0]{location};
+    $pxe_data->[0]{phase} = 'production';
+
+    $t->get_ok('/workspace/'.$global_ws_id.'/device/pxe')
+        ->status_is(200)
+        ->json_schema_is('WorkspaceDevicePXEs')
+        ->json_cmp_deeply($pxe_data);
 };
 
 done_testing;

--- a/t/integration/device-reports.t
+++ b/t/integration/device-reports.t
@@ -450,5 +450,21 @@ subtest 'system_uuid collisions' => sub {
     is($existing_device->health, 'error', 'bad reports flip device health to error');
 };
 
+subtest 'submit report for decommissioned device' => sub {
+    $t->app->db_devices->update_or_create({
+        serial_number => 'DECOMMISSIONED_TEST',
+        hardware_product_id => $t->load_fixture('hardware_product_profile_compute')->hardware_product_id,
+        health => 'pass',
+        phase => 'decommissioned',
+    });
+
+    my $altered_report = from_json($report);
+    $altered_report->{serial_number} = 'DECOMMISSIONED_TEST';
+
+    $t->post_ok('/device/DECOMMISSIONED_TEST', json => $altered_report)
+        ->status_is(409)
+        ->json_is({ error => 'device is decommissioned' });
+};
+
 done_testing;
 # vim: set ts=4 sts=4 sw=4 et :


### PR DESCRIPTION
Fulfills the v3 api spec for the "Decommissioned" and "Production" sections.

closes #823. closes #824.

* do not accept reports for decommissioned devices
* do not update information (via reports) for devices in production (or later phase)
* omit location, nics and disks from device endpoints when phase=production or later
* return 409 CONFLICT when device phase >= production for endpoints:
  * `GET /device/*/interface`
  * `GET /device/*/pxe`
  * `GET /device/*location`
* omit results for devices with phase >= production for endpoints:
  * `GET /device?ipaddr=..` and `GET /device?mac=..`
  * `GET /workspace/*/pxe`
  * `GET /build/*/device`
* adjust role checks to not use device location when phase >= production
