### PR TITLE
v3 a9 fixes

### DIFF
--- a/docs/modules/Conch::Command::check_layouts.md
+++ b/docs/modules/Conch::Command::check_layouts.md
@@ -7,7 +7,7 @@ check\_layouts - check for rack layout conflicts
 ```
 bin/conch check_layouts [long options...]
 
-    --ws --workspace  workspace name
+    --ws --build      build name
 
     --help            print usage message and exit
 ```

--- a/docs/modules/Conch::Controller::DeviceValidation.md
+++ b/docs/modules/Conch::Controller::DeviceValidation.md
@@ -8,7 +8,8 @@ Conch::Controller::DeviceValidation
 
 Get the latest validation states for a device. Accepts the query parameter `status`,
 indicating the desired status(es) to search for -- one or more of: pass, fail, error.
-e.g. `?status=pass`, `?status=error&status=fail`.
+e.g. `?status=pass`, `?status=error&status=fail`. (If no parameters are provided, all
+statuses are searched for.)
 
 Response uses the ValidationStatesWithResults json schema.
 

--- a/lib/Conch/Controller/DeviceValidation.pm
+++ b/lib/Conch/Controller/DeviceValidation.pm
@@ -16,7 +16,8 @@ Conch::Controller::DeviceValidation
 
 Get the latest validation states for a device. Accepts the query parameter C<status>,
 indicating the desired status(es) to search for -- one or more of: pass, fail, error.
-e.g. C<?status=pass>, C<?status=error&status=fail>.
+e.g. C<?status=pass>, C<?status=error&status=fail>. (If no parameters are provided, all
+statuses are searched for.)
 
 Response uses the ValidationStatesWithResults json schema.
 

--- a/sql/migrations/0136-user_account-email-ci.sql
+++ b/sql/migrations/0136-user_account-email-ci.sql
@@ -1,0 +1,7 @@
+SELECT run_migration(136, $$
+
+    drop index user_account_email_key;
+    create unique index user_account_email_key
+        on user_account (lower(email)) where deactivated is null;
+
+$$);

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1412,7 +1412,7 @@ CREATE INDEX rack_rack_role_id_idx ON public.rack USING btree (rack_role_id);
 -- Name: user_account_email_key; Type: INDEX; Schema: public; Owner: conch
 --
 
-CREATE UNIQUE INDEX user_account_email_key ON public.user_account USING btree (email) WHERE (deactivated IS NULL);
+CREATE UNIQUE INDEX user_account_email_key ON public.user_account USING btree (lower(email)) WHERE (deactivated IS NULL);
 
 
 --

--- a/t/conch-rollbar.t
+++ b/t/conch-rollbar.t
@@ -320,7 +320,7 @@ $t->do_and_wait_for_event(
 $t->do_and_wait_for_event(
     $rollbar_app->plugins, 'rollbar_sent',
     sub ($t) {
-        $t->get_ok('/i_do_not_exist')
+        $t->get_ok('/rack/i_do_not_exist')
             ->status_is(404)
             ->json_is({ error => 'Not Found' });
     },
@@ -335,7 +335,7 @@ $t->do_and_wait_for_event(
             $payload->{data}{request},
             superhashof({
                 method => 'GET',
-                url => re(qr{/i_do_not_exist}),
+                url => re(qr{/rack/i_do_not_exist}),
                 query_string => '',
                 body => '',
             }),
@@ -346,12 +346,23 @@ $t->do_and_wait_for_event(
             $payload->{data}{body},
             {
                 message => {
-                    body => 'no endpoint found for: GET /i_do_not_exist',
+                    body => 'no endpoint found for: GET /rack/i_do_not_exist',
                 },
             },
             'message for endpoint-not-found',
         );
     },
+);
+
+$t->do_and_wait_for_event(
+    $rollbar_app->plugins, 'rollbar_sent',
+    sub ($t) {
+        $t->get_ok('/i_do_not_exist')
+            ->status_is(404)
+            ->json_is({ error => 'Not Found' });
+    },
+    sub ($payload) { fail('rollbar message was incorrectly sent') },
+    sub { pass('no rollbar message was sent for unrecognized path prefix') },
 );
 
 $t->do_and_wait_for_event(


### PR DESCRIPTION
- work around shell bug where all fields would be transmitted in a POST payload even if they were not requested to be changed by the user
- make the user_account.email index a bit nicer
- fix check_layouts script to display bad racks, layouts by their build membership, not workspace
- do not send rollbar messages for unsupported endpoints when they don't match one of our recognized prefixes (where most likely they are coming from a spammer, not a misprogrammed client)