### PR TITLE
v3: more device data

### DIFF
--- a/docs/json-schema/query_params.json
+++ b/docs/json-schema/query_params.json
@@ -140,6 +140,15 @@
       },
       "type" : "object"
     },
+    "WithDeviceHealth" : {
+      "additionalProperties" : false,
+      "properties" : {
+        "with_device_health" : {
+          "$ref" : "/definitions/boolean_integer_or_flag"
+        }
+      },
+      "type" : "object"
+    },
     "WorkspaceDevices" : {
       "additionalProperties" : false,
       "properties" : {
@@ -195,6 +204,17 @@
       "maximum" : 1,
       "minimum" : 0,
       "type" : "integer"
+    },
+    "boolean_integer_or_flag" : {
+      "description" : "\"?foo\" and \"?foo=1\" are true; \"?foo=0\" is false",
+      "oneOf" : [
+        {
+          "const" : ""
+        },
+        {
+          "$ref" : "/definitions/boolean_integer"
+        }
+      ]
     }
   }
 }

--- a/docs/json-schema/response.json
+++ b/docs/json-schema/response.json
@@ -605,6 +605,9 @@
         "serial_number" : {
           "$ref" : "common.json#/definitions/device_serial_number"
         },
+        "sku" : {
+          "type" : "string"
+        },
         "system_uuid" : {
           "oneOf" : [
             {
@@ -648,6 +651,7 @@
         "asset_tag",
         "created",
         "hardware_product_id",
+        "sku",
         "health",
         "hostname",
         "last_seen",
@@ -802,6 +806,9 @@
         "serial_number" : {
           "$ref" : "common.json#/definitions/device_serial_number"
         },
+        "sku" : {
+          "type" : "string"
+        },
         "system_uuid" : {
           "oneOf" : [
             {
@@ -845,6 +852,7 @@
         "asset_tag",
         "created",
         "hardware_product_id",
+        "sku",
         "health",
         "hostname",
         "last_seen",
@@ -911,12 +919,16 @@
             "name" : {
               "description" : "Hardware product name",
               "type" : "string"
+            },
+            "sku" : {
+              "type" : "string"
             }
           },
           "required" : [
             "id",
             "name",
             "alias",
+            "sku",
             "hardware_vendor_id"
           ],
           "type" : "object"

--- a/docs/json-schema/response.json
+++ b/docs/json-schema/response.json
@@ -48,6 +48,17 @@
             }
           ]
         },
+        "device_health" : {
+          "additionalProperties" : {
+            "$ref" : "common.json#/definitions/non_negative_integer"
+          },
+          "maxProperties" : 4,
+          "minProperties" : 4,
+          "propertyNames" : {
+            "$ref" : "common.json#/definitions/device_health"
+          },
+          "type" : "object"
+        },
         "id" : {
           "$ref" : "common.json#/definitions/uuid"
         },

--- a/docs/json-schema/response.json
+++ b/docs/json-schema/response.json
@@ -681,6 +681,11 @@
             },
             {
               "required" : [
+                "rack_name"
+              ]
+            },
+            {
+              "required" : [
                 "rack_unit_start"
               ]
             }
@@ -774,6 +779,16 @@
             }
           ]
         },
+        "rack_name" : {
+          "oneOf" : [
+            {
+              "type" : "string"
+            },
+            {
+              "type" : "null"
+            }
+          ]
+        },
         "rack_unit_start" : {
           "oneOf" : [
             {
@@ -844,6 +859,7 @@
       "then" : {
         "required" : [
           "rack_id",
+          "rack_name",
           "rack_unit_start"
         ]
       },

--- a/docs/modules/Conch::DB::ResultSet::Build.md
+++ b/docs/modules/Conch::DB::ResultSet::Build.md
@@ -25,6 +25,11 @@ resultset.
 
 Returns a boolean.
 
+## with\_device\_health\_counts
+
+Modifies the resultset to add on a column named `device_health`) containing an array of arrays
+of correlated counts of device.health values for each build.
+
 # LICENSING
 
 Copyright Joyent, Inc.

--- a/docs/modules/Conch::DB::ResultSet::Device.md
+++ b/docs/modules/Conch::DB::ResultSet::Device.md
@@ -61,6 +61,10 @@ Returns a hash of all (active) device settings for the specified device(s).  (Wi
 merged results when passed a resultset referencing multiple devices, which is probably not what
 you want, so don't do that.)
 
+## with\_device\_location
+
+Modifies the resultset to add columns `rack_id`, `rack_unit_start` and `rack_name`.
+
 # LICENSING
 
 Copyright Joyent, Inc.

--- a/docs/modules/Conch::DB::ResultSet::Device.md
+++ b/docs/modules/Conch::DB::ResultSet::Device.md
@@ -65,6 +65,10 @@ you want, so don't do that.)
 
 Modifies the resultset to add columns `rack_id`, `rack_unit_start` and `rack_name`.
 
+## with\_sku
+
+Modifies the resultset to add the `sku` column.
+
 # LICENSING
 
 Copyright Joyent, Inc.

--- a/docs/modules/Conch::Route::Build.md
+++ b/docs/modules/Conch::Route::Build.md
@@ -12,6 +12,9 @@ Unless otherwise noted, all routes require authentication.
 
 ### `GET /build`
 
+Takes one optional query parameter `device_health` (defaults to false) to include
+correlated counts of devices having each health value.
+
 - Response: response.yaml#/Builds
 
 ### `POST /build`
@@ -21,6 +24,9 @@ Unless otherwise noted, all routes require authentication.
 - Response: Redirect to the build
 
 ### `GET /build/:build_id_or_name`
+
+Takes one optional query parameter `device_health` (defaults to false) to include counts
+of devices having each health value.
 
 - Requires system admin authorization or the read-only role on the build
 - Response: response.yaml#/Build

--- a/json-schema/query_params.yaml
+++ b/json-schema/query_params.yaml
@@ -18,6 +18,12 @@ definitions:
     minimum: 0
     maximum: 1
     default: 1
+  boolean_integer_or_flag:
+    description: '"?foo" and "?foo=1" are true; "?foo=0" is false'
+    oneOf:
+      - const: ''
+      - $ref: /definitions/boolean_integer
+
   RevokeUserTokens:
     allOf:
       - type: object
@@ -132,5 +138,11 @@ definitions:
     properties:
       active_minutes:
         $ref: common.yaml#/definitions/non_negative_integer
+  WithDeviceHealth:
+    type: object
+    additionalProperties: false
+    properties:
+      with_device_health:
+        $ref: /definitions/boolean_integer_or_flag
 
 # vim: set sts=2 sw=2 et :

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -397,6 +397,10 @@ definitions:
         oneOf:
           - $ref: common.yaml#/definitions/uuid
           - type: 'null'
+      rack_name:
+        oneOf:
+          - type: string
+          - type: 'null'
       rack_unit_start:
         oneOf:
           - $ref: common.yaml#/definitions/positive_integer
@@ -411,12 +415,15 @@ definitions:
     then:
       required:
         - rack_id
+        - rack_name
         - rack_unit_start
     else:
       not:
         anyOf:
           - required:
             - rack_id
+          - required:
+            - rack_name
           - required:
             - rack_unit_start
   DeviceNics:

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -2004,6 +2004,14 @@ definitions:
         oneOf:
           - type: 'null'
           - $ref: /definitions/UserTerse
+      device_health:
+        type: object
+        minProperties: 4
+        maxProperties: 4
+        propertyNames:
+          $ref: common.yaml#/definitions/device_health
+        additionalProperties:
+          $ref: common.yaml#/definitions/non_negative_integer
   Builds:
     type: array
     uniqueItems: true

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -106,6 +106,7 @@ definitions:
       - asset_tag
       - created
       - hardware_product_id
+      - sku
       - health
       - hostname
       - last_seen
@@ -131,6 +132,8 @@ definitions:
         format: date-time
       hardware_product_id:
         $ref: common.yaml#/definitions/uuid
+      sku:
+        type: string
       health:
         $ref: common.yaml#/definitions/device_health
       hostname:
@@ -329,6 +332,7 @@ definitions:
       - asset_tag
       - created
       - hardware_product_id
+      - sku
       - health
       - hostname
       - last_seen
@@ -353,6 +357,8 @@ definitions:
         format: date-time
       hardware_product_id:
         $ref: common.yaml#/definitions/uuid
+      sku:
+        type: string
       health:
         $ref: common.yaml#/definitions/device_health
       hostname:
@@ -707,6 +713,7 @@ definitions:
           - id
           - name
           - alias
+          - sku
           - hardware_vendor_id
         properties:
           id:
@@ -718,6 +725,8 @@ definitions:
             type: string
           alias:
             description: Hardware product alias
+            type: string
+          sku:
             type: string
           hardware_vendor_id:
             $ref: common.yaml#/definitions/uuid

--- a/lib/Conch/Controller/Build.pm
+++ b/lib/Conch/Controller/Build.pm
@@ -612,8 +612,8 @@ sub get_devices ($c) {
     # this query is carefully constructed to be efficient.
     # don't mess with it without checking with DBIC_TRACE=1.
     my $rs = $c->db_devices
-        ->search({ id => [ map +{ -in => $_->get_column('id')->as_query }, $direct_devices_rs, $rack_devices_rs ] })
-        ->prefetch('device_location')
+        ->search({ 'device.id' => [ map +{ -in => $_->get_column('id')->as_query }, $direct_devices_rs, $rack_devices_rs ] })
+        ->with_device_location
         ->order_by('device.created');
 
     $c->status(200, [ $rs->all ]);

--- a/lib/Conch/Controller/Build.pm
+++ b/lib/Conch/Controller/Build.pm
@@ -614,6 +614,7 @@ sub get_devices ($c) {
     my $rs = $c->db_devices
         ->search({ 'device.id' => [ map +{ -in => $_->get_column('id')->as_query }, $direct_devices_rs, $rack_devices_rs ] })
         ->with_device_location
+        ->with_sku
         ->order_by('device.created');
 
     $c->status(200, [ $rs->all ]);

--- a/lib/Conch/Controller/Build.pm
+++ b/lib/Conch/Controller/Build.pm
@@ -22,10 +22,17 @@ Response uses the Builds json schema.
 =cut
 
 sub list ($c) {
+    my $params = $c->validate_query_params('WithDeviceHealth');
+    return if not $params;
+
     my $rs = $c->db_builds
         ->search({ 'user_build_roles.role' => 'admin' })
         ->prefetch([ { user_build_roles => 'user_account' }, 'completed_user' ])
         ->order_by([qw(build.name user_account.name)]);
+
+    $rs = $rs->with_device_health_counts
+        if !exists $params->{with_device_health} ? 0
+           : length $params->{with_device_health} ? $params->{with_device_health} : 1;
 
     return $c->status(200, [ $rs->all ]) if $c->is_system_admin;
 
@@ -126,12 +133,19 @@ Response uses the Build json schema.
 =cut
 
 sub get ($c) {
-    my ($build) = $c->stash('build_rs')
+    my $params = $c->validate_query_params('WithDeviceHealth');
+    return if not $params;
+
+    my $rs = $c->stash('build_rs')
         ->search({ 'user_build_roles.role' => 'admin' })
         ->prefetch([ { user_build_roles => 'user_account' }, 'completed_user' ])
-        ->order_by('user_account.name')
-        ->all;
-    $c->status(200, $build);
+        ->order_by('user_account.name');
+
+    $rs = $rs->with_device_health_counts
+        if !exists $params->{with_device_health} ? 0
+           : length $params->{with_device_health} ? $params->{with_device_health} : 1;
+
+    $c->status(200, ($rs->all)[0]);
 }
 
 =head2 update

--- a/lib/Conch/Controller/Device.pm
+++ b/lib/Conch/Controller/Device.pm
@@ -255,7 +255,7 @@ sub lookup_by_other_attribute ($c) {
     }
 
     my @devices = $device_rs
-        ->prefetch('device_location')
+        ->with_device_location
         ->order_by('device.created')
         ->all;
 

--- a/lib/Conch/Controller/Device.pm
+++ b/lib/Conch/Controller/Device.pm
@@ -134,7 +134,7 @@ sub get ($c) {
     # TODO: this is really a weak etag. requires https://github.com/mojolicious/mojo/pull/1420
     return $c->status(304) if $c->is_fresh(etag => $etag);
 
-    my $device = $c->stash('device_rs')->single;
+    my $device = $c->stash('device_rs')->with_sku->single;
     my $latest_report = $c->stash('device_rs')->latest_device_report->get_column('report')->single;
 
     my $detailed_device = +{
@@ -158,7 +158,7 @@ sub get ($c) {
             datacenter => $location->rack->datacenter_room->datacenter,
             target_hardware_product => +{ do {
                 my $hardware_product = $location->rack_layout->hardware_product;
-                map +($_ => $hardware_product->$_), qw(id name alias hardware_vendor_id);
+                map +($_ => $hardware_product->$_), qw(id name alias sku hardware_vendor_id);
             } },
         } : undef;
 
@@ -256,6 +256,7 @@ sub lookup_by_other_attribute ($c) {
 
     my @devices = $device_rs
         ->with_device_location
+        ->with_sku
         ->order_by('device.created')
         ->all;
 

--- a/lib/Conch/Controller/DeviceLocation.pm
+++ b/lib/Conch/Controller/DeviceLocation.pm
@@ -39,7 +39,7 @@ sub get ($c) {
         rack_unit_start => $location->get_column('rack_unit_start'),
         datacenter_room => $rack->datacenter_room,
         datacenter => $rack->datacenter_room->datacenter,
-        target_hardware_product => { map +($_ => $hardware_product->$_), qw(id name alias hardware_vendor_id) },
+        target_hardware_product => { map +($_ => $hardware_product->$_), qw(id name alias sku hardware_vendor_id) },
     };
 
     $c->status(200, $location_data);

--- a/lib/Conch/Controller/WorkspaceDevice.pm
+++ b/lib/Conch/Controller/WorkspaceDevice.pm
@@ -54,7 +54,7 @@ sub list ($c) {
 
     $devices_rs = $params->{ids_only}
         ? $devices_rs->get_column('id')
-        : $devices_rs->with_device_location;
+        : $devices_rs->with_device_location->with_sku;
 
     my @devices = $devices_rs->all;
 

--- a/lib/Conch/Controller/WorkspaceDevice.pm
+++ b/lib/Conch/Controller/WorkspaceDevice.pm
@@ -54,7 +54,7 @@ sub list ($c) {
 
     $devices_rs = $params->{ids_only}
         ? $devices_rs->get_column('id')
-        : $devices_rs->prefetch('device_location');
+        : $devices_rs->with_device_location;
 
     my @devices = $devices_rs->all;
 

--- a/lib/Conch/Controller/WorkspaceRelay.pm
+++ b/lib/Conch/Controller/WorkspaceRelay.pm
@@ -99,7 +99,7 @@ sub get_relay_devices ($c) {
         ->related_resultset('device_locations')
         ->search_related('device',
             { relay_id => $c->stash('relay_id') }, { join => 'device_relay_connections' })
-        ->prefetch('device_location')
+        ->with_device_location
         ->order_by('device.created');
 
     my @devices = $devices_rs->all;

--- a/lib/Conch/Controller/WorkspaceRelay.pm
+++ b/lib/Conch/Controller/WorkspaceRelay.pm
@@ -100,6 +100,7 @@ sub get_relay_devices ($c) {
         ->search_related('device',
             { relay_id => $c->stash('relay_id') }, { join => 'device_relay_connections' })
         ->with_device_location
+        ->with_sku
         ->order_by('device.created');
 
     my @devices = $devices_rs->all;

--- a/lib/Conch/DB/Result/Build.pm
+++ b/lib/Conch/DB/Result/Build.pm
@@ -260,6 +260,14 @@ sub TO_JSON ($self) {
         $completed_user ? +{ map +($_ => $completed_user->$_), qw(id name email) }
       : undef;
 
+    if ($self->has_column_loaded('device_health')) {
+        my @health_enum = $self->related_resultset('devices')->result_source->column_info('health')->{extra}{list}->@*;
+        $data->{device_health}->@{@health_enum} = (0)x@health_enum;
+
+        my %health_data = map $_->@*, $self->get_column('device_health')->@*;
+        $data->{device_health}->@{keys %health_data} = map int, values %health_data;
+    }
+
     return $data;
 }
 

--- a/lib/Conch/DB/Result/Device.pm
+++ b/lib/Conch/DB/Result/Device.pm
@@ -410,11 +410,10 @@ sub TO_JSON ($self) {
     my $data = $self->next::method(@_);
 
     # include location information, when available and still relevant
-    if (my $cached_location = $self->related_resultset('device_location')->get_cache
-            and $self->phase_cmp('production') < 0) {
-        # the cache is always a listref, if it was prefetched.
-        $data->{rack_id} = @$cached_location ? $cached_location->[0]->rack_id : undef;
-        $data->{rack_unit_start} = @$cached_location ? $cached_location->[0]->rack_unit_start : undef;
+    # (see $device_rs->with_device_location)
+    if ($self->has_column_loaded('rack_id') and $self->phase_cmp('production') < 0) {
+        $data->@{qw(rack_id rack_unit_start rack_name)} =
+            map $self->get_column($_), qw(rack_id rack_unit_start rack_name);
     }
 
     return $data;

--- a/lib/Conch/DB/Result/Device.pm
+++ b/lib/Conch/DB/Result/Device.pm
@@ -409,6 +409,8 @@ use experimental 'signatures';
 sub TO_JSON ($self) {
     my $data = $self->next::method(@_);
 
+    $data->{sku} = $self->get_column('sku') if $self->has_column_loaded('sku');
+
     # include location information, when available and still relevant
     # (see $device_rs->with_device_location)
     if ($self->has_column_loaded('rack_id') and $self->phase_cmp('production') < 0) {

--- a/lib/Conch/DB/ResultSet/Build.pm
+++ b/lib/Conch/DB/ResultSet/Build.pm
@@ -106,6 +106,21 @@ sub user_has_role ($self, $user_id, $role) {
     return $via_user_rs->union_all($via_org_rs)->exists;
 }
 
+=head2 with_device_health_counts
+
+Modifies the resultset to add on a column named C<device_health>) containing an array of arrays
+of correlated counts of device.health values for each build.
+
+=cut
+
+sub with_device_health_counts ($self) {
+    my $health_rs = $self->correlate('devices')
+        ->search(undef, { select => [ \'array[health::text, count(*)::text]' ] })
+        ->group_by('health');
+
+    $self->add_columns({ device_health => { array => $health_rs->as_query } });
+}
+
 1;
 __END__
 

--- a/lib/Conch/DB/ResultSet/Device.pm
+++ b/lib/Conch/DB/ResultSet/Device.pm
@@ -179,6 +179,20 @@ sub device_settings_as_hash {
         $self->related_resultset('device_settings')->active->order_by('created');
 }
 
+=head2 with_device_location
+
+Modifies the resultset to add columns C<rack_id>, C<rack_unit_start> and C<rack_name>.
+
+=cut
+
+sub with_device_location ($self) {
+    $self->search(undef, { join => { device_location => 'rack' } })
+        ->add_columns({
+            (map +($_ => 'device_location.'.$_), qw(rack_id rack_unit_start)),
+            rack_name => 'rack.name',
+        });
+}
+
 1;
 __END__
 

--- a/lib/Conch/DB/ResultSet/Device.pm
+++ b/lib/Conch/DB/ResultSet/Device.pm
@@ -193,6 +193,17 @@ sub with_device_location ($self) {
         });
 }
 
+=head2 with_sku
+
+Modifies the resultset to add the C<sku> column.
+
+=cut
+
+sub with_sku ($self) {
+    $self->search(undef, { join => 'hardware_product' })
+        ->add_columns({ sku => 'hardware_product.sku' });
+}
+
 1;
 __END__
 

--- a/lib/Conch/Route/Build.pm
+++ b/lib/Conch/Route/Build.pm
@@ -112,6 +112,9 @@ Unless otherwise noted, all routes require authentication.
 
 =head3 C<GET /build>
 
+Takes one optional query parameter C<< device_health >> (defaults to false) to include
+correlated counts of devices having each health value.
+
 =over 4
 
 =item * Response: response.yaml#/Builds
@@ -131,6 +134,9 @@ Unless otherwise noted, all routes require authentication.
 =back
 
 =head3 C<GET /build/:build_id_or_name>
+
+Takes one optional query parameter C<< device_health >> (defaults to false) to include counts
+of devices having each health value.
 
 =over 4
 

--- a/t/integration/crud/build.t
+++ b/t/integration/crud/build.t
@@ -658,6 +658,7 @@ $t->get_ok('/build/our second build/device')
         superhashof({
             serial_number => 'FOO',
             hardware_product_id => $hardware_product->id,
+            health => 'unknown',
             asset_tag => undef,
             links => [],
             build_id => $build2->{id},
@@ -665,6 +666,43 @@ $t->get_ok('/build/our second build/device')
         }),
     ]);
 my $devices = $t->tx->res->json;
+
+$t->get_ok('/build?with_device_health')
+    ->status_is(200)
+    ->json_schema_is('Builds')
+    ->json_is([
+        {
+            $build->%*,
+            device_health => {
+                error => 0,
+                fail => 0,
+                unknown => 0,
+                pass => 0,
+            },
+        },
+        {
+            $build2->%*,
+            device_health => {
+                error => 0,
+                fail => 0,
+                unknown => 1,
+                pass => 0,
+            },
+        },
+    ]);
+
+$t->get_ok('/build/our second build?with_device_health')
+    ->status_is(200)
+    ->json_schema_is('Build')
+    ->json_is({
+        $build2->%*,
+        device_health => {
+            error => 0,
+            fail => 0,
+            unknown => 1,
+            pass => 0,
+        },
+    });
 
 $t->post_ok('/build/our second build/device', json => [ {
         serial_number => 'FOO',

--- a/t/integration/crud/devices.t
+++ b/t/integration/crud/devices.t
@@ -668,7 +668,7 @@ my @macs = map $_->{mac}, $detailed_device->{nics}->@*;
 
 my $undetailed_device = {
     $detailed_device->%*,
-    ($t->app->db_device_locations->search({ device_id => $test_device_id })->hri->single // {})->%{qw(rack_id rack_unit_start)},
+    ($t->app->db_devices->search({ 'device.id' => $test_device_id })->columns([])->with_device_location->hri->single // {})->%{qw(rack_id rack_unit_start rack_name)},
 };
 delete $undetailed_device->@{qw(latest_report location nics disks)};
 
@@ -714,7 +714,7 @@ subtest 'get by device attributes' => sub {
     $test_device->update({ phase => 'production' });
 
     $undetailed_device->{phase} = 'production';
-    delete $undetailed_device->@{qw(rack_id rack_unit_start)};
+    delete $undetailed_device->@{qw(rack_id rack_unit_start rack_name)};
 
     foreach my $query (qw(
         /device?hostname=elfo

--- a/t/integration/crud/devices.t
+++ b/t/integration/crud/devices.t
@@ -155,6 +155,7 @@ subtest 'unlocated device with a registered relay' => sub {
             (map +($_ => undef), qw(asset_tag uptime_since validated)),
             (map +($_ => re(qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/)), qw(created updated last_seen)),
             hardware_product_id => $hardware_product->id,
+            sku => $hardware_product->sku,
             location => undef,
             latest_report => from_json($report),
             nics => supersetof(),
@@ -362,6 +363,7 @@ subtest 'located device' => sub {
             (map +($_ => undef), qw(asset_tag hostname last_seen system_uuid uptime_since validated)),
             (map +($_ => re(qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/)), qw(created updated)),
             hardware_product_id => $hardware_product->id,
+            sku => $hardware_product->sku,
             location => {
                 rack => {
                     (map +($_ => $rack->$_), qw(id name datacenter_room_id serial_number asset_tag phase)),
@@ -1159,7 +1161,7 @@ subtest 'Device location' => sub {
             rack => superhashof({ id => $rack_id, name => $rack->name }),
             rack_unit_start => 3,
             target_hardware_product => {
-                (map +($_ => $layout->hardware_product->$_), qw(id name alias hardware_vendor_id)),
+                (map +($_ => $layout->hardware_product->$_), qw(id name alias sku hardware_vendor_id)),
             },
         });
     my $location_data = $t_build->tx->res->json;

--- a/t/integration/crud/workspace-rack.t
+++ b/t/integration/crud/workspace-rack.t
@@ -119,7 +119,7 @@ subtest 'Assign device to a location' => sub {
             datacenter_room => superhashof({ datacenter_id => $rack->datacenter_room->datacenter_id }),
             datacenter => superhashof({ id => $rack->datacenter_room->datacenter_id }),
             target_hardware_product => {
-                (map +($_ => $hardware_product_compute->$_), qw(id name alias hardware_vendor_id)),
+                (map +($_ => $hardware_product_compute->$_), qw(id name alias sku hardware_vendor_id)),
             },
         });
 


### PR DESCRIPTION
More data added to device endpoints, for the UI build pages.

- add ?with_device_health to GET /build, GET /build/:id
- add rack_name to Device, Devices response schemas (see below)
- add sku to DetailedDevice, Device, Devices, DeviceLocation response schemas (see below)

for #922.

Device endpoints affected:

GET /device/:id_or_serial_number
GET /device/:id_or_serial_number/location
GET /device?:key=:value
GET /build/:build_id_or_name/device
GET /workspace/:workspace_id_or_name/device
GET /workspace/:workspace_id_or_name/relay/:relay_id>/device

