### PR TITLE
v3: a8 fixes

### DIFF
--- a/docs/json-schema/request.json
+++ b/docs/json-schema/request.json
@@ -288,7 +288,7 @@
       "type" : "object"
     },
     "DeviceLinks" : {
-      "additionaProperties" : false,
+      "additionalProperties" : false,
       "properties" : {
         "links" : {
           "items" : {
@@ -322,7 +322,7 @@
       "type" : "object"
     },
     "DevicePhase" : {
-      "additionaProperties" : false,
+      "additionalProperties" : false,
       "properties" : {
         "phase" : {
           "$ref" : "common.json#/definitions/device_phase"
@@ -973,7 +973,7 @@
       "uniqueItems" : true
     },
     "RackPhase" : {
-      "additionaProperties" : false,
+      "additionalProperties" : false,
       "properties" : {
         "phase" : {
           "$ref" : "common.json#/definitions/device_phase"
@@ -1053,7 +1053,7 @@
       "type" : "object"
     },
     "RegisterRelay" : {
-      "additionaProperties" : false,
+      "additionalProperties" : false,
       "properties" : {
         "ipaddr" : {
           "description" : "postgres \"inet\": ipv4 or ipv6, with optional netmask",

--- a/json-schema/request.yaml
+++ b/json-schema/request.yaml
@@ -148,7 +148,7 @@ definitions:
         $ref: common.yaml#/definitions/positive_integer
   RackPhase:
     type: object
-    additionaProperties: false
+    additionalProperties: false
     required:
       - phase
     properties:
@@ -502,7 +502,7 @@ definitions:
           - type: 'null'
   DevicePhase:
     type: object
-    additionaProperties: false
+    additionalProperties: false
     required:
       - phase
     properties:
@@ -510,7 +510,7 @@ definitions:
         $ref: common.yaml#/definitions/device_phase
   DeviceLinks:
     type: object
-    additionaProperties: false
+    additionalProperties: false
     required:
       - links
     properties:
@@ -535,7 +535,7 @@ definitions:
       $ref: common.yaml#/definitions/device_setting_key
   RegisterRelay:
     type: object
-    additionaProperties: false
+    additionalProperties: false
     required:
       - serial
     properties:

--- a/lib/Conch/Controller/Rack.pm
+++ b/lib/Conch/Controller/Rack.pm
@@ -376,6 +376,7 @@ sub set_assignment ($c) {
                     asset_tag => $entry->{device_asset_tag},
                     hardware_product_id => $layout->hardware_product_id,
                     health => 'unknown',
+                    build_id => $c->stash('rack_rs')->get_column('build_id')->single,
                 });
                 $entry->{device_id} = $device->id;
             }


### PR DESCRIPTION
- when creating a device via `POST /rack/:id/assignment`, put the device in the rack's build
- fix embarrassing typos in request json schema