### PR TITLE
v3: a9 more build enhancements

### DIFF
--- a/docs/json-schema/query_params.json
+++ b/docs/json-schema/query_params.json
@@ -2,6 +2,43 @@
   "$comment" : "NOTE: This file is for human reference ONLY. For programmatic use, use the GET '/schema/query_params/$schema_name' endpoints, or within conch itself, json-schema/query_params.yaml.\nNote: for now, defaults are for documentation purposes only. see https://github.com/mojolicious/json-validator/issues/158",
   "$schema" : "http://json-schema.org/draft-07/schema#",
   "definitions" : {
+    "BuildDevices" : {
+      "additionalProperties" : false,
+      "properties" : {
+        "active_minutes" : {
+          "$ref" : "common.json#/definitions/non_negative_integer"
+        },
+        "health" : {
+          "oneOf" : [
+            {
+              "$ref" : "common.json#/definitions/device_health"
+            },
+            {
+              "items" : {
+                "$ref" : "common.json#/definitions/device_health"
+              },
+              "minItems" : 2,
+              "type" : "array",
+              "uniqueItems" : true
+            }
+          ]
+        },
+        "ids_only" : {
+          "$ref" : "/definitions/boolean_integer_default_false"
+        },
+        "phase_earlier_than" : {
+          "oneOf" : [
+            {
+              "const" : ""
+            },
+            {
+              "$ref" : "common.json#/definitions/device_phase"
+            }
+          ]
+        }
+      },
+      "type" : "object"
+    },
     "ChangePassword" : {
       "additionalProperties" : false,
       "properties" : {

--- a/docs/json-schema/request.json
+++ b/docs/json-schema/request.json
@@ -50,6 +50,18 @@
     },
     "BuildCreate" : {
       "additionalProperties" : false,
+      "oneOf" : [
+        {
+          "required" : [
+            "admins"
+          ]
+        },
+        {
+          "required" : [
+            "build_id"
+          ]
+        }
+      ],
       "properties" : {
         "admins" : {
           "items" : {
@@ -80,6 +92,9 @@
           "type" : "array",
           "uniqueItems" : true
         },
+        "build_id" : {
+          "$ref" : "common.json#/definitions/uuid"
+        },
         "description" : {
           "type" : "string"
         },
@@ -92,8 +107,7 @@
         }
       },
       "required" : [
-        "name",
-        "admins"
+        "name"
       ],
       "type" : "object"
     },

--- a/docs/json-schema/request.json
+++ b/docs/json-schema/request.json
@@ -85,6 +85,10 @@
         },
         "name" : {
           "$ref" : "common.json#/definitions/mojo_standard_placeholder"
+        },
+        "started" : {
+          "format" : "date-time",
+          "type" : "string"
         }
       },
       "required" : [

--- a/docs/modules/Conch::Controller::Build.md
+++ b/docs/modules/Conch::Controller::Build.md
@@ -93,7 +93,17 @@ to all organization members and to all build admins.
 Get the devices in this build.  (Includes devices located in rack(s) in this build.)
 Requires the 'read-only' role on the build.
 
-Response uses the Devices json schema.
+Supports these query parameters to constrain results (which are ANDed together for the search,
+not ORed):
+
+```
+health=<value>      only devices with health matching the provided value
+    (can be used more than once to search for ANY of the specified health values)
+active_minutes=X    only devices last seen (via a report relay) within X minutes
+ids_only=1          only return device ids, not full data
+```
+
+Response uses the Devices json schema, or DeviceIds iff `ids_only=1`.
 
 ## create\_and\_add\_devices
 

--- a/docs/modules/Conch::Route::Build.md
+++ b/docs/modules/Conch::Route::Build.md
@@ -83,6 +83,13 @@ an email to the organization members and build admins.
 
 ### `GET /build/:build_id_or_name/device`
 
+Accepts the following optional query parameters:
+
+- `health=<value>` show only devices with the health matching the provided value
+(can be used more than once)
+- `active_minutes=X` show only devices which have reported within the last X minutes
+- `ids_only=1` only return device IDs, not full device details
+
 - Requires system admin authorization or the read-only role on the build
 - Response: response.yaml#/Devices
 

--- a/json-schema/query_params.yaml
+++ b/json-schema/query_params.yaml
@@ -144,5 +144,25 @@ definitions:
     properties:
       with_device_health:
         $ref: /definitions/boolean_integer_or_flag
+  BuildDevices:
+    type: object
+    additionalProperties: false
+    properties:
+      phase_earlier_than:
+        oneOf:
+          - const: ''
+          - $ref: common.yaml#/definitions/device_phase
+      health:
+        oneOf:
+          - $ref: common.yaml#/definitions/device_health
+          - type: array
+            uniqueItems: true
+            minItems: 2
+            items:
+              $ref: common.yaml#/definitions/device_health
+      active_minutes:
+        $ref: common.yaml#/definitions/non_negative_integer
+      ids_only:
+        $ref: /definitions/boolean_integer_default_false
 
 # vim: set sts=2 sw=2 et :

--- a/json-schema/request.yaml
+++ b/json-schema/request.yaml
@@ -618,6 +618,9 @@ definitions:
         $ref: common.yaml#/definitions/mojo_standard_placeholder
       description:
         type: string
+      started:
+        type: string
+        format: date-time
       admins:
         type: array
         uniqueItems: true

--- a/json-schema/request.yaml
+++ b/json-schema/request.yaml
@@ -612,7 +612,11 @@ definitions:
     additionalProperties: false
     required:
       - name
-      - admins
+    oneOf:
+      - required:
+        - admins
+      - required:
+        - build_id
     properties:
       name:
         $ref: common.yaml#/definitions/mojo_standard_placeholder
@@ -638,6 +642,8 @@ definitions:
               $ref: common.yaml#/definitions/uuid
             email:
               $ref: common.yaml#/definitions/email_address
+      build_id:
+        $ref: common.yaml#/definitions/uuid
   BuildUpdate:
     type: object
     additionalProperties: false

--- a/lib/Conch/Route/Build.pm
+++ b/lib/Conch/Route/Build.pm
@@ -236,6 +236,19 @@ an email to the organization members and build admins.
 
 =head3 C<GET /build/:build_id_or_name/device>
 
+Accepts the following optional query parameters:
+
+=over 4
+
+=item * C<< health=<value> >> show only devices with the health matching the provided value
+(can be used more than once)
+
+=item * C<active_minutes=X> show only devices which have reported within the last X minutes
+
+=item * C<ids_only=1> only return device IDs, not full device details
+
+=back
+
 =over 4
 
 =item * Requires system admin authorization or the read-only role on the build

--- a/t/integration/crud/build.t
+++ b/t/integration/crud/build.t
@@ -159,7 +159,12 @@ $t->post_ok('/build', json => { name => 'my first build', admins => [ { email =>
     ->status_is(409)
     ->json_is({ error => 'a build already exists with that name' });
 
-$t->post_ok('/build', json => { name => 'our second build', description => 'funky', admins => [ { email => $admin_user->email } ] })
+$t->post_ok('/build', json => {
+        name => 'our second build',
+        description => 'funky',
+        started => '2019-01-01T00:00:00Z',
+        admins => [ { email => $admin_user->email } ],
+    })
     ->status_is(303)
     ->location_like(qr!^/build/${\Conch::UUID::UUID_FORMAT}$!)
     ->log_info_like(qr/^created build ${\Conch::UUID::UUID_FORMAT} \(our second build\)$/);
@@ -174,7 +179,7 @@ $t->get_ok('/build')
             name => 'our second build',
             description => 'funky',
             created => re(qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/),
-            started => undef,
+            started => '2019-01-01T00:00:00.000Z',
             completed => undef,
             admins => [
                 { map +($_ => $admin_user->$_), qw(id name email) },

--- a/t/integration/crud/build.t
+++ b/t/integration/crud/build.t
@@ -32,7 +32,10 @@ $t->post_ok('/build', json => { name => 'my first build', admins => [ {} ] })
 $t->post_ok('/build', json => { name => 'my first build' })
     ->status_is(400)
     ->json_schema_is('RequestValidationError')
-    ->json_cmp_deeply('/details', [ { path => '/admins', message => re(qr/missing property/i) } ] );
+    ->json_cmp_deeply('/details', [
+            { path => '/admins', message => re(qr/missing property/i) },
+            { path => '/build_id', message => re(qr/missing property/i) },
+        ] );
 
 $t->post_ok('/build', json => {
         name => 'my first build',
@@ -163,7 +166,16 @@ $t->post_ok('/build', json => {
         name => 'our second build',
         description => 'funky',
         started => '2019-01-01T00:00:00Z',
-        admins => [ { email => $admin_user->email } ],
+        build_id => create_uuid_str,
+    })
+    ->status_is(409)
+    ->json_cmp_deeply({ error => re(qr/^unrecognized build_id ${\Conch::UUID::UUID_FORMAT}$/) });
+
+$t->post_ok('/build', json => {
+        name => 'our second build',
+        description => 'funky',
+        started => '2019-01-01T00:00:00Z',
+        build_id => $build->{id},
     })
     ->status_is(303)
     ->location_like(qr!^/build/${\Conch::UUID::UUID_FORMAT}$!)


### PR DESCRIPTION
- allow "started" as an optional field to POST /build/:id_or_name
- add support for "cloning" a build (POST /build)
-  Add search parameters to for devices in a build: GET /build/:id_or_name/device?health=<value>&health=<other_value>&active_minutes=X&ids_only=1