### PR TITLE
v3-a8: more fixes

### DIFF
--- a/lib/Conch/Controller/Build.pm
+++ b/lib/Conch/Controller/Build.pm
@@ -157,6 +157,9 @@ sub update ($c) {
     return $c->status(409, { error => 'build was already completed' })
         if $build->completed and $old_columns{completed};
 
+    return $c->status(409, { error => 'build cannot be completed in the future' })
+        if $build->completed and $build->completed > Conch::Time->now;
+
     $c->log->info('build '.$build->id.' ('.$build->name.') started')
         if $build->started and not $old_columns{started};
 

--- a/lib/Conch/Controller/Build.pm
+++ b/lib/Conch/Controller/Build.pm
@@ -718,17 +718,6 @@ sub add_device ($c) {
         return $c->status(409, { error => 'device already member of build '.$device->build_id.' ('.$device->build->name.')' });
     }
 
-    if ($device->device_location
-            and my $current_build = $device->device_location->rack->build) {
-        return $c->status(204) if $current_build->id eq $build_id;
-
-        $c->log->warn('cannot add device '.$c->stash('device_id').' ('.$device->serial_number
-            .') to build '.$c->stash('build_id_or_name').' -- already a member of build '
-            .$current_build->id.' ('.$device->device_location->rack->build->name
-            .') via its rack location');
-        return $c->status(409, { error => 'device already member of build '.$current_build->id.' ('.$current_build->name.') via rack id '.$device->device_location->rack_id });
-    }
-
     # TODO: check other constraints..
     # - what if the build is completed?
     # - what about device.phase or rack.phase?

--- a/lib/Conch/Controller/Build.pm
+++ b/lib/Conch/Controller/Build.pm
@@ -163,12 +163,12 @@ sub update ($c) {
     $c->log->info('build '.$build->id.' ('.$build->name.') started')
         if $build->started and not $old_columns{started};
 
-    if (not $build->completed and $build->completed_user_id) {
+    if (not $build->completed and $old_columns{completed}) {
         $build->completed_user_id(undef);
         $c->log->info('build '.$build->id.' ('.$build->name
             .') moved out of completed state');
     }
-    elsif ($build->completed and not $build->completed_user_id) {
+    elsif ($build->completed and not $old_columns{completed}) {
         $build->completed_user_id($c->stash('user')->id);
         my $users_updated = $build->search_related('user_build_roles', { role => 'rw' })
             ->update({ role => 'ro' });

--- a/lib/Conch/Plugin/Logging.pm
+++ b/lib/Conch/Plugin/Logging.pm
@@ -37,7 +37,7 @@ sub register ($self, $app, $config) {
     );
 
     # without 'path' option, Mojo::Log defaults to *STDERR
-    if (not $app->feature('log_to_stderr')) {
+    if (not $app->feature('log_to_stderr') and not $log_args{handle}) {
         $log_dir = path($log_dir);
         $log_dir = $app->home->child($log_dir) if not $log_dir->is_abs;
 

--- a/lib/Conch/Plugin/Rollbar.pm
+++ b/lib/Conch/Plugin/Rollbar.pm
@@ -10,6 +10,7 @@ use Config;
 use Mojo::JSON 'to_json';
 use List::Util qw(none any);
 use Carp;
+use Storable 'dclone';
 
 my @message_levels = qw(critical error warning info debug);
 
@@ -76,8 +77,9 @@ message is sent to Rollbar.
             return;
         }
 
-        delete $payload->@{qw(level msg)};
-        $c->send_message_to_rollbar('error', 'api error', $payload);
+        my $data = dclone($payload);
+        delete $data->@{qw(level msg)};
+        $c->send_message_to_rollbar('error', 'api error', $data);
     })
     if keys $config->{rollbar}{error_match_header}->%*;
 

--- a/lib/Conch/Plugin/Rollbar.pm
+++ b/lib/Conch/Plugin/Rollbar.pm
@@ -167,7 +167,7 @@ Requires a message string. A hashref of additional data is optional.
         # see https://docs.rollbar.com/docs/grouping-algorithm
         my $fingerprint = join(',',
             $message_string,
-            to_json($payload),
+            $payload ? to_json($payload) : (),
         );
         $fingerprint = Digest::SHA::sha1_hex($fingerprint) if length($fingerprint) > 40;
 

--- a/misc/get-api-token
+++ b/misc/get-api-token
@@ -1,4 +1,4 @@
-#!/bin/env perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/misc/get-api-token
+++ b/misc/get-api-token
@@ -43,7 +43,7 @@ my $api_token = $token_content->{token};
 say 'here is your api token (keep it in a safe place!)';
 say $api_token;
 say '';
-say 'Hint: you can put "Authorization: Bearer <token>" in ~/.conch-client,';
+say 'Hint: you can put "Authorization: Bearer <token>" in ~/.conch-token,';
 say 'and then in the future you can do:   curl -H @~/.conch-token ...';
 
 exit;

--- a/misc/get-api-token
+++ b/misc/get-api-token
@@ -44,7 +44,7 @@ say 'here is your api token (keep it in a safe place!)';
 say $api_token;
 say '';
 say 'Hint: you can put "Authorization: Bearer <token>" in ~/.conch-token,';
-say 'and then in the future you can do:   curl -H @~/.conch-token ...';
+say 'and then in the future you can do:   curl -H @$(echo ~/.conch-token) ...';
 
 exit;
 

--- a/t/client-verification.t
+++ b/t/client-verification.t
@@ -33,6 +33,10 @@ $t->get_ok('/ping', { 'User-Agent' => 'Mozilla/5.0 Macintosh', 'X-Conch-UI' => '
             res => superhashof({ statusCode => 403 }),
         }), 'we still logged the request');
 
+$t->get_ok('/ping', { 'User-Agent' => 'Mozilla/5.0 Macintosh', 'x-conch-ui' => 'v3.0.2.1-gdeadbeef' })
+    ->status_is(403)
+    ->log_error_is('Conch UI too old: requires at least 4.x');
+
 $t->get_ok('/ping', { 'User-Agent' => 'Mozilla/5.0 Macintosh', 'X-Conch-UI' => 'v4.0.0.3.gdeadbeef' })
     ->status_is(200);
 

--- a/t/conch-log.t
+++ b/t/conch-log.t
@@ -156,7 +156,6 @@ sub add_test_routes ($t) {
 {
     reset_log;
     my $t = Test::Conch->new(config => {
-        logging => { handle => $log_fh },
         features => { audit => 0 },
     });
 
@@ -171,6 +170,27 @@ sub add_test_routes ($t) {
             ),
         ),
         'logger via $app gets good default options',
+    );
+}
+
+{
+    reset_log;
+    my $t = Test::Conch->new(config => {
+        logging => { handle => $log_fh },
+        features => { audit => 0 },
+    });
+
+    cmp_deeply(
+        $t->app->log,
+        all(
+            isa('Conch::Log'),
+            methods(
+                handle => ignore,
+                bunyan => 1,
+                with_trace => 0,
+            ),
+        ),
+        'logger via $app gets filehandle',
     );
 
     $t->app->log->info('info to the app');

--- a/t/integration/crud/build.t
+++ b/t/integration/crud/build.t
@@ -792,11 +792,6 @@ $device2->update({ build_id => undef });
 $rack2->update({ build_id => $build2->{id} });
 $device2->create_related('device_location', { rack_id => $rack2->id, rack_unit_start => $rack_layout2->rack_unit_start });
 
-$t->post_ok('/build/my first build/device/'.$device2->id)
-    ->status_is(409)
-    ->log_warn_is('cannot add device '.$device2->id.' ('.$device2->serial_number.') to build my first build -- already a member of build '.$build2->{id}.' (our second build) via its rack location')
-    ->json_is({ error => 'device already member of build '.$build2->{id}.' (our second build) via rack id '.$rack2->id });
-
 $device2->delete_related('device_location');
 $t->post_ok('/build/my first build/device/'.$device2->id)
     ->status_is(204)


### PR DESCRIPTION
- fix some request header handling for the "send message to rollbar when an error happens" feature
- dispatch log message was losing a few fields if a rollbar message was sent
- change to build logic: no longer allow setting a build to completed if it has devices that are not passing validations
- change to build logic: allow adding a device to a build when it is located in a rack that is in another build