### PR TITLE
v2: request schema typos

### DIFF
--- a/json-schema/input.yaml
+++ b/json-schema/input.yaml
@@ -157,7 +157,7 @@ definitions:
         type: integer
   RackPhase:
     type: object
-    additionaProperties: false
+    additionalProperties: false
     required:
       - phase
     properties:
@@ -555,7 +555,7 @@ definitions:
         $ref: /definitions/uuid
   DevicePhase:
     type: object
-    additionaProperties: false
+    additionalProperties: false
     required:
       - phase
     properties:
@@ -582,7 +582,7 @@ definitions:
         - $ref: /definitions/uuid
   RegisterRelay:
     type: object
-    additionaProperties: false
+    additionalProperties: false
     required:
       - serial
     properties:


### PR DESCRIPTION
This was causing invalid fields to slip through and then cause explosions when they reached the database

as done in v3 (PR #917).