### PR TITLE
v3: the "last" fixes

### DIFF
--- a/bin/conch
+++ b/bin/conch
@@ -55,6 +55,9 @@ die '. is in %INC: this is not safe'
 
 use Mojolicious::Commands;
 
+# hypnotoad will override this to 'production'
+$ENV{MOJO_MODE} ||= 'command';
+
 # Start command line interface for application
 Mojolicious::Commands->start_app('Conch');
 

--- a/cpanfile
+++ b/cpanfile
@@ -29,6 +29,7 @@ requires 'Email::Simple';
 requires 'Email::Sender::Simple';
 requires 'Email::Sender::Transport::SMTP';
 requires 'Net::DNS';    # not used directly, but Email::Valid sometimes demands it
+requires 'experimental', '0.020';
 
 # mojolicious and networking
 requires 'Mojolicious', '8.15';
@@ -61,6 +62,7 @@ requires 'Devel::Confess';
 # misc scripts
 requires 'Pod::Usage';
 requires 'Pod::Markdown::Github';
+requires 'Pod::Markdown', '3.200';
 requires 'Getopt::Long';
 
 # database and rendering
@@ -72,7 +74,7 @@ requires 'DateTime::Format::Pg';    # used by DBIx::Class::Storage::DBI::Pg
 requires 'DBIx::Class::InflateColumn::TimeMoment';
 requires 'Lingua::EN::Inflexion';
 requires 'Text::CSV_XS';
-requires 'DBIx::Class::PassphraseColumn', dist => 'ETHER/DBIx-Class-PassphraseColumn-0.04-TRIAL.tar.gz';
+requires 'DBIx::Class::PassphraseColumn';
 requires 'Authen::Passphrase::BlowfishCrypt';
 
 on 'test' => sub {

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -9,25 +9,6 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 0
       Test::More 0.47
       perl 5.006
-  Algorithm-Combinatorics-0.27
-    pathname: F/FX/FXN/Algorithm-Combinatorics-0.27.tar.gz
-    provides:
-      Algorithm::Combinatorics 0.27
-      Algorithm::Combinatorics::Iterator 0.27
-      Algorithm::Combinatorics::JustCoderef 0.27
-    requirements:
-      ExtUtils::MakeMaker 0
-      FindBin 0
-      Scalar::Util 0
-      Test::More 0
-      XSLoader 0
-  Algorithm-Diff-1.1903
-    pathname: T/TY/TYEMQ/Algorithm-Diff-1.1903.tar.gz
-    provides:
-      Algorithm::Diff 1.1903
-      Algorithm::Diff::_impl 1.1903
-    requirements:
-      ExtUtils::MakeMaker 0
   Authen-DecHpwd-2.007
     pathname: Z/ZE/ZEFRAM/Authen-DecHpwd-2.007.tar.gz
     provides:
@@ -184,10 +165,10 @@ DISTRIBUTIONS
       perl 5.006
       strict 0
       warnings 0
-  Carp-Clan-6.07
-    pathname: E/ET/ETHER/Carp-Clan-6.07.tar.gz
+  Carp-Clan-6.08
+    pathname: E/ET/ETHER/Carp-Clan-6.08.tar.gz
     provides:
-      Carp::Clan 6.07
+      Carp::Clan 6.08
     requirements:
       ExtUtils::MakeMaker 0
       overload 0
@@ -289,19 +270,20 @@ DISTRIBUTIONS
       Class::Data::Inheritable 0.08
     requirements:
       ExtUtils::MakeMaker 0
-  Class-Inspector-1.34
-    pathname: P/PL/PLICEASE/Class-Inspector-1.34.tar.gz
+  Class-Inspector-1.36
+    pathname: P/PL/PLICEASE/Class-Inspector-1.36.tar.gz
     provides:
-      Class::Inspector 1.34
-      Class::Inspector::Functions 1.34
+      Class::Inspector 1.36
+      Class::Inspector::Functions 1.36
     requirements:
       ExtUtils::MakeMaker 0
       File::Spec 0.80
-      perl 5.006
-  Class-Method-Modifiers-2.12
-    pathname: E/ET/ETHER/Class-Method-Modifiers-2.12.tar.gz
+      base 0
+      perl 5.008
+  Class-Method-Modifiers-2.13
+    pathname: E/ET/ETHER/Class-Method-Modifiers-2.13.tar.gz
     provides:
-      Class::Method::Modifiers 2.12
+      Class::Method::Modifiers 2.13
     requirements:
       B 0
       Carp 0
@@ -397,14 +379,22 @@ DISTRIBUTIONS
       perl 5.006
       strict 0
       warnings 0
-  Cpanel-JSON-XS-4.12
-    pathname: R/RU/RURBAN/Cpanel-JSON-XS-4.12.tar.gz
+  Cpanel-JSON-XS-4.15
+    pathname: R/RU/RURBAN/Cpanel-JSON-XS-4.15.tar.gz
     provides:
-      Cpanel::JSON::XS 4.12
+      Cpanel::JSON::XS 4.15
       Cpanel::JSON::XS::Type undef
     requirements:
+      Carp 0
+      Config 0
+      Encode 1.9801
+      Exporter 0
       ExtUtils::MakeMaker 0
       Pod::Text 2.08
+      XSLoader 0
+      overload 0
+      strict 0
+      warnings 0
   Crypt-DES-2.07
     pathname: D/DP/DPARIS/Crypt-DES-2.07.tar.gz
     provides:
@@ -475,14 +465,14 @@ DISTRIBUTIONS
       Test::More 0.88
       Time::HiRes 0
       version 0
-  DBD-SQLite-1.62
-    pathname: I/IS/ISHIGAKI/DBD-SQLite-1.62.tar.gz
+  DBD-SQLite-1.64
+    pathname: I/IS/ISHIGAKI/DBD-SQLite-1.64.tar.gz
     provides:
-      DBD::SQLite 1.62
+      DBD::SQLite 1.64
       DBD::SQLite::Constants undef
       DBD::SQLite::GetInfo undef
-      DBD::SQLite::VirtualTable 1.62
-      DBD::SQLite::VirtualTable::Cursor 1.62
+      DBD::SQLite::VirtualTable 1.64
+      DBD::SQLite::VirtualTable::Cursor 1.64
       DBD::SQLite::VirtualTable::FileContent undef
       DBD::SQLite::VirtualTable::FileContent::Cursor undef
       DBD::SQLite::VirtualTable::PerlData undef
@@ -491,8 +481,7 @@ DISTRIBUTIONS
       DBI 1.57
       ExtUtils::MakeMaker 0
       File::Spec 0.82
-      Test::Builder 0.86
-      Test::More 0.47
+      Test::More 0.88
       Tie::Hash 0
       perl 5.006
   DBI-1.642
@@ -749,79 +738,79 @@ DISTRIBUTIONS
       aliased 0
       namespace::autoclean 0
       perl 5.010
-  DBIx-Class-Helpers-2.033004
-    pathname: F/FR/FREW/DBIx-Class-Helpers-2.033004.tar.gz
+  DBIx-Class-Helpers-2.034000
+    pathname: F/FR/FREW/DBIx-Class-Helpers-2.034000.tar.gz
     provides:
-      DBIx::Class::Helper::IgnoreWantarray 2.033004
-      DBIx::Class::Helper::JoinTable 2.033004
-      DBIx::Class::Helper::Random 2.033004
-      DBIx::Class::Helper::ResultClass::Tee 2.033004
-      DBIx::Class::Helper::ResultSet 2.033004
-      DBIx::Class::Helper::ResultSet::AutoRemoveColumns 2.033004
-      DBIx::Class::Helper::ResultSet::Bare 2.033004
-      DBIx::Class::Helper::ResultSet::CorrelateRelationship 2.033004
-      DBIx::Class::Helper::ResultSet::DateMethods1 2.033004
-      DBIx::Class::Helper::ResultSet::Errors 2.033004
-      DBIx::Class::Helper::ResultSet::Explain 2.033004
-      DBIx::Class::Helper::ResultSet::IgnoreWantarray 2.033004
-      DBIx::Class::Helper::ResultSet::Me 2.033004
-      DBIx::Class::Helper::ResultSet::NoColumns 2.033004
-      DBIx::Class::Helper::ResultSet::OneRow 2.033004
-      DBIx::Class::Helper::ResultSet::Random 2.033004
-      DBIx::Class::Helper::ResultSet::RemoveColumns 2.033004
-      DBIx::Class::Helper::ResultSet::ResultClassDWIM 2.033004
-      DBIx::Class::Helper::ResultSet::SearchOr 2.033004
-      DBIx::Class::Helper::ResultSet::SetOperations 2.033004
-      DBIx::Class::Helper::ResultSet::Shortcut 2.033004
-      DBIx::Class::Helper::ResultSet::Shortcut::AddColumns 2.033004
-      DBIx::Class::Helper::ResultSet::Shortcut::Columns 2.033004
-      DBIx::Class::Helper::ResultSet::Shortcut::Distinct 2.033004
-      DBIx::Class::Helper::ResultSet::Shortcut::GroupBy 2.033004
-      DBIx::Class::Helper::ResultSet::Shortcut::HRI 2.033004
-      DBIx::Class::Helper::ResultSet::Shortcut::HasRows 2.033004
-      DBIx::Class::Helper::ResultSet::Shortcut::Limit 2.033004
-      DBIx::Class::Helper::ResultSet::Shortcut::LimitedPage 2.033004
-      DBIx::Class::Helper::ResultSet::Shortcut::OrderBy 2.033004
-      DBIx::Class::Helper::ResultSet::Shortcut::OrderByMagic 2.033004
-      DBIx::Class::Helper::ResultSet::Shortcut::Page 2.033004
-      DBIx::Class::Helper::ResultSet::Shortcut::Prefetch 2.033004
-      DBIx::Class::Helper::ResultSet::Shortcut::ResultsExist 2.033004
-      DBIx::Class::Helper::ResultSet::Shortcut::Rows 2.033004
-      DBIx::Class::Helper::ResultSet::Shortcut::Search 2.033004
-      DBIx::Class::Helper::ResultSet::Shortcut::Search::Base 2.033004
-      DBIx::Class::Helper::ResultSet::Shortcut::Search::Like 2.033004
-      DBIx::Class::Helper::ResultSet::Shortcut::Search::NotLike 2.033004
-      DBIx::Class::Helper::ResultSet::Shortcut::Search::NotNull 2.033004
-      DBIx::Class::Helper::ResultSet::Shortcut::Search::Null 2.033004
-      DBIx::Class::Helper::ResultSet::Union 2.033004
-      DBIx::Class::Helper::ResultSet::Util 2.033004
-      DBIx::Class::Helper::ResultSet::VirtualView 2.033004
-      DBIx::Class::Helper::Row::CleanResultSet 2.033004
-      DBIx::Class::Helper::Row::JoinTable 2.033004
-      DBIx::Class::Helper::Row::NumifyGet 2.033004
-      DBIx::Class::Helper::Row::OnColumnChange 2.033004
-      DBIx::Class::Helper::Row::OnColumnMissing 2.033004
-      DBIx::Class::Helper::Row::ProxyResultSetMethod 2.033004
-      DBIx::Class::Helper::Row::ProxyResultSetUpdate 2.033004
-      DBIx::Class::Helper::Row::RelationshipDWIM 2.033004
-      DBIx::Class::Helper::Row::SelfResultSet 2.033004
-      DBIx::Class::Helper::Row::StorageValues 2.033004
-      DBIx::Class::Helper::Row::SubClass 2.033004
-      DBIx::Class::Helper::Row::ToJSON 2.033004
-      DBIx::Class::Helper::Schema::DateTime 2.033004
-      DBIx::Class::Helper::Schema::DidYouMean 2.033004
-      DBIx::Class::Helper::Schema::GenerateSource 2.033004
-      DBIx::Class::Helper::Schema::LintContents 2.033004
-      DBIx::Class::Helper::Schema::QuoteNames 2.033004
-      DBIx::Class::Helper::Schema::Verifier 2.033004
-      DBIx::Class::Helper::Schema::Verifier::C3 2.033004
-      DBIx::Class::Helper::Schema::Verifier::ColumnInfo 2.033004
-      DBIx::Class::Helper::Schema::Verifier::Parent 2.033004
-      DBIx::Class::Helper::Schema::Verifier::RelationshipColumnName 2.033004
-      DBIx::Class::Helper::SubClass 2.033004
-      DBIx::Class::Helper::VirtualView 2.033004
-      DBIx::Class::Helpers 2.033004
-      DBIx::Class::Helpers::Util 2.033004
+      DBIx::Class::Helper::IgnoreWantarray 2.034000
+      DBIx::Class::Helper::JoinTable 2.034000
+      DBIx::Class::Helper::Random 2.034000
+      DBIx::Class::Helper::ResultClass::Tee 2.034000
+      DBIx::Class::Helper::ResultSet 2.034000
+      DBIx::Class::Helper::ResultSet::AutoRemoveColumns 2.034000
+      DBIx::Class::Helper::ResultSet::Bare 2.034000
+      DBIx::Class::Helper::ResultSet::CorrelateRelationship 2.034000
+      DBIx::Class::Helper::ResultSet::DateMethods1 2.034000
+      DBIx::Class::Helper::ResultSet::Errors 2.034000
+      DBIx::Class::Helper::ResultSet::Explain 2.034000
+      DBIx::Class::Helper::ResultSet::IgnoreWantarray 2.034000
+      DBIx::Class::Helper::ResultSet::Me 2.034000
+      DBIx::Class::Helper::ResultSet::NoColumns 2.034000
+      DBIx::Class::Helper::ResultSet::OneRow 2.034000
+      DBIx::Class::Helper::ResultSet::Random 2.034000
+      DBIx::Class::Helper::ResultSet::RemoveColumns 2.034000
+      DBIx::Class::Helper::ResultSet::ResultClassDWIM 2.034000
+      DBIx::Class::Helper::ResultSet::SearchOr 2.034000
+      DBIx::Class::Helper::ResultSet::SetOperations 2.034000
+      DBIx::Class::Helper::ResultSet::Shortcut 2.034000
+      DBIx::Class::Helper::ResultSet::Shortcut::AddColumns 2.034000
+      DBIx::Class::Helper::ResultSet::Shortcut::Columns 2.034000
+      DBIx::Class::Helper::ResultSet::Shortcut::Distinct 2.034000
+      DBIx::Class::Helper::ResultSet::Shortcut::GroupBy 2.034000
+      DBIx::Class::Helper::ResultSet::Shortcut::HRI 2.034000
+      DBIx::Class::Helper::ResultSet::Shortcut::HasRows 2.034000
+      DBIx::Class::Helper::ResultSet::Shortcut::Limit 2.034000
+      DBIx::Class::Helper::ResultSet::Shortcut::LimitedPage 2.034000
+      DBIx::Class::Helper::ResultSet::Shortcut::OrderBy 2.034000
+      DBIx::Class::Helper::ResultSet::Shortcut::OrderByMagic 2.034000
+      DBIx::Class::Helper::ResultSet::Shortcut::Page 2.034000
+      DBIx::Class::Helper::ResultSet::Shortcut::Prefetch 2.034000
+      DBIx::Class::Helper::ResultSet::Shortcut::ResultsExist 2.034000
+      DBIx::Class::Helper::ResultSet::Shortcut::Rows 2.034000
+      DBIx::Class::Helper::ResultSet::Shortcut::Search 2.034000
+      DBIx::Class::Helper::ResultSet::Shortcut::Search::Base 2.034000
+      DBIx::Class::Helper::ResultSet::Shortcut::Search::Like 2.034000
+      DBIx::Class::Helper::ResultSet::Shortcut::Search::NotLike 2.034000
+      DBIx::Class::Helper::ResultSet::Shortcut::Search::NotNull 2.034000
+      DBIx::Class::Helper::ResultSet::Shortcut::Search::Null 2.034000
+      DBIx::Class::Helper::ResultSet::Union 2.034000
+      DBIx::Class::Helper::ResultSet::Util 2.034000
+      DBIx::Class::Helper::ResultSet::VirtualView 2.034000
+      DBIx::Class::Helper::Row::CleanResultSet 2.034000
+      DBIx::Class::Helper::Row::JoinTable 2.034000
+      DBIx::Class::Helper::Row::NumifyGet 2.034000
+      DBIx::Class::Helper::Row::OnColumnChange 2.034000
+      DBIx::Class::Helper::Row::OnColumnMissing 2.034000
+      DBIx::Class::Helper::Row::ProxyResultSetMethod 2.034000
+      DBIx::Class::Helper::Row::ProxyResultSetUpdate 2.034000
+      DBIx::Class::Helper::Row::RelationshipDWIM 2.034000
+      DBIx::Class::Helper::Row::SelfResultSet 2.034000
+      DBIx::Class::Helper::Row::StorageValues 2.034000
+      DBIx::Class::Helper::Row::SubClass 2.034000
+      DBIx::Class::Helper::Row::ToJSON 2.034000
+      DBIx::Class::Helper::Schema::DateTime 2.034000
+      DBIx::Class::Helper::Schema::DidYouMean 2.034000
+      DBIx::Class::Helper::Schema::GenerateSource 2.034000
+      DBIx::Class::Helper::Schema::LintContents 2.034000
+      DBIx::Class::Helper::Schema::QuoteNames 2.034000
+      DBIx::Class::Helper::Schema::Verifier 2.034000
+      DBIx::Class::Helper::Schema::Verifier::C3 2.034000
+      DBIx::Class::Helper::Schema::Verifier::ColumnInfo 2.034000
+      DBIx::Class::Helper::Schema::Verifier::Parent 2.034000
+      DBIx::Class::Helper::Schema::Verifier::RelationshipColumnName 2.034000
+      DBIx::Class::Helper::SubClass 2.034000
+      DBIx::Class::Helper::VirtualView 2.034000
+      DBIx::Class::Helpers 2.034000
+      DBIx::Class::Helpers::Util 2.034000
     requirements:
       Carp::Clan 6.04
       DBIx::Class 0.0826
@@ -863,10 +852,10 @@ DISTRIBUTIONS
       perl 5.008
       strict 0
       warnings 0
-  DBIx-Class-PassphraseColumn-0.04-TRIAL
-    pathname: E/ET/ETHER/DBIx-Class-PassphraseColumn-0.04-TRIAL.tar.gz
+  DBIx-Class-PassphraseColumn-0.05
+    pathname: E/ET/ETHER/DBIx-Class-PassphraseColumn-0.05.tar.gz
     provides:
-      DBIx::Class::PassphraseColumn 0.04
+      DBIx::Class::PassphraseColumn 0.05
     requirements:
       DBIx::Class 0
       DBIx::Class::InflateColumn::Authen::Passphrase 0
@@ -1239,15 +1228,15 @@ DISTRIBUTIONS
       parent 0
       strict 0
       warnings 0
-  DateTime-Locale-1.24
-    pathname: D/DR/DROLSKY/DateTime-Locale-1.24.tar.gz
+  DateTime-Locale-1.25
+    pathname: D/DR/DROLSKY/DateTime-Locale-1.25.tar.gz
     provides:
-      DateTime::Locale 1.24
-      DateTime::Locale::Base 1.24
-      DateTime::Locale::Catalog 1.24
-      DateTime::Locale::Data 1.24
-      DateTime::Locale::FromData 1.24
-      DateTime::Locale::Util 1.24
+      DateTime::Locale 1.25
+      DateTime::Locale::Base 1.25
+      DateTime::Locale::Catalog 1.25
+      DateTime::Locale::Data 1.25
+      DateTime::Locale::FromData 1.25
+      DateTime::Locale::Util 1.25
     requirements:
       Carp 0
       Dist::CheckConflicts 0.02
@@ -1263,382 +1252,382 @@ DISTRIBUTIONS
       perl 5.008004
       strict 0
       warnings 0
-  DateTime-TimeZone-2.36
-    pathname: D/DR/DROLSKY/DateTime-TimeZone-2.36.tar.gz
+  DateTime-TimeZone-2.37
+    pathname: D/DR/DROLSKY/DateTime-TimeZone-2.37.tar.gz
     provides:
-      DateTime::TimeZone 2.36
-      DateTime::TimeZone::Africa::Abidjan 2.36
-      DateTime::TimeZone::Africa::Accra 2.36
-      DateTime::TimeZone::Africa::Algiers 2.36
-      DateTime::TimeZone::Africa::Bissau 2.36
-      DateTime::TimeZone::Africa::Cairo 2.36
-      DateTime::TimeZone::Africa::Casablanca 2.36
-      DateTime::TimeZone::Africa::Ceuta 2.36
-      DateTime::TimeZone::Africa::El_Aaiun 2.36
-      DateTime::TimeZone::Africa::Johannesburg 2.36
-      DateTime::TimeZone::Africa::Juba 2.36
-      DateTime::TimeZone::Africa::Khartoum 2.36
-      DateTime::TimeZone::Africa::Lagos 2.36
-      DateTime::TimeZone::Africa::Maputo 2.36
-      DateTime::TimeZone::Africa::Monrovia 2.36
-      DateTime::TimeZone::Africa::Nairobi 2.36
-      DateTime::TimeZone::Africa::Ndjamena 2.36
-      DateTime::TimeZone::Africa::Sao_Tome 2.36
-      DateTime::TimeZone::Africa::Tripoli 2.36
-      DateTime::TimeZone::Africa::Tunis 2.36
-      DateTime::TimeZone::Africa::Windhoek 2.36
-      DateTime::TimeZone::America::Adak 2.36
-      DateTime::TimeZone::America::Anchorage 2.36
-      DateTime::TimeZone::America::Araguaina 2.36
-      DateTime::TimeZone::America::Argentina::Buenos_Aires 2.36
-      DateTime::TimeZone::America::Argentina::Catamarca 2.36
-      DateTime::TimeZone::America::Argentina::Cordoba 2.36
-      DateTime::TimeZone::America::Argentina::Jujuy 2.36
-      DateTime::TimeZone::America::Argentina::La_Rioja 2.36
-      DateTime::TimeZone::America::Argentina::Mendoza 2.36
-      DateTime::TimeZone::America::Argentina::Rio_Gallegos 2.36
-      DateTime::TimeZone::America::Argentina::Salta 2.36
-      DateTime::TimeZone::America::Argentina::San_Juan 2.36
-      DateTime::TimeZone::America::Argentina::San_Luis 2.36
-      DateTime::TimeZone::America::Argentina::Tucuman 2.36
-      DateTime::TimeZone::America::Argentina::Ushuaia 2.36
-      DateTime::TimeZone::America::Asuncion 2.36
-      DateTime::TimeZone::America::Atikokan 2.36
-      DateTime::TimeZone::America::Bahia 2.36
-      DateTime::TimeZone::America::Bahia_Banderas 2.36
-      DateTime::TimeZone::America::Barbados 2.36
-      DateTime::TimeZone::America::Belem 2.36
-      DateTime::TimeZone::America::Belize 2.36
-      DateTime::TimeZone::America::Blanc_Sablon 2.36
-      DateTime::TimeZone::America::Boa_Vista 2.36
-      DateTime::TimeZone::America::Bogota 2.36
-      DateTime::TimeZone::America::Boise 2.36
-      DateTime::TimeZone::America::Cambridge_Bay 2.36
-      DateTime::TimeZone::America::Campo_Grande 2.36
-      DateTime::TimeZone::America::Cancun 2.36
-      DateTime::TimeZone::America::Caracas 2.36
-      DateTime::TimeZone::America::Cayenne 2.36
-      DateTime::TimeZone::America::Chicago 2.36
-      DateTime::TimeZone::America::Chihuahua 2.36
-      DateTime::TimeZone::America::Costa_Rica 2.36
-      DateTime::TimeZone::America::Creston 2.36
-      DateTime::TimeZone::America::Cuiaba 2.36
-      DateTime::TimeZone::America::Curacao 2.36
-      DateTime::TimeZone::America::Danmarkshavn 2.36
-      DateTime::TimeZone::America::Dawson 2.36
-      DateTime::TimeZone::America::Dawson_Creek 2.36
-      DateTime::TimeZone::America::Denver 2.36
-      DateTime::TimeZone::America::Detroit 2.36
-      DateTime::TimeZone::America::Edmonton 2.36
-      DateTime::TimeZone::America::Eirunepe 2.36
-      DateTime::TimeZone::America::El_Salvador 2.36
-      DateTime::TimeZone::America::Fort_Nelson 2.36
-      DateTime::TimeZone::America::Fortaleza 2.36
-      DateTime::TimeZone::America::Glace_Bay 2.36
-      DateTime::TimeZone::America::Godthab 2.36
-      DateTime::TimeZone::America::Goose_Bay 2.36
-      DateTime::TimeZone::America::Grand_Turk 2.36
-      DateTime::TimeZone::America::Guatemala 2.36
-      DateTime::TimeZone::America::Guayaquil 2.36
-      DateTime::TimeZone::America::Guyana 2.36
-      DateTime::TimeZone::America::Halifax 2.36
-      DateTime::TimeZone::America::Havana 2.36
-      DateTime::TimeZone::America::Hermosillo 2.36
-      DateTime::TimeZone::America::Indiana::Indianapolis 2.36
-      DateTime::TimeZone::America::Indiana::Knox 2.36
-      DateTime::TimeZone::America::Indiana::Marengo 2.36
-      DateTime::TimeZone::America::Indiana::Petersburg 2.36
-      DateTime::TimeZone::America::Indiana::Tell_City 2.36
-      DateTime::TimeZone::America::Indiana::Vevay 2.36
-      DateTime::TimeZone::America::Indiana::Vincennes 2.36
-      DateTime::TimeZone::America::Indiana::Winamac 2.36
-      DateTime::TimeZone::America::Inuvik 2.36
-      DateTime::TimeZone::America::Iqaluit 2.36
-      DateTime::TimeZone::America::Jamaica 2.36
-      DateTime::TimeZone::America::Juneau 2.36
-      DateTime::TimeZone::America::Kentucky::Louisville 2.36
-      DateTime::TimeZone::America::Kentucky::Monticello 2.36
-      DateTime::TimeZone::America::La_Paz 2.36
-      DateTime::TimeZone::America::Lima 2.36
-      DateTime::TimeZone::America::Los_Angeles 2.36
-      DateTime::TimeZone::America::Maceio 2.36
-      DateTime::TimeZone::America::Managua 2.36
-      DateTime::TimeZone::America::Manaus 2.36
-      DateTime::TimeZone::America::Martinique 2.36
-      DateTime::TimeZone::America::Matamoros 2.36
-      DateTime::TimeZone::America::Mazatlan 2.36
-      DateTime::TimeZone::America::Menominee 2.36
-      DateTime::TimeZone::America::Merida 2.36
-      DateTime::TimeZone::America::Metlakatla 2.36
-      DateTime::TimeZone::America::Mexico_City 2.36
-      DateTime::TimeZone::America::Miquelon 2.36
-      DateTime::TimeZone::America::Moncton 2.36
-      DateTime::TimeZone::America::Monterrey 2.36
-      DateTime::TimeZone::America::Montevideo 2.36
-      DateTime::TimeZone::America::Nassau 2.36
-      DateTime::TimeZone::America::New_York 2.36
-      DateTime::TimeZone::America::Nipigon 2.36
-      DateTime::TimeZone::America::Nome 2.36
-      DateTime::TimeZone::America::Noronha 2.36
-      DateTime::TimeZone::America::North_Dakota::Beulah 2.36
-      DateTime::TimeZone::America::North_Dakota::Center 2.36
-      DateTime::TimeZone::America::North_Dakota::New_Salem 2.36
-      DateTime::TimeZone::America::Ojinaga 2.36
-      DateTime::TimeZone::America::Panama 2.36
-      DateTime::TimeZone::America::Pangnirtung 2.36
-      DateTime::TimeZone::America::Paramaribo 2.36
-      DateTime::TimeZone::America::Phoenix 2.36
-      DateTime::TimeZone::America::Port_au_Prince 2.36
-      DateTime::TimeZone::America::Port_of_Spain 2.36
-      DateTime::TimeZone::America::Porto_Velho 2.36
-      DateTime::TimeZone::America::Puerto_Rico 2.36
-      DateTime::TimeZone::America::Punta_Arenas 2.36
-      DateTime::TimeZone::America::Rainy_River 2.36
-      DateTime::TimeZone::America::Rankin_Inlet 2.36
-      DateTime::TimeZone::America::Recife 2.36
-      DateTime::TimeZone::America::Regina 2.36
-      DateTime::TimeZone::America::Resolute 2.36
-      DateTime::TimeZone::America::Rio_Branco 2.36
-      DateTime::TimeZone::America::Santarem 2.36
-      DateTime::TimeZone::America::Santiago 2.36
-      DateTime::TimeZone::America::Santo_Domingo 2.36
-      DateTime::TimeZone::America::Sao_Paulo 2.36
-      DateTime::TimeZone::America::Scoresbysund 2.36
-      DateTime::TimeZone::America::Sitka 2.36
-      DateTime::TimeZone::America::St_Johns 2.36
-      DateTime::TimeZone::America::Swift_Current 2.36
-      DateTime::TimeZone::America::Tegucigalpa 2.36
-      DateTime::TimeZone::America::Thule 2.36
-      DateTime::TimeZone::America::Thunder_Bay 2.36
-      DateTime::TimeZone::America::Tijuana 2.36
-      DateTime::TimeZone::America::Toronto 2.36
-      DateTime::TimeZone::America::Vancouver 2.36
-      DateTime::TimeZone::America::Whitehorse 2.36
-      DateTime::TimeZone::America::Winnipeg 2.36
-      DateTime::TimeZone::America::Yakutat 2.36
-      DateTime::TimeZone::America::Yellowknife 2.36
-      DateTime::TimeZone::Antarctica::Casey 2.36
-      DateTime::TimeZone::Antarctica::Davis 2.36
-      DateTime::TimeZone::Antarctica::DumontDUrville 2.36
-      DateTime::TimeZone::Antarctica::Macquarie 2.36
-      DateTime::TimeZone::Antarctica::Mawson 2.36
-      DateTime::TimeZone::Antarctica::Palmer 2.36
-      DateTime::TimeZone::Antarctica::Rothera 2.36
-      DateTime::TimeZone::Antarctica::Syowa 2.36
-      DateTime::TimeZone::Antarctica::Troll 2.36
-      DateTime::TimeZone::Antarctica::Vostok 2.36
-      DateTime::TimeZone::Asia::Almaty 2.36
-      DateTime::TimeZone::Asia::Amman 2.36
-      DateTime::TimeZone::Asia::Anadyr 2.36
-      DateTime::TimeZone::Asia::Aqtau 2.36
-      DateTime::TimeZone::Asia::Aqtobe 2.36
-      DateTime::TimeZone::Asia::Ashgabat 2.36
-      DateTime::TimeZone::Asia::Atyrau 2.36
-      DateTime::TimeZone::Asia::Baghdad 2.36
-      DateTime::TimeZone::Asia::Baku 2.36
-      DateTime::TimeZone::Asia::Bangkok 2.36
-      DateTime::TimeZone::Asia::Barnaul 2.36
-      DateTime::TimeZone::Asia::Beirut 2.36
-      DateTime::TimeZone::Asia::Bishkek 2.36
-      DateTime::TimeZone::Asia::Brunei 2.36
-      DateTime::TimeZone::Asia::Chita 2.36
-      DateTime::TimeZone::Asia::Choibalsan 2.36
-      DateTime::TimeZone::Asia::Colombo 2.36
-      DateTime::TimeZone::Asia::Damascus 2.36
-      DateTime::TimeZone::Asia::Dhaka 2.36
-      DateTime::TimeZone::Asia::Dili 2.36
-      DateTime::TimeZone::Asia::Dubai 2.36
-      DateTime::TimeZone::Asia::Dushanbe 2.36
-      DateTime::TimeZone::Asia::Famagusta 2.36
-      DateTime::TimeZone::Asia::Gaza 2.36
-      DateTime::TimeZone::Asia::Hebron 2.36
-      DateTime::TimeZone::Asia::Ho_Chi_Minh 2.36
-      DateTime::TimeZone::Asia::Hong_Kong 2.36
-      DateTime::TimeZone::Asia::Hovd 2.36
-      DateTime::TimeZone::Asia::Irkutsk 2.36
-      DateTime::TimeZone::Asia::Jakarta 2.36
-      DateTime::TimeZone::Asia::Jayapura 2.36
-      DateTime::TimeZone::Asia::Jerusalem 2.36
-      DateTime::TimeZone::Asia::Kabul 2.36
-      DateTime::TimeZone::Asia::Kamchatka 2.36
-      DateTime::TimeZone::Asia::Karachi 2.36
-      DateTime::TimeZone::Asia::Kathmandu 2.36
-      DateTime::TimeZone::Asia::Khandyga 2.36
-      DateTime::TimeZone::Asia::Kolkata 2.36
-      DateTime::TimeZone::Asia::Krasnoyarsk 2.36
-      DateTime::TimeZone::Asia::Kuala_Lumpur 2.36
-      DateTime::TimeZone::Asia::Kuching 2.36
-      DateTime::TimeZone::Asia::Macau 2.36
-      DateTime::TimeZone::Asia::Magadan 2.36
-      DateTime::TimeZone::Asia::Makassar 2.36
-      DateTime::TimeZone::Asia::Manila 2.36
-      DateTime::TimeZone::Asia::Nicosia 2.36
-      DateTime::TimeZone::Asia::Novokuznetsk 2.36
-      DateTime::TimeZone::Asia::Novosibirsk 2.36
-      DateTime::TimeZone::Asia::Omsk 2.36
-      DateTime::TimeZone::Asia::Oral 2.36
-      DateTime::TimeZone::Asia::Pontianak 2.36
-      DateTime::TimeZone::Asia::Pyongyang 2.36
-      DateTime::TimeZone::Asia::Qatar 2.36
-      DateTime::TimeZone::Asia::Qostanay 2.36
-      DateTime::TimeZone::Asia::Qyzylorda 2.36
-      DateTime::TimeZone::Asia::Riyadh 2.36
-      DateTime::TimeZone::Asia::Sakhalin 2.36
-      DateTime::TimeZone::Asia::Samarkand 2.36
-      DateTime::TimeZone::Asia::Seoul 2.36
-      DateTime::TimeZone::Asia::Shanghai 2.36
-      DateTime::TimeZone::Asia::Singapore 2.36
-      DateTime::TimeZone::Asia::Srednekolymsk 2.36
-      DateTime::TimeZone::Asia::Taipei 2.36
-      DateTime::TimeZone::Asia::Tashkent 2.36
-      DateTime::TimeZone::Asia::Tbilisi 2.36
-      DateTime::TimeZone::Asia::Tehran 2.36
-      DateTime::TimeZone::Asia::Thimphu 2.36
-      DateTime::TimeZone::Asia::Tokyo 2.36
-      DateTime::TimeZone::Asia::Tomsk 2.36
-      DateTime::TimeZone::Asia::Ulaanbaatar 2.36
-      DateTime::TimeZone::Asia::Urumqi 2.36
-      DateTime::TimeZone::Asia::Ust_Nera 2.36
-      DateTime::TimeZone::Asia::Vladivostok 2.36
-      DateTime::TimeZone::Asia::Yakutsk 2.36
-      DateTime::TimeZone::Asia::Yangon 2.36
-      DateTime::TimeZone::Asia::Yekaterinburg 2.36
-      DateTime::TimeZone::Asia::Yerevan 2.36
-      DateTime::TimeZone::Atlantic::Azores 2.36
-      DateTime::TimeZone::Atlantic::Bermuda 2.36
-      DateTime::TimeZone::Atlantic::Canary 2.36
-      DateTime::TimeZone::Atlantic::Cape_Verde 2.36
-      DateTime::TimeZone::Atlantic::Faroe 2.36
-      DateTime::TimeZone::Atlantic::Madeira 2.36
-      DateTime::TimeZone::Atlantic::Reykjavik 2.36
-      DateTime::TimeZone::Atlantic::South_Georgia 2.36
-      DateTime::TimeZone::Atlantic::Stanley 2.36
-      DateTime::TimeZone::Australia::Adelaide 2.36
-      DateTime::TimeZone::Australia::Brisbane 2.36
-      DateTime::TimeZone::Australia::Broken_Hill 2.36
-      DateTime::TimeZone::Australia::Currie 2.36
-      DateTime::TimeZone::Australia::Darwin 2.36
-      DateTime::TimeZone::Australia::Eucla 2.36
-      DateTime::TimeZone::Australia::Hobart 2.36
-      DateTime::TimeZone::Australia::Lindeman 2.36
-      DateTime::TimeZone::Australia::Lord_Howe 2.36
-      DateTime::TimeZone::Australia::Melbourne 2.36
-      DateTime::TimeZone::Australia::Perth 2.36
-      DateTime::TimeZone::Australia::Sydney 2.36
-      DateTime::TimeZone::CET 2.36
-      DateTime::TimeZone::CST6CDT 2.36
-      DateTime::TimeZone::Catalog 2.36
-      DateTime::TimeZone::EET 2.36
-      DateTime::TimeZone::EST 2.36
-      DateTime::TimeZone::EST5EDT 2.36
-      DateTime::TimeZone::Europe::Amsterdam 2.36
-      DateTime::TimeZone::Europe::Andorra 2.36
-      DateTime::TimeZone::Europe::Astrakhan 2.36
-      DateTime::TimeZone::Europe::Athens 2.36
-      DateTime::TimeZone::Europe::Belgrade 2.36
-      DateTime::TimeZone::Europe::Berlin 2.36
-      DateTime::TimeZone::Europe::Brussels 2.36
-      DateTime::TimeZone::Europe::Bucharest 2.36
-      DateTime::TimeZone::Europe::Budapest 2.36
-      DateTime::TimeZone::Europe::Chisinau 2.36
-      DateTime::TimeZone::Europe::Copenhagen 2.36
-      DateTime::TimeZone::Europe::Dublin 2.36
-      DateTime::TimeZone::Europe::Gibraltar 2.36
-      DateTime::TimeZone::Europe::Helsinki 2.36
-      DateTime::TimeZone::Europe::Istanbul 2.36
-      DateTime::TimeZone::Europe::Kaliningrad 2.36
-      DateTime::TimeZone::Europe::Kiev 2.36
-      DateTime::TimeZone::Europe::Kirov 2.36
-      DateTime::TimeZone::Europe::Lisbon 2.36
-      DateTime::TimeZone::Europe::London 2.36
-      DateTime::TimeZone::Europe::Luxembourg 2.36
-      DateTime::TimeZone::Europe::Madrid 2.36
-      DateTime::TimeZone::Europe::Malta 2.36
-      DateTime::TimeZone::Europe::Minsk 2.36
-      DateTime::TimeZone::Europe::Monaco 2.36
-      DateTime::TimeZone::Europe::Moscow 2.36
-      DateTime::TimeZone::Europe::Oslo 2.36
-      DateTime::TimeZone::Europe::Paris 2.36
-      DateTime::TimeZone::Europe::Prague 2.36
-      DateTime::TimeZone::Europe::Riga 2.36
-      DateTime::TimeZone::Europe::Rome 2.36
-      DateTime::TimeZone::Europe::Samara 2.36
-      DateTime::TimeZone::Europe::Saratov 2.36
-      DateTime::TimeZone::Europe::Simferopol 2.36
-      DateTime::TimeZone::Europe::Sofia 2.36
-      DateTime::TimeZone::Europe::Stockholm 2.36
-      DateTime::TimeZone::Europe::Tallinn 2.36
-      DateTime::TimeZone::Europe::Tirane 2.36
-      DateTime::TimeZone::Europe::Ulyanovsk 2.36
-      DateTime::TimeZone::Europe::Uzhgorod 2.36
-      DateTime::TimeZone::Europe::Vienna 2.36
-      DateTime::TimeZone::Europe::Vilnius 2.36
-      DateTime::TimeZone::Europe::Volgograd 2.36
-      DateTime::TimeZone::Europe::Warsaw 2.36
-      DateTime::TimeZone::Europe::Zaporozhye 2.36
-      DateTime::TimeZone::Europe::Zurich 2.36
-      DateTime::TimeZone::Floating 2.36
-      DateTime::TimeZone::HST 2.36
-      DateTime::TimeZone::Indian::Chagos 2.36
-      DateTime::TimeZone::Indian::Christmas 2.36
-      DateTime::TimeZone::Indian::Cocos 2.36
-      DateTime::TimeZone::Indian::Kerguelen 2.36
-      DateTime::TimeZone::Indian::Mahe 2.36
-      DateTime::TimeZone::Indian::Maldives 2.36
-      DateTime::TimeZone::Indian::Mauritius 2.36
-      DateTime::TimeZone::Indian::Reunion 2.36
-      DateTime::TimeZone::Local 2.36
-      DateTime::TimeZone::Local::Android 2.36
-      DateTime::TimeZone::Local::Unix 2.36
-      DateTime::TimeZone::Local::VMS 2.36
-      DateTime::TimeZone::MET 2.36
-      DateTime::TimeZone::MST 2.36
-      DateTime::TimeZone::MST7MDT 2.36
-      DateTime::TimeZone::OffsetOnly 2.36
-      DateTime::TimeZone::OlsonDB 2.36
-      DateTime::TimeZone::OlsonDB::Change 2.36
-      DateTime::TimeZone::OlsonDB::Observance 2.36
-      DateTime::TimeZone::OlsonDB::Rule 2.36
-      DateTime::TimeZone::OlsonDB::Zone 2.36
-      DateTime::TimeZone::PST8PDT 2.36
-      DateTime::TimeZone::Pacific::Apia 2.36
-      DateTime::TimeZone::Pacific::Auckland 2.36
-      DateTime::TimeZone::Pacific::Bougainville 2.36
-      DateTime::TimeZone::Pacific::Chatham 2.36
-      DateTime::TimeZone::Pacific::Chuuk 2.36
-      DateTime::TimeZone::Pacific::Easter 2.36
-      DateTime::TimeZone::Pacific::Efate 2.36
-      DateTime::TimeZone::Pacific::Enderbury 2.36
-      DateTime::TimeZone::Pacific::Fakaofo 2.36
-      DateTime::TimeZone::Pacific::Fiji 2.36
-      DateTime::TimeZone::Pacific::Funafuti 2.36
-      DateTime::TimeZone::Pacific::Galapagos 2.36
-      DateTime::TimeZone::Pacific::Gambier 2.36
-      DateTime::TimeZone::Pacific::Guadalcanal 2.36
-      DateTime::TimeZone::Pacific::Guam 2.36
-      DateTime::TimeZone::Pacific::Honolulu 2.36
-      DateTime::TimeZone::Pacific::Kiritimati 2.36
-      DateTime::TimeZone::Pacific::Kosrae 2.36
-      DateTime::TimeZone::Pacific::Kwajalein 2.36
-      DateTime::TimeZone::Pacific::Majuro 2.36
-      DateTime::TimeZone::Pacific::Marquesas 2.36
-      DateTime::TimeZone::Pacific::Nauru 2.36
-      DateTime::TimeZone::Pacific::Niue 2.36
-      DateTime::TimeZone::Pacific::Norfolk 2.36
-      DateTime::TimeZone::Pacific::Noumea 2.36
-      DateTime::TimeZone::Pacific::Pago_Pago 2.36
-      DateTime::TimeZone::Pacific::Palau 2.36
-      DateTime::TimeZone::Pacific::Pitcairn 2.36
-      DateTime::TimeZone::Pacific::Pohnpei 2.36
-      DateTime::TimeZone::Pacific::Port_Moresby 2.36
-      DateTime::TimeZone::Pacific::Rarotonga 2.36
-      DateTime::TimeZone::Pacific::Tahiti 2.36
-      DateTime::TimeZone::Pacific::Tarawa 2.36
-      DateTime::TimeZone::Pacific::Tongatapu 2.36
-      DateTime::TimeZone::Pacific::Wake 2.36
-      DateTime::TimeZone::Pacific::Wallis 2.36
-      DateTime::TimeZone::UTC 2.36
-      DateTime::TimeZone::WET 2.36
+      DateTime::TimeZone 2.37
+      DateTime::TimeZone::Africa::Abidjan 2.37
+      DateTime::TimeZone::Africa::Accra 2.37
+      DateTime::TimeZone::Africa::Algiers 2.37
+      DateTime::TimeZone::Africa::Bissau 2.37
+      DateTime::TimeZone::Africa::Cairo 2.37
+      DateTime::TimeZone::Africa::Casablanca 2.37
+      DateTime::TimeZone::Africa::Ceuta 2.37
+      DateTime::TimeZone::Africa::El_Aaiun 2.37
+      DateTime::TimeZone::Africa::Johannesburg 2.37
+      DateTime::TimeZone::Africa::Juba 2.37
+      DateTime::TimeZone::Africa::Khartoum 2.37
+      DateTime::TimeZone::Africa::Lagos 2.37
+      DateTime::TimeZone::Africa::Maputo 2.37
+      DateTime::TimeZone::Africa::Monrovia 2.37
+      DateTime::TimeZone::Africa::Nairobi 2.37
+      DateTime::TimeZone::Africa::Ndjamena 2.37
+      DateTime::TimeZone::Africa::Sao_Tome 2.37
+      DateTime::TimeZone::Africa::Tripoli 2.37
+      DateTime::TimeZone::Africa::Tunis 2.37
+      DateTime::TimeZone::Africa::Windhoek 2.37
+      DateTime::TimeZone::America::Adak 2.37
+      DateTime::TimeZone::America::Anchorage 2.37
+      DateTime::TimeZone::America::Araguaina 2.37
+      DateTime::TimeZone::America::Argentina::Buenos_Aires 2.37
+      DateTime::TimeZone::America::Argentina::Catamarca 2.37
+      DateTime::TimeZone::America::Argentina::Cordoba 2.37
+      DateTime::TimeZone::America::Argentina::Jujuy 2.37
+      DateTime::TimeZone::America::Argentina::La_Rioja 2.37
+      DateTime::TimeZone::America::Argentina::Mendoza 2.37
+      DateTime::TimeZone::America::Argentina::Rio_Gallegos 2.37
+      DateTime::TimeZone::America::Argentina::Salta 2.37
+      DateTime::TimeZone::America::Argentina::San_Juan 2.37
+      DateTime::TimeZone::America::Argentina::San_Luis 2.37
+      DateTime::TimeZone::America::Argentina::Tucuman 2.37
+      DateTime::TimeZone::America::Argentina::Ushuaia 2.37
+      DateTime::TimeZone::America::Asuncion 2.37
+      DateTime::TimeZone::America::Atikokan 2.37
+      DateTime::TimeZone::America::Bahia 2.37
+      DateTime::TimeZone::America::Bahia_Banderas 2.37
+      DateTime::TimeZone::America::Barbados 2.37
+      DateTime::TimeZone::America::Belem 2.37
+      DateTime::TimeZone::America::Belize 2.37
+      DateTime::TimeZone::America::Blanc_Sablon 2.37
+      DateTime::TimeZone::America::Boa_Vista 2.37
+      DateTime::TimeZone::America::Bogota 2.37
+      DateTime::TimeZone::America::Boise 2.37
+      DateTime::TimeZone::America::Cambridge_Bay 2.37
+      DateTime::TimeZone::America::Campo_Grande 2.37
+      DateTime::TimeZone::America::Cancun 2.37
+      DateTime::TimeZone::America::Caracas 2.37
+      DateTime::TimeZone::America::Cayenne 2.37
+      DateTime::TimeZone::America::Chicago 2.37
+      DateTime::TimeZone::America::Chihuahua 2.37
+      DateTime::TimeZone::America::Costa_Rica 2.37
+      DateTime::TimeZone::America::Creston 2.37
+      DateTime::TimeZone::America::Cuiaba 2.37
+      DateTime::TimeZone::America::Curacao 2.37
+      DateTime::TimeZone::America::Danmarkshavn 2.37
+      DateTime::TimeZone::America::Dawson 2.37
+      DateTime::TimeZone::America::Dawson_Creek 2.37
+      DateTime::TimeZone::America::Denver 2.37
+      DateTime::TimeZone::America::Detroit 2.37
+      DateTime::TimeZone::America::Edmonton 2.37
+      DateTime::TimeZone::America::Eirunepe 2.37
+      DateTime::TimeZone::America::El_Salvador 2.37
+      DateTime::TimeZone::America::Fort_Nelson 2.37
+      DateTime::TimeZone::America::Fortaleza 2.37
+      DateTime::TimeZone::America::Glace_Bay 2.37
+      DateTime::TimeZone::America::Godthab 2.37
+      DateTime::TimeZone::America::Goose_Bay 2.37
+      DateTime::TimeZone::America::Grand_Turk 2.37
+      DateTime::TimeZone::America::Guatemala 2.37
+      DateTime::TimeZone::America::Guayaquil 2.37
+      DateTime::TimeZone::America::Guyana 2.37
+      DateTime::TimeZone::America::Halifax 2.37
+      DateTime::TimeZone::America::Havana 2.37
+      DateTime::TimeZone::America::Hermosillo 2.37
+      DateTime::TimeZone::America::Indiana::Indianapolis 2.37
+      DateTime::TimeZone::America::Indiana::Knox 2.37
+      DateTime::TimeZone::America::Indiana::Marengo 2.37
+      DateTime::TimeZone::America::Indiana::Petersburg 2.37
+      DateTime::TimeZone::America::Indiana::Tell_City 2.37
+      DateTime::TimeZone::America::Indiana::Vevay 2.37
+      DateTime::TimeZone::America::Indiana::Vincennes 2.37
+      DateTime::TimeZone::America::Indiana::Winamac 2.37
+      DateTime::TimeZone::America::Inuvik 2.37
+      DateTime::TimeZone::America::Iqaluit 2.37
+      DateTime::TimeZone::America::Jamaica 2.37
+      DateTime::TimeZone::America::Juneau 2.37
+      DateTime::TimeZone::America::Kentucky::Louisville 2.37
+      DateTime::TimeZone::America::Kentucky::Monticello 2.37
+      DateTime::TimeZone::America::La_Paz 2.37
+      DateTime::TimeZone::America::Lima 2.37
+      DateTime::TimeZone::America::Los_Angeles 2.37
+      DateTime::TimeZone::America::Maceio 2.37
+      DateTime::TimeZone::America::Managua 2.37
+      DateTime::TimeZone::America::Manaus 2.37
+      DateTime::TimeZone::America::Martinique 2.37
+      DateTime::TimeZone::America::Matamoros 2.37
+      DateTime::TimeZone::America::Mazatlan 2.37
+      DateTime::TimeZone::America::Menominee 2.37
+      DateTime::TimeZone::America::Merida 2.37
+      DateTime::TimeZone::America::Metlakatla 2.37
+      DateTime::TimeZone::America::Mexico_City 2.37
+      DateTime::TimeZone::America::Miquelon 2.37
+      DateTime::TimeZone::America::Moncton 2.37
+      DateTime::TimeZone::America::Monterrey 2.37
+      DateTime::TimeZone::America::Montevideo 2.37
+      DateTime::TimeZone::America::Nassau 2.37
+      DateTime::TimeZone::America::New_York 2.37
+      DateTime::TimeZone::America::Nipigon 2.37
+      DateTime::TimeZone::America::Nome 2.37
+      DateTime::TimeZone::America::Noronha 2.37
+      DateTime::TimeZone::America::North_Dakota::Beulah 2.37
+      DateTime::TimeZone::America::North_Dakota::Center 2.37
+      DateTime::TimeZone::America::North_Dakota::New_Salem 2.37
+      DateTime::TimeZone::America::Ojinaga 2.37
+      DateTime::TimeZone::America::Panama 2.37
+      DateTime::TimeZone::America::Pangnirtung 2.37
+      DateTime::TimeZone::America::Paramaribo 2.37
+      DateTime::TimeZone::America::Phoenix 2.37
+      DateTime::TimeZone::America::Port_au_Prince 2.37
+      DateTime::TimeZone::America::Port_of_Spain 2.37
+      DateTime::TimeZone::America::Porto_Velho 2.37
+      DateTime::TimeZone::America::Puerto_Rico 2.37
+      DateTime::TimeZone::America::Punta_Arenas 2.37
+      DateTime::TimeZone::America::Rainy_River 2.37
+      DateTime::TimeZone::America::Rankin_Inlet 2.37
+      DateTime::TimeZone::America::Recife 2.37
+      DateTime::TimeZone::America::Regina 2.37
+      DateTime::TimeZone::America::Resolute 2.37
+      DateTime::TimeZone::America::Rio_Branco 2.37
+      DateTime::TimeZone::America::Santarem 2.37
+      DateTime::TimeZone::America::Santiago 2.37
+      DateTime::TimeZone::America::Santo_Domingo 2.37
+      DateTime::TimeZone::America::Sao_Paulo 2.37
+      DateTime::TimeZone::America::Scoresbysund 2.37
+      DateTime::TimeZone::America::Sitka 2.37
+      DateTime::TimeZone::America::St_Johns 2.37
+      DateTime::TimeZone::America::Swift_Current 2.37
+      DateTime::TimeZone::America::Tegucigalpa 2.37
+      DateTime::TimeZone::America::Thule 2.37
+      DateTime::TimeZone::America::Thunder_Bay 2.37
+      DateTime::TimeZone::America::Tijuana 2.37
+      DateTime::TimeZone::America::Toronto 2.37
+      DateTime::TimeZone::America::Vancouver 2.37
+      DateTime::TimeZone::America::Whitehorse 2.37
+      DateTime::TimeZone::America::Winnipeg 2.37
+      DateTime::TimeZone::America::Yakutat 2.37
+      DateTime::TimeZone::America::Yellowknife 2.37
+      DateTime::TimeZone::Antarctica::Casey 2.37
+      DateTime::TimeZone::Antarctica::Davis 2.37
+      DateTime::TimeZone::Antarctica::DumontDUrville 2.37
+      DateTime::TimeZone::Antarctica::Macquarie 2.37
+      DateTime::TimeZone::Antarctica::Mawson 2.37
+      DateTime::TimeZone::Antarctica::Palmer 2.37
+      DateTime::TimeZone::Antarctica::Rothera 2.37
+      DateTime::TimeZone::Antarctica::Syowa 2.37
+      DateTime::TimeZone::Antarctica::Troll 2.37
+      DateTime::TimeZone::Antarctica::Vostok 2.37
+      DateTime::TimeZone::Asia::Almaty 2.37
+      DateTime::TimeZone::Asia::Amman 2.37
+      DateTime::TimeZone::Asia::Anadyr 2.37
+      DateTime::TimeZone::Asia::Aqtau 2.37
+      DateTime::TimeZone::Asia::Aqtobe 2.37
+      DateTime::TimeZone::Asia::Ashgabat 2.37
+      DateTime::TimeZone::Asia::Atyrau 2.37
+      DateTime::TimeZone::Asia::Baghdad 2.37
+      DateTime::TimeZone::Asia::Baku 2.37
+      DateTime::TimeZone::Asia::Bangkok 2.37
+      DateTime::TimeZone::Asia::Barnaul 2.37
+      DateTime::TimeZone::Asia::Beirut 2.37
+      DateTime::TimeZone::Asia::Bishkek 2.37
+      DateTime::TimeZone::Asia::Brunei 2.37
+      DateTime::TimeZone::Asia::Chita 2.37
+      DateTime::TimeZone::Asia::Choibalsan 2.37
+      DateTime::TimeZone::Asia::Colombo 2.37
+      DateTime::TimeZone::Asia::Damascus 2.37
+      DateTime::TimeZone::Asia::Dhaka 2.37
+      DateTime::TimeZone::Asia::Dili 2.37
+      DateTime::TimeZone::Asia::Dubai 2.37
+      DateTime::TimeZone::Asia::Dushanbe 2.37
+      DateTime::TimeZone::Asia::Famagusta 2.37
+      DateTime::TimeZone::Asia::Gaza 2.37
+      DateTime::TimeZone::Asia::Hebron 2.37
+      DateTime::TimeZone::Asia::Ho_Chi_Minh 2.37
+      DateTime::TimeZone::Asia::Hong_Kong 2.37
+      DateTime::TimeZone::Asia::Hovd 2.37
+      DateTime::TimeZone::Asia::Irkutsk 2.37
+      DateTime::TimeZone::Asia::Jakarta 2.37
+      DateTime::TimeZone::Asia::Jayapura 2.37
+      DateTime::TimeZone::Asia::Jerusalem 2.37
+      DateTime::TimeZone::Asia::Kabul 2.37
+      DateTime::TimeZone::Asia::Kamchatka 2.37
+      DateTime::TimeZone::Asia::Karachi 2.37
+      DateTime::TimeZone::Asia::Kathmandu 2.37
+      DateTime::TimeZone::Asia::Khandyga 2.37
+      DateTime::TimeZone::Asia::Kolkata 2.37
+      DateTime::TimeZone::Asia::Krasnoyarsk 2.37
+      DateTime::TimeZone::Asia::Kuala_Lumpur 2.37
+      DateTime::TimeZone::Asia::Kuching 2.37
+      DateTime::TimeZone::Asia::Macau 2.37
+      DateTime::TimeZone::Asia::Magadan 2.37
+      DateTime::TimeZone::Asia::Makassar 2.37
+      DateTime::TimeZone::Asia::Manila 2.37
+      DateTime::TimeZone::Asia::Nicosia 2.37
+      DateTime::TimeZone::Asia::Novokuznetsk 2.37
+      DateTime::TimeZone::Asia::Novosibirsk 2.37
+      DateTime::TimeZone::Asia::Omsk 2.37
+      DateTime::TimeZone::Asia::Oral 2.37
+      DateTime::TimeZone::Asia::Pontianak 2.37
+      DateTime::TimeZone::Asia::Pyongyang 2.37
+      DateTime::TimeZone::Asia::Qatar 2.37
+      DateTime::TimeZone::Asia::Qostanay 2.37
+      DateTime::TimeZone::Asia::Qyzylorda 2.37
+      DateTime::TimeZone::Asia::Riyadh 2.37
+      DateTime::TimeZone::Asia::Sakhalin 2.37
+      DateTime::TimeZone::Asia::Samarkand 2.37
+      DateTime::TimeZone::Asia::Seoul 2.37
+      DateTime::TimeZone::Asia::Shanghai 2.37
+      DateTime::TimeZone::Asia::Singapore 2.37
+      DateTime::TimeZone::Asia::Srednekolymsk 2.37
+      DateTime::TimeZone::Asia::Taipei 2.37
+      DateTime::TimeZone::Asia::Tashkent 2.37
+      DateTime::TimeZone::Asia::Tbilisi 2.37
+      DateTime::TimeZone::Asia::Tehran 2.37
+      DateTime::TimeZone::Asia::Thimphu 2.37
+      DateTime::TimeZone::Asia::Tokyo 2.37
+      DateTime::TimeZone::Asia::Tomsk 2.37
+      DateTime::TimeZone::Asia::Ulaanbaatar 2.37
+      DateTime::TimeZone::Asia::Urumqi 2.37
+      DateTime::TimeZone::Asia::Ust_Nera 2.37
+      DateTime::TimeZone::Asia::Vladivostok 2.37
+      DateTime::TimeZone::Asia::Yakutsk 2.37
+      DateTime::TimeZone::Asia::Yangon 2.37
+      DateTime::TimeZone::Asia::Yekaterinburg 2.37
+      DateTime::TimeZone::Asia::Yerevan 2.37
+      DateTime::TimeZone::Atlantic::Azores 2.37
+      DateTime::TimeZone::Atlantic::Bermuda 2.37
+      DateTime::TimeZone::Atlantic::Canary 2.37
+      DateTime::TimeZone::Atlantic::Cape_Verde 2.37
+      DateTime::TimeZone::Atlantic::Faroe 2.37
+      DateTime::TimeZone::Atlantic::Madeira 2.37
+      DateTime::TimeZone::Atlantic::Reykjavik 2.37
+      DateTime::TimeZone::Atlantic::South_Georgia 2.37
+      DateTime::TimeZone::Atlantic::Stanley 2.37
+      DateTime::TimeZone::Australia::Adelaide 2.37
+      DateTime::TimeZone::Australia::Brisbane 2.37
+      DateTime::TimeZone::Australia::Broken_Hill 2.37
+      DateTime::TimeZone::Australia::Currie 2.37
+      DateTime::TimeZone::Australia::Darwin 2.37
+      DateTime::TimeZone::Australia::Eucla 2.37
+      DateTime::TimeZone::Australia::Hobart 2.37
+      DateTime::TimeZone::Australia::Lindeman 2.37
+      DateTime::TimeZone::Australia::Lord_Howe 2.37
+      DateTime::TimeZone::Australia::Melbourne 2.37
+      DateTime::TimeZone::Australia::Perth 2.37
+      DateTime::TimeZone::Australia::Sydney 2.37
+      DateTime::TimeZone::CET 2.37
+      DateTime::TimeZone::CST6CDT 2.37
+      DateTime::TimeZone::Catalog 2.37
+      DateTime::TimeZone::EET 2.37
+      DateTime::TimeZone::EST 2.37
+      DateTime::TimeZone::EST5EDT 2.37
+      DateTime::TimeZone::Europe::Amsterdam 2.37
+      DateTime::TimeZone::Europe::Andorra 2.37
+      DateTime::TimeZone::Europe::Astrakhan 2.37
+      DateTime::TimeZone::Europe::Athens 2.37
+      DateTime::TimeZone::Europe::Belgrade 2.37
+      DateTime::TimeZone::Europe::Berlin 2.37
+      DateTime::TimeZone::Europe::Brussels 2.37
+      DateTime::TimeZone::Europe::Bucharest 2.37
+      DateTime::TimeZone::Europe::Budapest 2.37
+      DateTime::TimeZone::Europe::Chisinau 2.37
+      DateTime::TimeZone::Europe::Copenhagen 2.37
+      DateTime::TimeZone::Europe::Dublin 2.37
+      DateTime::TimeZone::Europe::Gibraltar 2.37
+      DateTime::TimeZone::Europe::Helsinki 2.37
+      DateTime::TimeZone::Europe::Istanbul 2.37
+      DateTime::TimeZone::Europe::Kaliningrad 2.37
+      DateTime::TimeZone::Europe::Kiev 2.37
+      DateTime::TimeZone::Europe::Kirov 2.37
+      DateTime::TimeZone::Europe::Lisbon 2.37
+      DateTime::TimeZone::Europe::London 2.37
+      DateTime::TimeZone::Europe::Luxembourg 2.37
+      DateTime::TimeZone::Europe::Madrid 2.37
+      DateTime::TimeZone::Europe::Malta 2.37
+      DateTime::TimeZone::Europe::Minsk 2.37
+      DateTime::TimeZone::Europe::Monaco 2.37
+      DateTime::TimeZone::Europe::Moscow 2.37
+      DateTime::TimeZone::Europe::Oslo 2.37
+      DateTime::TimeZone::Europe::Paris 2.37
+      DateTime::TimeZone::Europe::Prague 2.37
+      DateTime::TimeZone::Europe::Riga 2.37
+      DateTime::TimeZone::Europe::Rome 2.37
+      DateTime::TimeZone::Europe::Samara 2.37
+      DateTime::TimeZone::Europe::Saratov 2.37
+      DateTime::TimeZone::Europe::Simferopol 2.37
+      DateTime::TimeZone::Europe::Sofia 2.37
+      DateTime::TimeZone::Europe::Stockholm 2.37
+      DateTime::TimeZone::Europe::Tallinn 2.37
+      DateTime::TimeZone::Europe::Tirane 2.37
+      DateTime::TimeZone::Europe::Ulyanovsk 2.37
+      DateTime::TimeZone::Europe::Uzhgorod 2.37
+      DateTime::TimeZone::Europe::Vienna 2.37
+      DateTime::TimeZone::Europe::Vilnius 2.37
+      DateTime::TimeZone::Europe::Volgograd 2.37
+      DateTime::TimeZone::Europe::Warsaw 2.37
+      DateTime::TimeZone::Europe::Zaporozhye 2.37
+      DateTime::TimeZone::Europe::Zurich 2.37
+      DateTime::TimeZone::Floating 2.37
+      DateTime::TimeZone::HST 2.37
+      DateTime::TimeZone::Indian::Chagos 2.37
+      DateTime::TimeZone::Indian::Christmas 2.37
+      DateTime::TimeZone::Indian::Cocos 2.37
+      DateTime::TimeZone::Indian::Kerguelen 2.37
+      DateTime::TimeZone::Indian::Mahe 2.37
+      DateTime::TimeZone::Indian::Maldives 2.37
+      DateTime::TimeZone::Indian::Mauritius 2.37
+      DateTime::TimeZone::Indian::Reunion 2.37
+      DateTime::TimeZone::Local 2.37
+      DateTime::TimeZone::Local::Android 2.37
+      DateTime::TimeZone::Local::Unix 2.37
+      DateTime::TimeZone::Local::VMS 2.37
+      DateTime::TimeZone::MET 2.37
+      DateTime::TimeZone::MST 2.37
+      DateTime::TimeZone::MST7MDT 2.37
+      DateTime::TimeZone::OffsetOnly 2.37
+      DateTime::TimeZone::OlsonDB 2.37
+      DateTime::TimeZone::OlsonDB::Change 2.37
+      DateTime::TimeZone::OlsonDB::Observance 2.37
+      DateTime::TimeZone::OlsonDB::Rule 2.37
+      DateTime::TimeZone::OlsonDB::Zone 2.37
+      DateTime::TimeZone::PST8PDT 2.37
+      DateTime::TimeZone::Pacific::Apia 2.37
+      DateTime::TimeZone::Pacific::Auckland 2.37
+      DateTime::TimeZone::Pacific::Bougainville 2.37
+      DateTime::TimeZone::Pacific::Chatham 2.37
+      DateTime::TimeZone::Pacific::Chuuk 2.37
+      DateTime::TimeZone::Pacific::Easter 2.37
+      DateTime::TimeZone::Pacific::Efate 2.37
+      DateTime::TimeZone::Pacific::Enderbury 2.37
+      DateTime::TimeZone::Pacific::Fakaofo 2.37
+      DateTime::TimeZone::Pacific::Fiji 2.37
+      DateTime::TimeZone::Pacific::Funafuti 2.37
+      DateTime::TimeZone::Pacific::Galapagos 2.37
+      DateTime::TimeZone::Pacific::Gambier 2.37
+      DateTime::TimeZone::Pacific::Guadalcanal 2.37
+      DateTime::TimeZone::Pacific::Guam 2.37
+      DateTime::TimeZone::Pacific::Honolulu 2.37
+      DateTime::TimeZone::Pacific::Kiritimati 2.37
+      DateTime::TimeZone::Pacific::Kosrae 2.37
+      DateTime::TimeZone::Pacific::Kwajalein 2.37
+      DateTime::TimeZone::Pacific::Majuro 2.37
+      DateTime::TimeZone::Pacific::Marquesas 2.37
+      DateTime::TimeZone::Pacific::Nauru 2.37
+      DateTime::TimeZone::Pacific::Niue 2.37
+      DateTime::TimeZone::Pacific::Norfolk 2.37
+      DateTime::TimeZone::Pacific::Noumea 2.37
+      DateTime::TimeZone::Pacific::Pago_Pago 2.37
+      DateTime::TimeZone::Pacific::Palau 2.37
+      DateTime::TimeZone::Pacific::Pitcairn 2.37
+      DateTime::TimeZone::Pacific::Pohnpei 2.37
+      DateTime::TimeZone::Pacific::Port_Moresby 2.37
+      DateTime::TimeZone::Pacific::Rarotonga 2.37
+      DateTime::TimeZone::Pacific::Tahiti 2.37
+      DateTime::TimeZone::Pacific::Tarawa 2.37
+      DateTime::TimeZone::Pacific::Tongatapu 2.37
+      DateTime::TimeZone::Pacific::Wake 2.37
+      DateTime::TimeZone::Pacific::Wallis 2.37
+      DateTime::TimeZone::UTC 2.37
+      DateTime::TimeZone::WET 2.37
     requirements:
       Class::Singleton 1.03
       Cwd 3
@@ -2308,10 +2297,10 @@ DISTRIBUTIONS
       Lingua::EN::Nums2Words 1.16
     requirements:
       ExtUtils::MakeMaker 0
-  Lingua-EN-Tagger-0.30
-    pathname: A/AC/ACOBURN/Lingua-EN-Tagger-0.30.tar.gz
+  Lingua-EN-Tagger-0.31
+    pathname: A/AC/ACOBURN/Lingua-EN-Tagger-0.31.tar.gz
     provides:
-      Lingua::EN::Tagger 0.30
+      Lingua::EN::Tagger 0.31
     requirements:
       ExtUtils::MakeMaker 0
       File::Spec 0.84
@@ -2674,10 +2663,10 @@ DISTRIBUTIONS
       Module::Build::Tiny 0
       Mojolicious 5.00
       perl 5.010
-  Mojo-Pg-4.13
-    pathname: S/SR/SRI/Mojo-Pg-4.13.tar.gz
+  Mojo-Pg-4.17
+    pathname: S/SR/SRI/Mojo-Pg-4.17.tar.gz
     provides:
-      Mojo::Pg 4.13
+      Mojo::Pg 4.17
       Mojo::Pg::Database undef
       Mojo::Pg::Migrations undef
       Mojo::Pg::PubSub undef
@@ -2685,13 +2674,13 @@ DISTRIBUTIONS
       Mojo::Pg::Transaction undef
       SQL::Abstract::Pg undef
     requirements:
-      DBD::Pg 3.005001
+      DBD::Pg 3.007004
       ExtUtils::MakeMaker 0
       Mojolicious 8.03
       SQL::Abstract 1.86
       perl 5.010001
-  Mojolicious-8.22
-    pathname: S/SR/SRI/Mojolicious-8.22.tar.gz
+  Mojolicious-8.26
+    pathname: S/SR/SRI/Mojolicious-8.26.tar.gz
     provides:
       Mojo undef
       Mojo::Asset undef
@@ -2760,7 +2749,7 @@ DISTRIBUTIONS
       Mojo::UserAgent::Transactor undef
       Mojo::Util undef
       Mojo::WebSocket undef
-      Mojolicious 8.22
+      Mojolicious 8.26
       Mojolicious::Command undef
       Mojolicious::Command::Author::cpanify undef
       Mojolicious::Command::Author::generate undef
@@ -2820,35 +2809,34 @@ DISTRIBUTIONS
       Test::Memory::Cycle 1.06
       Test::More 0
       perl 5.010001
-  Moo-2.003004
-    pathname: H/HA/HAARG/Moo-2.003004.tar.gz
+  Moo-2.003006
+    pathname: H/HA/HAARG/Moo-2.003006.tar.gz
     provides:
       Method::Generate::Accessor undef
       Method::Generate::BuildAll undef
       Method::Generate::Constructor undef
       Method::Generate::DemolishAll undef
-      Moo 2.003004
+      Moo 2.003006
       Moo::HandleMoose undef
       Moo::HandleMoose::FakeConstructor undef
       Moo::HandleMoose::FakeMetaClass undef
       Moo::HandleMoose::_TypeMap undef
       Moo::Object undef
-      Moo::Role 2.003004
+      Moo::Role 2.003006
       Moo::_Utils undef
       Moo::_mro undef
       Moo::_strictures undef
       Moo::sification undef
       oo undef
     requirements:
-      Class::Method::Modifiers 1.1
-      Devel::GlobalDestruction 0.11
+      Class::Method::Modifiers 1.10
       Exporter 5.57
       ExtUtils::MakeMaker 0
       Module::Runtime 0.014
-      Role::Tiny 2.000004
-      Scalar::Util 0
-      Sub::Defer 2.003001
-      Sub::Quote 2.003001
+      Role::Tiny 2.001004
+      Scalar::Util 1.09
+      Sub::Defer 2.006006
+      Sub::Quote 2.006006
       perl 5.006
   MooX-HandlesVia-0.001008
     pathname: M/MA/MATTP/MooX-HandlesVia-0.001008.tar.gz
@@ -2882,10 +2870,10 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 0
       Test 0
       perl 5.006
-  Net-DNS-1.20
-    pathname: N/NL/NLNETLABS/Net-DNS-1.20.tar.gz
+  Net-DNS-1.21
+    pathname: N/NL/NLNETLABS/Net-DNS-1.21.tar.gz
     provides:
-      Net::DNS 1.20
+      Net::DNS 1.21
       Net::DNS::Domain 1726
       Net::DNS::DomainName 1605
       Net::DNS::DomainName1035 1605
@@ -2895,31 +2883,30 @@ DISTRIBUTIONS
       Net::DNS::Mailbox1035 1605
       Net::DNS::Mailbox2535 1605
       Net::DNS::Nameserver 1692
-      Net::DNS::Packet 1714
-      Net::DNS::Parameters 1729
+      Net::DNS::Packet 1747
+      Net::DNS::Parameters 1740
       Net::DNS::Question 1726
-      Net::DNS::RR 1726
+      Net::DNS::RR 1748
       Net::DNS::RR::A 1597
       Net::DNS::RR::AAAA 1597
       Net::DNS::RR::AFSDB 1597
-      Net::DNS::RR::APL 1597
-      Net::DNS::RR::APL::Item 1597
-      Net::DNS::RR::CAA 1597
+      Net::DNS::RR::APL 1741
+      Net::DNS::RR::APL::Item 1741
+      Net::DNS::RR::CAA 1741
       Net::DNS::RR::CDNSKEY 1586
       Net::DNS::RR::CDS 1586
       Net::DNS::RR::CERT 1729
       Net::DNS::RR::CNAME 1597
-      Net::DNS::RR::CSYNC 1597
+      Net::DNS::RR::CSYNC 1741
       Net::DNS::RR::DHCID 1597
-      Net::DNS::RR::DLV 1528
       Net::DNS::RR::DNAME 1597
-      Net::DNS::RR::DNSKEY 1729
-      Net::DNS::RR::DS 1729
+      Net::DNS::RR::DNSKEY 1741
+      Net::DNS::RR::DS 1741
       Net::DNS::RR::EUI48 1597
       Net::DNS::RR::EUI64 1597
       Net::DNS::RR::GPOS 1528
       Net::DNS::RR::HINFO 1597
-      Net::DNS::RR::HIP 1597
+      Net::DNS::RR::HIP 1749
       Net::DNS::RR::IPSECKEY 1718
       Net::DNS::RR::ISDN 1597
       Net::DNS::RR::KEY 1528
@@ -2936,53 +2923,54 @@ DISTRIBUTIONS
       Net::DNS::RR::NAPTR 1597
       Net::DNS::RR::NID 1597
       Net::DNS::RR::NS 1597
-      Net::DNS::RR::NSEC 1696
-      Net::DNS::RR::NSEC3 1726
-      Net::DNS::RR::NSEC3PARAM 1597
+      Net::DNS::RR::NSEC 1749
+      Net::DNS::RR::NSEC3 1749
+      Net::DNS::RR::NSEC3PARAM 1741
       Net::DNS::RR::NULL 1528
       Net::DNS::RR::OPENPGPKEY 1597
-      Net::DNS::RR::OPT 1717
-      Net::DNS::RR::OPT::CHAIN 1717
-      Net::DNS::RR::OPT::CLIENT_SUBNET 1717
-      Net::DNS::RR::OPT::COOKIE 1717
-      Net::DNS::RR::OPT::DAU 1717
-      Net::DNS::RR::OPT::DHU 1717
-      Net::DNS::RR::OPT::EXPIRE 1717
-      Net::DNS::RR::OPT::KEY_TAG 1717
-      Net::DNS::RR::OPT::N3U 1717
-      Net::DNS::RR::OPT::PADDING 1717
-      Net::DNS::RR::OPT::TCP_KEEPALIVE 1717
+      Net::DNS::RR::OPT 1754
+      Net::DNS::RR::OPT::CHAIN 1754
+      Net::DNS::RR::OPT::CLIENT_SUBNET 1754
+      Net::DNS::RR::OPT::COOKIE 1754
+      Net::DNS::RR::OPT::DAU 1754
+      Net::DNS::RR::OPT::DHU 1754
+      Net::DNS::RR::OPT::EXPIRE 1754
+      Net::DNS::RR::OPT::KEY_TAG 1754
+      Net::DNS::RR::OPT::N3U 1754
+      Net::DNS::RR::OPT::PADDING 1754
+      Net::DNS::RR::OPT::TCP_KEEPALIVE 1754
       Net::DNS::RR::PTR 1597
       Net::DNS::RR::PX 1597
       Net::DNS::RR::RP 1597
-      Net::DNS::RR::RRSIG 1729
+      Net::DNS::RR::RRSIG 1754
       Net::DNS::RR::RT 1597
-      Net::DNS::RR::SIG 1729
-      Net::DNS::RR::SMIMEA 1597
+      Net::DNS::RR::SIG 1754
+      Net::DNS::RR::SMIMEA 1741
       Net::DNS::RR::SOA 1597
       Net::DNS::RR::SPF 1593
       Net::DNS::RR::SRV 1597
-      Net::DNS::RR::SSHFP 1597
+      Net::DNS::RR::SSHFP 1741
       Net::DNS::RR::TKEY 1528
-      Net::DNS::RR::TLSA 1597
-      Net::DNS::RR::TSIG 1726
+      Net::DNS::RR::TLSA 1741
+      Net::DNS::RR::TSIG 1749
       Net::DNS::RR::TXT 1597
       Net::DNS::RR::URI 1597
       Net::DNS::RR::X25 1597
-      Net::DNS::Resolver 1726
-      Net::DNS::Resolver::Base 1727
+      Net::DNS::RR::ZONEMD 1740
+      Net::DNS::Resolver 1740
+      Net::DNS::Resolver::Base 1748
       Net::DNS::Resolver::MSWin32 1568
-      Net::DNS::Resolver::Recurse 1737
+      Net::DNS::Resolver::Recurse 1748
       Net::DNS::Resolver::UNIX 1573
       Net::DNS::Resolver::android 1568
       Net::DNS::Resolver::cygwin 1719
       Net::DNS::Resolver::os2 1568
       Net::DNS::Resolver::os390 1719
-      Net::DNS::Text 1726
+      Net::DNS::Text 1748
       Net::DNS::Update 1726
-      Net::DNS::ZoneFile 1709
-      Net::DNS::ZoneFile::Generator 1709
-      Net::DNS::ZoneFile::Text 1709
+      Net::DNS::ZoneFile 1748
+      Net::DNS::ZoneFile::Generator 1748
+      Net::DNS::ZoneFile::Text 1748
     requirements:
       Digest::HMAC 1.03
       Digest::MD5 2.13
@@ -3218,11 +3206,11 @@ DISTRIBUTIONS
       Pod::Find 0.21
       Pod::Parser 1.13
       Test::More 0
-  Pod-Markdown-3.101
-    pathname: R/RW/RWSTAUNER/Pod-Markdown-3.101.tar.gz
+  Pod-Markdown-3.200
+    pathname: R/RW/RWSTAUNER/Pod-Markdown-3.200.tar.gz
     provides:
-      Pod::Markdown 3.101
-      Pod::Perldoc::ToMarkdown 3.101
+      Pod::Markdown 3.200
+      Pod::Perldoc::ToMarkdown 3.200
     requirements:
       Encode 0
       ExtUtils::MakeMaker 0
@@ -3230,6 +3218,7 @@ DISTRIBUTIONS
       Pod::Simple 3.27
       Pod::Simple::Methody 0
       Pod::Usage 0
+      URI::Escape 0
       parent 0
       perl 5.008
       strict 0
@@ -3270,11 +3259,11 @@ DISTRIBUTIONS
       perl 5.008
       strict 0
       warnings 0
-  Role-Tiny-2.000006
-    pathname: H/HA/HAARG/Role-Tiny-2.000006.tar.gz
+  Role-Tiny-2.001004
+    pathname: H/HA/HAARG/Role-Tiny-2.001004.tar.gz
     provides:
-      Role::Tiny 2.000006
-      Role::Tiny::With 2.000006
+      Role::Tiny 2.001004
+      Role::Tiny::With 2.001004
     requirements:
       Exporter 5.57
       perl 5.006
@@ -3347,49 +3336,49 @@ DISTRIBUTIONS
       Lingua::Stem::Snowball::Se 1.2
     requirements:
       Test::More 0.42
-  Specio-0.43
-    pathname: D/DR/DROLSKY/Specio-0.43.tar.gz
+  Specio-0.44
+    pathname: D/DR/DROLSKY/Specio-0.44.tar.gz
     provides:
-      Specio 0.43
-      Specio::Coercion 0.43
-      Specio::Constraint::AnyCan 0.43
-      Specio::Constraint::AnyDoes 0.43
-      Specio::Constraint::AnyIsa 0.43
-      Specio::Constraint::Enum 0.43
-      Specio::Constraint::Intersection 0.43
-      Specio::Constraint::ObjectCan 0.43
-      Specio::Constraint::ObjectDoes 0.43
-      Specio::Constraint::ObjectIsa 0.43
-      Specio::Constraint::Parameterizable 0.43
-      Specio::Constraint::Parameterized 0.43
-      Specio::Constraint::Role::CanType 0.43
-      Specio::Constraint::Role::DoesType 0.43
-      Specio::Constraint::Role::Interface 0.43
-      Specio::Constraint::Role::IsaType 0.43
-      Specio::Constraint::Simple 0.43
-      Specio::Constraint::Structurable 0.43
-      Specio::Constraint::Structured 0.43
-      Specio::Constraint::Union 0.43
-      Specio::Declare 0.43
-      Specio::DeclaredAt 0.43
-      Specio::Exception 0.43
-      Specio::Exporter 0.43
-      Specio::Helpers 0.43
-      Specio::Library::Builtins 0.43
-      Specio::Library::Numeric 0.43
-      Specio::Library::Perl 0.43
-      Specio::Library::String 0.43
-      Specio::Library::Structured 0.43
-      Specio::Library::Structured::Dict 0.43
-      Specio::Library::Structured::Map 0.43
-      Specio::Library::Structured::Tuple 0.43
-      Specio::OO 0.43
-      Specio::PartialDump 0.43
-      Specio::Registry 0.43
-      Specio::Role::Inlinable 0.43
-      Specio::Subs 0.43
-      Specio::TypeChecks 0.43
-      Test::Specio 0.43
+      Specio 0.44
+      Specio::Coercion 0.44
+      Specio::Constraint::AnyCan 0.44
+      Specio::Constraint::AnyDoes 0.44
+      Specio::Constraint::AnyIsa 0.44
+      Specio::Constraint::Enum 0.44
+      Specio::Constraint::Intersection 0.44
+      Specio::Constraint::ObjectCan 0.44
+      Specio::Constraint::ObjectDoes 0.44
+      Specio::Constraint::ObjectIsa 0.44
+      Specio::Constraint::Parameterizable 0.44
+      Specio::Constraint::Parameterized 0.44
+      Specio::Constraint::Role::CanType 0.44
+      Specio::Constraint::Role::DoesType 0.44
+      Specio::Constraint::Role::Interface 0.44
+      Specio::Constraint::Role::IsaType 0.44
+      Specio::Constraint::Simple 0.44
+      Specio::Constraint::Structurable 0.44
+      Specio::Constraint::Structured 0.44
+      Specio::Constraint::Union 0.44
+      Specio::Declare 0.44
+      Specio::DeclaredAt 0.44
+      Specio::Exception 0.44
+      Specio::Exporter 0.44
+      Specio::Helpers 0.44
+      Specio::Library::Builtins 0.44
+      Specio::Library::Numeric 0.44
+      Specio::Library::Perl 0.44
+      Specio::Library::String 0.44
+      Specio::Library::Structured 0.44
+      Specio::Library::Structured::Dict 0.44
+      Specio::Library::Structured::Map 0.44
+      Specio::Library::Structured::Tuple 0.44
+      Specio::OO 0.44
+      Specio::PartialDump 0.44
+      Specio::Registry 0.44
+      Specio::Role::Inlinable 0.44
+      Specio::Subs 0.44
+      Specio::TypeChecks 0.44
+      Test::Specio 0.44
     requirements:
       B 0
       Carp 0
@@ -3475,22 +3464,22 @@ DISTRIBUTIONS
       Scalar::Util 0
       strict 0
       warnings 0
-  Sub-Name-0.21
-    pathname: E/ET/ETHER/Sub-Name-0.21.tar.gz
+  Sub-Name-0.26
+    pathname: E/ET/ETHER/Sub-Name-0.26.tar.gz
     provides:
-      Sub::Name 0.21
+      Sub::Name 0.26
     requirements:
-      Exporter 5.57
+      Exporter 0
       ExtUtils::MakeMaker 0
       XSLoader 0
       perl 5.006
       strict 0
       warnings 0
-  Sub-Quote-2.006003
-    pathname: H/HA/HAARG/Sub-Quote-2.006003.tar.gz
+  Sub-Quote-2.006006
+    pathname: H/HA/HAARG/Sub-Quote-2.006006.tar.gz
     provides:
-      Sub::Defer 2.006003
-      Sub::Quote 2.006003
+      Sub::Defer 2.006006
+      Sub::Quote 2.006006
     requirements:
       ExtUtils::MakeMaker 0
       Scalar::Util 0
@@ -3589,16 +3578,6 @@ DISTRIBUTIONS
       perl 5.006
       strict 0
       warnings 0
-  Test-Differences-0.67
-    pathname: D/DC/DCANTRELL/Test-Differences-0.67.tar.gz
-    provides:
-      Test::Differences 0.67
-    requirements:
-      Capture::Tiny 0.24
-      Data::Dumper 2.126
-      ExtUtils::MakeMaker 0
-      Test::More 0.88
-      Text::Diff 1.43
   Test-Exception-0.43
     pathname: E/EX/EXODIST/Test-Exception-0.43.tar.gz
     provides:
@@ -3728,10 +3707,10 @@ DISTRIBUTIONS
       Test::Builder 0.13
       Test::Builder::Tester 1.02
       perl 5.006
-  Test-Warnings-0.026
-    pathname: E/ET/ETHER/Test-Warnings-0.026.tar.gz
+  Test-Warnings-0.027
+    pathname: E/ET/ETHER/Test-Warnings-0.027.tar.gz
     provides:
-      Test::Warnings 0.026
+      Test::Warnings 0.027
     requirements:
       Carp 0
       Exporter 0
@@ -3748,28 +3727,16 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       Test::More 0
-  Text-CSV_XS-1.39
-    pathname: H/HM/HMBRAND/Text-CSV_XS-1.39.tgz
+  Text-CSV_XS-1.40
+    pathname: H/HM/HMBRAND/Text-CSV_XS-1.40.tgz
     provides:
-      Text::CSV_XS 1.39
+      Text::CSV_XS 1.40
     requirements:
       Config 0
       ExtUtils::MakeMaker 0
       IO::Handle 0
       Test::More 0
       XSLoader 0
-  Text-Diff-1.45
-    pathname: N/NE/NEILB/Text-Diff-1.45.tar.gz
-    provides:
-      Text::Diff 1.45
-      Text::Diff::Base 1.45
-      Text::Diff::Config 1.44
-      Text::Diff::Table 1.44
-    requirements:
-      Algorithm::Diff 1.19
-      Exporter 0
-      ExtUtils::MakeMaker 0
-      perl 5.006
   Text-German-0.06
     pathname: U/UL/ULPFR/Text-German-0.06.tar.gz
     provides:
@@ -3939,11 +3906,11 @@ DISTRIBUTIONS
       Exporter::Tiny 0.040
       ExtUtils::MakeMaker 6.17
       perl 5.006001
-  Type-Tiny-XS-0.015
-    pathname: T/TO/TOBYINK/Type-Tiny-XS-0.015.tar.gz
+  Type-Tiny-XS-0.016
+    pathname: T/TO/TOBYINK/Type-Tiny-XS-0.016.tar.gz
     provides:
-      Type::Tiny::XS 0.015
-      Type::Tiny::XS::Util 0.015
+      Type::Tiny::XS 0.016
+      Type::Tiny::XS::Util 0.016
     requirements:
       ExtUtils::MakeMaker 6.17
       perl 5.010001
@@ -4051,11 +4018,11 @@ DISTRIBUTIONS
       Win32::ShellQuote 0.003001
     requirements:
       perl 5.006
-  YAML-LibYAML-0.79
-    pathname: T/TI/TINITA/YAML-LibYAML-0.79.tar.gz
+  YAML-LibYAML-0.80
+    pathname: T/TI/TINITA/YAML-LibYAML-0.80.tar.gz
     provides:
-      YAML::LibYAML 0.79
-      YAML::XS 0.79
+      YAML::LibYAML 0.80
+      YAML::XS 0.80
       YAML::XS::LibYAML undef
     requirements:
       ExtUtils::MakeMaker 0
@@ -4093,6 +4060,16 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       perl 5.006
+  experimental-0.020
+    pathname: L/LE/LEONT/experimental-0.020.tar.gz
+    provides:
+      experimental 0.020
+    requirements:
+      Carp 0
+      ExtUtils::MakeMaker 0
+      strict 0
+      version 0
+      warnings 0
   indirect-0.39
     pathname: V/VP/VPIT/indirect-0.39.tar.gz
     provides:
@@ -4133,10 +4110,10 @@ DISTRIBUTIONS
       perl 5.008001
       strict 0
       warnings 0
-  namespace-autoclean-0.28
-    pathname: E/ET/ETHER/namespace-autoclean-0.28.tar.gz
+  namespace-autoclean-0.29
+    pathname: E/ET/ETHER/namespace-autoclean-0.29.tar.gz
     provides:
-      namespace::autoclean 0.28
+      namespace::autoclean 0.29
     requirements:
       B::Hooks::EndOfScope 0.12
       ExtUtils::MakeMaker 0

--- a/docs/json-schema/response.json
+++ b/docs/json-schema/response.json
@@ -196,6 +196,7 @@
           "type" : "string"
         },
         "vendor_name" : {
+          "description" : "the vendor's name for the datacenter",
           "oneOf" : [
             {
               "type" : "string"
@@ -241,6 +242,7 @@
           "type" : "string"
         },
         "vendor_name" : {
+          "description" : "the vendor's name for the room",
           "oneOf" : [
             {
               "type" : "string"
@@ -1113,7 +1115,7 @@
                       "type" : "string"
                     },
                     "vendor_name" : {
-                      "description" : "datacenter.vendor_name",
+                      "description" : "the vendor's name for the datacenter",
                       "oneOf" : [
                         {
                           "type" : "null"
@@ -3060,7 +3062,7 @@
                     "type" : "string"
                   },
                   "vendor_name" : {
-                    "description" : "datacenter.vendor_name",
+                    "description" : "the vendor's name for the datacenter",
                     "oneOf" : [
                       {
                         "type" : "null"

--- a/docs/modules/Conch.md
+++ b/docs/modules/Conch.md
@@ -26,7 +26,7 @@ Helper method for setting the response status code and json content.
 
 ## startup\_time
 
-Stores a [Conch::Time](../modules/Conch::Time) instance representing the time the server started accepting requests.
+Stores a [Conch::Time](../modules/Conch%3A%3ATime) instance representing the time the server started accepting requests.
 
 # LICENSING
 

--- a/docs/modules/Conch::Controller::Build.md
+++ b/docs/modules/Conch::Controller::Build.md
@@ -52,7 +52,7 @@ Requires the 'admin' role on the build.
 Optionally takes a query parameter `send_mail` (defaulting to true), to send an email
 to the user and to all build admins.
 
-This endpoint is nearly identical to ["add\_user" in Conch::Controller::Organization](../modules/Conch::Controller::Organization#add_user).
+This endpoint is nearly identical to ["add\_user" in Conch::Controller::Organization](../modules/Conch%3A%3AController%3A%3AOrganization#add_user).
 
 ## remove\_user
 
@@ -62,7 +62,7 @@ Requires the 'admin' role on the build.
 Optionally takes a query parameter `send_mail` (defaulting to true), to send an email
 to the user and to all build admins.
 
-This endpoint is nearly identical to ["remove\_user" in Conch::Controller::Organization](../modules/Conch::Controller::Organization#remove_user).
+This endpoint is nearly identical to ["remove\_user" in Conch::Controller::Organization](../modules/Conch%3A%3AController%3A%3AOrganization#remove_user).
 
 ## list\_organizations
 

--- a/docs/modules/Conch::Controller::DeviceReport.md
+++ b/docs/modules/Conch::Controller::DeviceReport.md
@@ -29,7 +29,7 @@ Role checks are done in the next controller action in the chain.
 ## get
 
 Get the device\_report record specified by uuid.
-A role check has already been done by [device#find\_device](../modules/Conch::Controller::Device#find_device).
+A role check has already been done by [device#find\_device](../modules/Conch%3A%3AController%3A%3ADevice#find_device).
 
 Response uses the DeviceReportRow json schema.
 

--- a/docs/modules/Conch::Controller::Schema.md
+++ b/docs/modules/Conch::Controller::Schema.md
@@ -10,7 +10,7 @@ Get the json-schema in JSON format.
 
 ## \_extract\_schema\_definition
 
-Given a [JSON::Validator](https://metacpan.org/pod/JSON::Validator) object containing a schema definition, extract the requested portion
+Given a [JSON::Validator](https://metacpan.org/pod/JSON%3A%3AValidator) object containing a schema definition, extract the requested portion
 out of the "definitions" section, including any named references, and add some standard
 headers.
 

--- a/docs/modules/Conch::Controller::User.md
+++ b/docs/modules/Conch::Controller::User.md
@@ -104,7 +104,7 @@ The response uses the UserError json schema for some error conditions; on succes
 
 ## list
 
-List all active users and their workspaces. System admin only.
+List all active users and their workspaces, builds and organizations. System admin only.
 Response uses the UsersDetailed json schema.
 
 ## create

--- a/docs/modules/Conch::Controller::WorkspaceRack.md
+++ b/docs/modules/Conch::Controller::WorkspaceRack.md
@@ -15,8 +15,8 @@ Response uses the WorkspaceRackSummary json schema.
 Chainable action that uses the `workspace_rs` and `rack_id` stash values and confirms the
 rack is a (direct or indirect) member of the workspace.
 
-Relies on ["find\_workspace" in Conch::Controller::Workspace](../modules/Conch::Controller::Workspace#find_workspace) and
-["find\_rack" in Conch::Controller::Rack](../modules/Conch::Controller::Rack#find_rack) to have already run, verified user roles, and populated
+Relies on ["find\_workspace" in Conch::Controller::Workspace](../modules/Conch%3A%3AController%3A%3AWorkspace#find_workspace) and
+["find\_rack" in Conch::Controller::Rack](../modules/Conch%3A%3AController%3A%3ARack#find_rack) to have already run, verified user roles, and populated
 the stash values.
 
 Saves `workspace_rack_rs` to the stash.

--- a/docs/modules/Conch::DB.md
+++ b/docs/modules/Conch::DB.md
@@ -4,7 +4,7 @@ Conch::DB
 
 # DESCRIPTION
 
-Base schema class for the Conch application. See [DBIx::Class::Schema](https://metacpan.org/pod/DBIx::Class::Schema).
+Base schema class for the Conch application. See [DBIx::Class::Schema](https://metacpan.org/pod/DBIx%3A%3AClass%3A%3ASchema).
 
 # LICENSING
 

--- a/docs/modules/Conch::DB::Helper::ResultSet::AsEpoch.md
+++ b/docs/modules/Conch::DB::Helper::ResultSet::AsEpoch.md
@@ -4,7 +4,7 @@ Conch::DB::Helper::ResultSet::AsEpoch
 
 # DESCRIPTION
 
-A component for [Conch::DB::ResultSet](../modules/Conch::DB::ResultSet) classes that provides the `as_epoch` method.
+A component for [Conch::DB::ResultSet](../modules/Conch%3A%3ADB%3A%3AResultSet) classes that provides the `as_epoch` method.
 
 This code is postgres-specific.
 

--- a/docs/modules/Conch::DB::Helper::ResultSet::Deactivatable.md
+++ b/docs/modules/Conch::DB::Helper::ResultSet::Deactivatable.md
@@ -4,7 +4,7 @@ Conch::DB::Helper::ResultSet::Deactivatable
 
 # DESCRIPTION
 
-A component for [Conch::DB::ResultSet](../modules/Conch::DB::ResultSet) classes for database tables with a `deactivated`
+A component for [Conch::DB::ResultSet](../modules/Conch%3A%3ADB%3A%3AResultSet) classes for database tables with a `deactivated`
 column, to provide common query functionality.
 
 # USAGE

--- a/docs/modules/Conch::DB::Helper::ResultSet::ResultsExist.md
+++ b/docs/modules/Conch::DB::Helper::ResultSet::ResultsExist.md
@@ -21,7 +21,7 @@ __PACKAGE__->load_components('+Conch::DB::Helper::ResultSet::ResultsExist');
 
 ## exists
 
-Efficiently efficiently determines if a result exists, without needing to do a `->count`.
+Efficiently determines if a result exists, without needing to do a `->count`.
 Essentially does:
 
 ```

--- a/docs/modules/Conch::DB::Helper::ResultSet::ResultsExist.md
+++ b/docs/modules/Conch::DB::Helper::ResultSet::ResultsExist.md
@@ -4,9 +4,9 @@ Conch::DB::Helper::ResultSet::ResultsExist
 
 # DESCRIPTION
 
-A component for [Conch::DB::ResultSet](../modules/Conch::DB::ResultSet) classes that provides the `exists` method.
+A component for [Conch::DB::ResultSet](../modules/Conch%3A%3ADB%3A%3AResultSet) classes that provides the `exists` method.
 
-See also [DBIx::Class::Helper::ResultSet::Shortcut::ResultsExist](https://metacpan.org/pod/DBIx::Class::Helper::ResultSet::Shortcut::ResultsExist), which is not usable in its
+See also [DBIx::Class::Helper::ResultSet::Shortcut::ResultsExist](https://metacpan.org/pod/DBIx%3A%3AClass%3A%3AHelper%3A%3AResultSet%3A%3AShortcut%3A%3AResultsExist), which is not usable in its
 present form due to [https://github.com/frioux/DBIx-Class-Helpers/issues/54](https://github.com/frioux/DBIx-Class-Helpers/issues/54).
 
 This code is postgres-specific.

--- a/docs/modules/Conch::DB::Helper::ResultSet::WithRole.md
+++ b/docs/modules/Conch::DB::Helper::ResultSet::WithRole.md
@@ -4,7 +4,7 @@ Conch::DB::Helper::ResultSet::WithRole
 
 # DESCRIPTION
 
-A component for [Conch::DB::ResultSet](../modules/Conch::DB::ResultSet) classes for database tables with a `role`
+A component for [Conch::DB::ResultSet](../modules/Conch%3A%3ADB%3A%3AResultSet) classes for database tables with a `role`
 column, to provide common query functionality.
 
 # USAGE

--- a/docs/modules/Conch::DB::Helper::Row::ToJSON.md
+++ b/docs/modules/Conch::DB::Helper::Row::ToJSON.md
@@ -4,8 +4,8 @@ Conch::DB::Helper::Row::ToJSON
 
 # DESCRIPTION
 
-A component for [Conch::DB::Result](../modules/Conch::DB::Result) classes to provide serialization functionality via `TO_JSON`.
-Sub-classes [DBIx::Class::Helper::Row::ToJSON](https://metacpan.org/pod/DBIx::Class::Helper::Row::ToJSON) to also serialize 'text' data.
+A component for [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult) classes to provide serialization functionality via `TO_JSON`.
+Sub-classes [DBIx::Class::Helper::Row::ToJSON](https://metacpan.org/pod/DBIx%3A%3AClass%3A%3AHelper%3A%3ARow%3A%3AToJSON) to also serialize 'text' data.
 
 # USAGE
 

--- a/docs/modules/Conch::DB::Helper::Row::WithPhase.md
+++ b/docs/modules/Conch::DB::Helper::Row::WithPhase.md
@@ -4,7 +4,7 @@ Conch::DB::Helper::Row::WithPhase
 
 # DESCRIPTION
 
-A component for [Conch::DB::Result](../modules/Conch::DB::Result) classes for database tables with a `phase` column, to
+A component for [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult) classes for database tables with a `phase` column, to
 provide common functionality.
 
 # USAGE

--- a/docs/modules/Conch::DB::Helper::Row::WithRole.md
+++ b/docs/modules/Conch::DB::Helper::Row::WithRole.md
@@ -4,7 +4,7 @@ Conch::DB::Helper::Row::WithRole
 
 # DESCRIPTION
 
-A component for [Conch::DB::Result](../modules/Conch::DB::Result) classes for database tables with a `role`
+A component for [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult) classes for database tables with a `role`
 column, to provide common functionality.
 
 # USAGE

--- a/docs/modules/Conch::DB::InflateColumn::Time.md
+++ b/docs/modules/Conch::DB::InflateColumn::Time.md
@@ -1,11 +1,11 @@
 # DESCRIPTION
 
-Automatically inflates/deflates timestamps in the database to [Conch::Time](../modules/Conch::Time) objects (which is
-a subclass of [Time::Moment](https://metacpan.org/pod/Time::Moment)).
+Automatically inflates/deflates timestamps in the database to [Conch::Time](../modules/Conch%3A%3ATime) objects (which is
+a subclass of [Time::Moment](https://metacpan.org/pod/Time%3A%3AMoment)).
 
 No extra work needs to be done for deflation, because postgres is happy to accept our slight
 modifications to the format used in `to_string`. All we need to do is rebless the
-[Time::Moment](https://metacpan.org/pod/Time::Moment) object into [Conch::Time](../modules/Conch::Time), and work around the bug in
+[Time::Moment](https://metacpan.org/pod/Time%3A%3AMoment) object into [Conch::Time](../modules/Conch%3A%3ATime), and work around the bug in
 [RT#125975](https://rt.cpan.org/Ticket/Display.html?id=125975).
 
 # LICENSING

--- a/docs/modules/Conch::DB::Result.md
+++ b/docs/modules/Conch::DB::Result.md
@@ -5,14 +5,14 @@ Conch::DB::Result
 # DESCRIPTION
 
 Base class for our result classes, to allow us to add on additional functionality from what is
-available in core [DBIx::Class](https://metacpan.org/pod/DBIx::Class).
+available in core [DBIx::Class](https://metacpan.org/pod/DBIx%3A%3AClass).
 
 # METHODS
 
 Methods added are:
 
-- [self\_rs](https://metacpan.org/pod/DBIx::Class::Helper::Row::SelfResultSet#self_rs)
-- [TO\_JSON](../modules/Conch::DB::Helper::Row::ToJSON)
+- [self\_rs](https://metacpan.org/pod/DBIx%3A%3AClass%3A%3AHelper%3A%3ARow%3A%3ASelfResultSet#self_rs)
+- [TO\_JSON](../modules/Conch%3A%3ADB%3A%3AHelper%3A%3ARow%3A%3AToJSON)
 
 # LICENSING
 

--- a/docs/modules/Conch::DB::Result::Build.md
+++ b/docs/modules/Conch::DB::Result::Build.md
@@ -2,7 +2,7 @@
 
 Conch::DB::Result::Build
 
-# BASE CLASS: [Conch::DB::Result](../modules/Conch::DB::Result)
+# BASE CLASS: [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult)
 
 # TABLE: `build`
 
@@ -79,31 +79,31 @@ size: 16
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::UserAccount](../modules/Conch::DB::Result::UserAccount)
+Related object: [Conch::DB::Result::UserAccount](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AUserAccount)
 
 ## devices
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::Device](../modules/Conch::DB::Result::Device)
+Related object: [Conch::DB::Result::Device](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ADevice)
 
 ## organization\_build\_roles
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::OrganizationBuildRole](../modules/Conch::DB::Result::OrganizationBuildRole)
+Related object: [Conch::DB::Result::OrganizationBuildRole](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AOrganizationBuildRole)
 
 ## racks
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::Rack](../modules/Conch::DB::Result::Rack)
+Related object: [Conch::DB::Result::Rack](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ARack)
 
 ## user\_build\_roles
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::UserBuildRole](../modules/Conch::DB::Result::UserBuildRole)
+Related object: [Conch::DB::Result::UserBuildRole](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AUserBuildRole)
 
 ## organizations
 

--- a/docs/modules/Conch::DB::Result::Datacenter.md
+++ b/docs/modules/Conch::DB::Result::Datacenter.md
@@ -2,7 +2,7 @@
 
 Conch::DB::Result::Datacenter
 
-# BASE CLASS: [Conch::DB::Result](../modules/Conch::DB::Result)
+# BASE CLASS: [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult)
 
 # TABLE: `datacenter`
 
@@ -81,7 +81,7 @@ original: {default_value => \"now()"}
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::DatacenterRoom](../modules/Conch::DB::Result::DatacenterRoom)
+Related object: [Conch::DB::Result::DatacenterRoom](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ADatacenterRoom)
 
 # LICENSING
 

--- a/docs/modules/Conch::DB::Result::DatacenterRoom.md
+++ b/docs/modules/Conch::DB::Result::DatacenterRoom.md
@@ -2,7 +2,7 @@
 
 Conch::DB::Result::DatacenterRoom
 
-# BASE CLASS: [Conch::DB::Result](../modules/Conch::DB::Result)
+# BASE CLASS: [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult)
 
 # TABLE: `datacenter_room`
 
@@ -81,13 +81,13 @@ original: {default_value => \"now()"}
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::Datacenter](../modules/Conch::DB::Result::Datacenter)
+Related object: [Conch::DB::Result::Datacenter](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ADatacenter)
 
 ## racks
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::Rack](../modules/Conch::DB::Result::Rack)
+Related object: [Conch::DB::Result::Rack](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ARack)
 
 # LICENSING
 

--- a/docs/modules/Conch::DB::Result::Device.md
+++ b/docs/modules/Conch::DB::Result::Device.md
@@ -2,7 +2,7 @@
 
 Conch::DB::Result::Device
 
-# BASE CLASS: [Conch::DB::Result](../modules/Conch::DB::Result)
+# BASE CLASS: [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult)
 
 # TABLE: `device`
 
@@ -148,61 +148,61 @@ size: 16
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::Build](../modules/Conch::DB::Result::Build)
+Related object: [Conch::DB::Result::Build](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ABuild)
 
 ## device\_disks
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::DeviceDisk](../modules/Conch::DB::Result::DeviceDisk)
+Related object: [Conch::DB::Result::DeviceDisk](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ADeviceDisk)
 
 ## device\_location
 
 Type: might\_have
 
-Related object: [Conch::DB::Result::DeviceLocation](../modules/Conch::DB::Result::DeviceLocation)
+Related object: [Conch::DB::Result::DeviceLocation](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ADeviceLocation)
 
 ## device\_nics
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::DeviceNic](../modules/Conch::DB::Result::DeviceNic)
+Related object: [Conch::DB::Result::DeviceNic](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ADeviceNic)
 
 ## device\_relay\_connections
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::DeviceRelayConnection](../modules/Conch::DB::Result::DeviceRelayConnection)
+Related object: [Conch::DB::Result::DeviceRelayConnection](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ADeviceRelayConnection)
 
 ## device\_reports
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::DeviceReport](../modules/Conch::DB::Result::DeviceReport)
+Related object: [Conch::DB::Result::DeviceReport](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ADeviceReport)
 
 ## device\_settings
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::DeviceSetting](../modules/Conch::DB::Result::DeviceSetting)
+Related object: [Conch::DB::Result::DeviceSetting](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ADeviceSetting)
 
 ## hardware\_product
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::HardwareProduct](../modules/Conch::DB::Result::HardwareProduct)
+Related object: [Conch::DB::Result::HardwareProduct](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AHardwareProduct)
 
 ## validation\_results
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::ValidationResult](../modules/Conch::DB::Result::ValidationResult)
+Related object: [Conch::DB::Result::ValidationResult](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AValidationResult)
 
 ## validation\_states
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::ValidationState](../modules/Conch::DB::Result::ValidationState)
+Related object: [Conch::DB::Result::ValidationState](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AValidationState)
 
 ## relays
 

--- a/docs/modules/Conch::DB::Result::DeviceDisk.md
+++ b/docs/modules/Conch::DB::Result::DeviceDisk.md
@@ -2,7 +2,7 @@
 
 Conch::DB::Result::DeviceDisk
 
-# BASE CLASS: [Conch::DB::Result](../modules/Conch::DB::Result)
+# BASE CLASS: [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult)
 
 # TABLE: `device_disk`
 
@@ -144,7 +144,7 @@ size: 16
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::Device](../modules/Conch::DB::Result::Device)
+Related object: [Conch::DB::Result::Device](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ADevice)
 
 # LICENSING
 

--- a/docs/modules/Conch::DB::Result::DeviceLocation.md
+++ b/docs/modules/Conch::DB::Result::DeviceLocation.md
@@ -2,7 +2,7 @@
 
 Conch::DB::Result::DeviceLocation
 
-# BASE CLASS: [Conch::DB::Result](../modules/Conch::DB::Result)
+# BASE CLASS: [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult)
 
 # TABLE: `device_location`
 
@@ -69,19 +69,19 @@ size: 16
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::Device](../modules/Conch::DB::Result::Device)
+Related object: [Conch::DB::Result::Device](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ADevice)
 
 ## rack
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::Rack](../modules/Conch::DB::Result::Rack)
+Related object: [Conch::DB::Result::Rack](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ARack)
 
 ## rack\_layout
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::RackLayout](../modules/Conch::DB::Result::RackLayout)
+Related object: [Conch::DB::Result::RackLayout](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ARackLayout)
 
 # LICENSING
 

--- a/docs/modules/Conch::DB::Result::DeviceNeighbor.md
+++ b/docs/modules/Conch::DB::Result::DeviceNeighbor.md
@@ -2,7 +2,7 @@
 
 Conch::DB::Result::DeviceNeighbor
 
-# BASE CLASS: [Conch::DB::Result](../modules/Conch::DB::Result)
+# BASE CLASS: [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult)
 
 # TABLE: `device_neighbor`
 
@@ -72,7 +72,7 @@ is_nullable: 1
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::DeviceNic](../modules/Conch::DB::Result::DeviceNic)
+Related object: [Conch::DB::Result::DeviceNic](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ADeviceNic)
 
 # LICENSING
 

--- a/docs/modules/Conch::DB::Result::DeviceNic.md
+++ b/docs/modules/Conch::DB::Result::DeviceNic.md
@@ -2,7 +2,7 @@
 
 Conch::DB::Result::DeviceNic
 
-# BASE CLASS: [Conch::DB::Result](../modules/Conch::DB::Result)
+# BASE CLASS: [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult)
 
 # TABLE: `device_nic`
 
@@ -108,13 +108,13 @@ size: 16
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::Device](../modules/Conch::DB::Result::Device)
+Related object: [Conch::DB::Result::Device](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ADevice)
 
 ## device\_neighbor
 
 Type: might\_have
 
-Related object: [Conch::DB::Result::DeviceNeighbor](../modules/Conch::DB::Result::DeviceNeighbor)
+Related object: [Conch::DB::Result::DeviceNeighbor](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ADeviceNeighbor)
 
 # LICENSING
 

--- a/docs/modules/Conch::DB::Result::DeviceRelayConnection.md
+++ b/docs/modules/Conch::DB::Result::DeviceRelayConnection.md
@@ -2,7 +2,7 @@
 
 Conch::DB::Result::DeviceRelayConnection
 
-# BASE CLASS: [Conch::DB::Result](../modules/Conch::DB::Result)
+# BASE CLASS: [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult)
 
 # TABLE: `device_relay_connection`
 
@@ -55,13 +55,13 @@ size: 16
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::Device](../modules/Conch::DB::Result::Device)
+Related object: [Conch::DB::Result::Device](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ADevice)
 
 ## relay
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::Relay](../modules/Conch::DB::Result::Relay)
+Related object: [Conch::DB::Result::Relay](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ARelay)
 
 # LICENSING
 

--- a/docs/modules/Conch::DB::Result::DeviceReport.md
+++ b/docs/modules/Conch::DB::Result::DeviceReport.md
@@ -2,7 +2,7 @@
 
 Conch::DB::Result::DeviceReport
 
-# BASE CLASS: [Conch::DB::Result](../modules/Conch::DB::Result)
+# BASE CLASS: [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult)
 
 # TABLE: `device_report`
 
@@ -59,13 +59,13 @@ size: 16
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::Device](../modules/Conch::DB::Result::Device)
+Related object: [Conch::DB::Result::Device](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ADevice)
 
 ## validation\_states
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::ValidationState](../modules/Conch::DB::Result::ValidationState)
+Related object: [Conch::DB::Result::ValidationState](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AValidationState)
 
 # LICENSING
 

--- a/docs/modules/Conch::DB::Result::DeviceSetting.md
+++ b/docs/modules/Conch::DB::Result::DeviceSetting.md
@@ -2,7 +2,7 @@
 
 Conch::DB::Result::DeviceSetting
 
-# BASE CLASS: [Conch::DB::Result](../modules/Conch::DB::Result)
+# BASE CLASS: [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult)
 
 # TABLE: `device_setting`
 
@@ -75,7 +75,7 @@ size: 16
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::Device](../modules/Conch::DB::Result::Device)
+Related object: [Conch::DB::Result::Device](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ADevice)
 
 # LICENSING
 

--- a/docs/modules/Conch::DB::Result::HardwareProduct.md
+++ b/docs/modules/Conch::DB::Result::HardwareProduct.md
@@ -2,7 +2,7 @@
 
 Conch::DB::Result::HardwareProduct
 
-# BASE CLASS: [Conch::DB::Result](../modules/Conch::DB::Result)
+# BASE CLASS: [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult)
 
 # TABLE: `hardware_product`
 
@@ -126,37 +126,37 @@ size: 16
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::Device](../modules/Conch::DB::Result::Device)
+Related object: [Conch::DB::Result::Device](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ADevice)
 
 ## hardware\_product\_profile
 
 Type: might\_have
 
-Related object: [Conch::DB::Result::HardwareProductProfile](../modules/Conch::DB::Result::HardwareProductProfile)
+Related object: [Conch::DB::Result::HardwareProductProfile](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AHardwareProductProfile)
 
 ## hardware\_vendor
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::HardwareVendor](../modules/Conch::DB::Result::HardwareVendor)
+Related object: [Conch::DB::Result::HardwareVendor](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AHardwareVendor)
 
 ## rack\_layouts
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::RackLayout](../modules/Conch::DB::Result::RackLayout)
+Related object: [Conch::DB::Result::RackLayout](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ARackLayout)
 
 ## validation\_plan
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::ValidationPlan](../modules/Conch::DB::Result::ValidationPlan)
+Related object: [Conch::DB::Result::ValidationPlan](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AValidationPlan)
 
 ## validation\_results
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::ValidationResult](../modules/Conch::DB::Result::ValidationResult)
+Related object: [Conch::DB::Result::ValidationResult](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AValidationResult)
 
 # LICENSING
 

--- a/docs/modules/Conch::DB::Result::HardwareProductProfile.md
+++ b/docs/modules/Conch::DB::Result::HardwareProductProfile.md
@@ -2,7 +2,7 @@
 
 Conch::DB::Result::HardwareProductProfile
 
-# BASE CLASS: [Conch::DB::Result](../modules/Conch::DB::Result)
+# BASE CLASS: [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult)
 
 # TABLE: `hardware_product_profile`
 
@@ -249,7 +249,7 @@ is_nullable: 1
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::HardwareProduct](../modules/Conch::DB::Result::HardwareProduct)
+Related object: [Conch::DB::Result::HardwareProduct](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AHardwareProduct)
 
 # LICENSING
 

--- a/docs/modules/Conch::DB::Result::HardwareVendor.md
+++ b/docs/modules/Conch::DB::Result::HardwareVendor.md
@@ -2,7 +2,7 @@
 
 Conch::DB::Result::HardwareVendor
 
-# BASE CLASS: [Conch::DB::Result](../modules/Conch::DB::Result)
+# BASE CLASS: [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult)
 
 # TABLE: `hardware_vendor`
 
@@ -59,7 +59,7 @@ original: {default_value => \"now()"}
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::HardwareProduct](../modules/Conch::DB::Result::HardwareProduct)
+Related object: [Conch::DB::Result::HardwareProduct](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AHardwareProduct)
 
 # LICENSING
 

--- a/docs/modules/Conch::DB::Result::Migration.md
+++ b/docs/modules/Conch::DB::Result::Migration.md
@@ -2,7 +2,7 @@
 
 Conch::DB::Result::Migration
 
-# BASE CLASS: [Conch::DB::Result](../modules/Conch::DB::Result)
+# BASE CLASS: [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult)
 
 # TABLE: `migration`
 

--- a/docs/modules/Conch::DB::Result::Organization.md
+++ b/docs/modules/Conch::DB::Result::Organization.md
@@ -2,7 +2,7 @@
 
 Conch::DB::Result::Organization
 
-# BASE CLASS: [Conch::DB::Result](../modules/Conch::DB::Result)
+# BASE CLASS: [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult)
 
 # TABLE: `organization`
 
@@ -57,19 +57,19 @@ is_nullable: 1
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::OrganizationBuildRole](../modules/Conch::DB::Result::OrganizationBuildRole)
+Related object: [Conch::DB::Result::OrganizationBuildRole](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AOrganizationBuildRole)
 
 ## organization\_workspace\_roles
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::OrganizationWorkspaceRole](../modules/Conch::DB::Result::OrganizationWorkspaceRole)
+Related object: [Conch::DB::Result::OrganizationWorkspaceRole](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AOrganizationWorkspaceRole)
 
 ## user\_organization\_roles
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::UserOrganizationRole](../modules/Conch::DB::Result::UserOrganizationRole)
+Related object: [Conch::DB::Result::UserOrganizationRole](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AUserOrganizationRole)
 
 ## builds
 

--- a/docs/modules/Conch::DB::Result::OrganizationBuildRole.md
+++ b/docs/modules/Conch::DB::Result::OrganizationBuildRole.md
@@ -2,7 +2,7 @@
 
 Conch::DB::Result::OrganizationBuildRole
 
-# BASE CLASS: [Conch::DB::Result](../modules/Conch::DB::Result)
+# BASE CLASS: [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult)
 
 # TABLE: `organization_build_role`
 
@@ -46,13 +46,13 @@ is_nullable: 0
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::Build](../modules/Conch::DB::Result::Build)
+Related object: [Conch::DB::Result::Build](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ABuild)
 
 ## organization
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::Organization](../modules/Conch::DB::Result::Organization)
+Related object: [Conch::DB::Result::Organization](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AOrganization)
 
 # LICENSING
 

--- a/docs/modules/Conch::DB::Result::OrganizationWorkspaceRole.md
+++ b/docs/modules/Conch::DB::Result::OrganizationWorkspaceRole.md
@@ -2,7 +2,7 @@
 
 Conch::DB::Result::OrganizationWorkspaceRole
 
-# BASE CLASS: [Conch::DB::Result](../modules/Conch::DB::Result)
+# BASE CLASS: [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult)
 
 # TABLE: `organization_workspace_role`
 
@@ -46,13 +46,13 @@ is_nullable: 0
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::Organization](../modules/Conch::DB::Result::Organization)
+Related object: [Conch::DB::Result::Organization](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AOrganization)
 
 ## workspace
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::Workspace](../modules/Conch::DB::Result::Workspace)
+Related object: [Conch::DB::Result::Workspace](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AWorkspace)
 
 # LICENSING
 

--- a/docs/modules/Conch::DB::Result::Rack.md
+++ b/docs/modules/Conch::DB::Result::Rack.md
@@ -2,7 +2,7 @@
 
 Conch::DB::Result::Rack
 
-# BASE CLASS: [Conch::DB::Result](../modules/Conch::DB::Result)
+# BASE CLASS: [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult)
 
 # TABLE: `rack`
 
@@ -102,37 +102,37 @@ size: 16
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::Build](../modules/Conch::DB::Result::Build)
+Related object: [Conch::DB::Result::Build](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ABuild)
 
 ## datacenter\_room
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::DatacenterRoom](../modules/Conch::DB::Result::DatacenterRoom)
+Related object: [Conch::DB::Result::DatacenterRoom](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ADatacenterRoom)
 
 ## device\_locations
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::DeviceLocation](../modules/Conch::DB::Result::DeviceLocation)
+Related object: [Conch::DB::Result::DeviceLocation](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ADeviceLocation)
 
 ## rack\_layouts
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::RackLayout](../modules/Conch::DB::Result::RackLayout)
+Related object: [Conch::DB::Result::RackLayout](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ARackLayout)
 
 ## rack\_role
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::RackRole](../modules/Conch::DB::Result::RackRole)
+Related object: [Conch::DB::Result::RackRole](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ARackRole)
 
 ## workspace\_racks
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::WorkspaceRack](../modules/Conch::DB::Result::WorkspaceRack)
+Related object: [Conch::DB::Result::WorkspaceRack](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AWorkspaceRack)
 
 ## workspaces
 

--- a/docs/modules/Conch::DB::Result::RackLayout.md
+++ b/docs/modules/Conch::DB::Result::RackLayout.md
@@ -2,7 +2,7 @@
 
 Conch::DB::Result::RackLayout
 
-# BASE CLASS: [Conch::DB::Result](../modules/Conch::DB::Result)
+# BASE CLASS: [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult)
 
 # TABLE: `rack_layout`
 
@@ -77,19 +77,19 @@ original: {default_value => \"now()"}
 
 Type: might\_have
 
-Related object: [Conch::DB::Result::DeviceLocation](../modules/Conch::DB::Result::DeviceLocation)
+Related object: [Conch::DB::Result::DeviceLocation](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ADeviceLocation)
 
 ## hardware\_product
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::HardwareProduct](../modules/Conch::DB::Result::HardwareProduct)
+Related object: [Conch::DB::Result::HardwareProduct](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AHardwareProduct)
 
 ## rack
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::Rack](../modules/Conch::DB::Result::Rack)
+Related object: [Conch::DB::Result::Rack](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ARack)
 
 # LICENSING
 

--- a/docs/modules/Conch::DB::Result::RackRole.md
+++ b/docs/modules/Conch::DB::Result::RackRole.md
@@ -2,7 +2,7 @@
 
 Conch::DB::Result::RackRole
 
-# BASE CLASS: [Conch::DB::Result](../modules/Conch::DB::Result)
+# BASE CLASS: [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult)
 
 # TABLE: `rack_role`
 
@@ -70,7 +70,7 @@ original: {default_value => \"now()"}
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::Rack](../modules/Conch::DB::Result::Rack)
+Related object: [Conch::DB::Result::Rack](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ARack)
 
 # LICENSING
 

--- a/docs/modules/Conch::DB::Result::Relay.md
+++ b/docs/modules/Conch::DB::Result::Relay.md
@@ -2,7 +2,7 @@
 
 Conch::DB::Result::Relay
 
-# BASE CLASS: [Conch::DB::Result](../modules/Conch::DB::Result)
+# BASE CLASS: [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult)
 
 # TABLE: `relay`
 
@@ -102,13 +102,13 @@ original: {default_value => \"now()"}
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::DeviceRelayConnection](../modules/Conch::DB::Result::DeviceRelayConnection)
+Related object: [Conch::DB::Result::DeviceRelayConnection](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ADeviceRelayConnection)
 
 ## user\_relay\_connections
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::UserRelayConnection](../modules/Conch::DB::Result::UserRelayConnection)
+Related object: [Conch::DB::Result::UserRelayConnection](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AUserRelayConnection)
 
 ## devices
 

--- a/docs/modules/Conch::DB::Result::UserAccount.md
+++ b/docs/modules/Conch::DB::Result::UserAccount.md
@@ -2,7 +2,7 @@
 
 Conch::DB::Result::UserAccount
 
-# BASE CLASS: [Conch::DB::Result](../modules/Conch::DB::Result)
+# BASE CLASS: [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult)
 
 # TABLE: `user_account`
 
@@ -102,43 +102,43 @@ is_nullable: 1
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::Build](../modules/Conch::DB::Result::Build)
+Related object: [Conch::DB::Result::Build](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ABuild)
 
 ## user\_build\_roles
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::UserBuildRole](../modules/Conch::DB::Result::UserBuildRole)
+Related object: [Conch::DB::Result::UserBuildRole](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AUserBuildRole)
 
 ## user\_organization\_roles
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::UserOrganizationRole](../modules/Conch::DB::Result::UserOrganizationRole)
+Related object: [Conch::DB::Result::UserOrganizationRole](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AUserOrganizationRole)
 
 ## user\_relay\_connections
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::UserRelayConnection](../modules/Conch::DB::Result::UserRelayConnection)
+Related object: [Conch::DB::Result::UserRelayConnection](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AUserRelayConnection)
 
 ## user\_session\_tokens
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::UserSessionToken](../modules/Conch::DB::Result::UserSessionToken)
+Related object: [Conch::DB::Result::UserSessionToken](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AUserSessionToken)
 
 ## user\_settings
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::UserSetting](../modules/Conch::DB::Result::UserSetting)
+Related object: [Conch::DB::Result::UserSetting](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AUserSetting)
 
 ## user\_workspace\_roles
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::UserWorkspaceRole](../modules/Conch::DB::Result::UserWorkspaceRole)
+Related object: [Conch::DB::Result::UserWorkspaceRole](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AUserWorkspaceRole)
 
 ## builds
 

--- a/docs/modules/Conch::DB::Result::UserBuildRole.md
+++ b/docs/modules/Conch::DB::Result::UserBuildRole.md
@@ -2,7 +2,7 @@
 
 Conch::DB::Result::UserBuildRole
 
-# BASE CLASS: [Conch::DB::Result](../modules/Conch::DB::Result)
+# BASE CLASS: [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult)
 
 # TABLE: `user_build_role`
 
@@ -46,13 +46,13 @@ is_nullable: 0
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::Build](../modules/Conch::DB::Result::Build)
+Related object: [Conch::DB::Result::Build](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ABuild)
 
 ## user\_account
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::UserAccount](../modules/Conch::DB::Result::UserAccount)
+Related object: [Conch::DB::Result::UserAccount](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AUserAccount)
 
 # LICENSING
 

--- a/docs/modules/Conch::DB::Result::UserOrganizationRole.md
+++ b/docs/modules/Conch::DB::Result::UserOrganizationRole.md
@@ -2,7 +2,7 @@
 
 Conch::DB::Result::UserOrganizationRole
 
-# BASE CLASS: [Conch::DB::Result](../modules/Conch::DB::Result)
+# BASE CLASS: [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult)
 
 # TABLE: `user_organization_role`
 
@@ -46,13 +46,13 @@ is_nullable: 0
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::Organization](../modules/Conch::DB::Result::Organization)
+Related object: [Conch::DB::Result::Organization](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AOrganization)
 
 ## user\_account
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::UserAccount](../modules/Conch::DB::Result::UserAccount)
+Related object: [Conch::DB::Result::UserAccount](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AUserAccount)
 
 # LICENSING
 

--- a/docs/modules/Conch::DB::Result::UserRelayConnection.md
+++ b/docs/modules/Conch::DB::Result::UserRelayConnection.md
@@ -2,7 +2,7 @@
 
 Conch::DB::Result::UserRelayConnection
 
-# BASE CLASS: [Conch::DB::Result](../modules/Conch::DB::Result)
+# BASE CLASS: [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult)
 
 # TABLE: `user_relay_connection`
 
@@ -55,13 +55,13 @@ size: 16
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::Relay](../modules/Conch::DB::Result::Relay)
+Related object: [Conch::DB::Result::Relay](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ARelay)
 
 ## user\_account
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::UserAccount](../modules/Conch::DB::Result::UserAccount)
+Related object: [Conch::DB::Result::UserAccount](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AUserAccount)
 
 # LICENSING
 

--- a/docs/modules/Conch::DB::Result::UserSessionToken.md
+++ b/docs/modules/Conch::DB::Result::UserSessionToken.md
@@ -2,7 +2,7 @@
 
 Conch::DB::Result::UserSessionToken
 
-# BASE CLASS: [Conch::DB::Result](../modules/Conch::DB::Result)
+# BASE CLASS: [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult)
 
 # TABLE: `user_session_token`
 
@@ -73,7 +73,7 @@ size: 16
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::UserAccount](../modules/Conch::DB::Result::UserAccount)
+Related object: [Conch::DB::Result::UserAccount](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AUserAccount)
 
 # METHODS
 

--- a/docs/modules/Conch::DB::Result::UserSetting.md
+++ b/docs/modules/Conch::DB::Result::UserSetting.md
@@ -2,7 +2,7 @@
 
 Conch::DB::Result::UserSetting
 
-# BASE CLASS: [Conch::DB::Result](../modules/Conch::DB::Result)
+# BASE CLASS: [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult)
 
 # TABLE: `user_setting`
 
@@ -66,7 +66,7 @@ is_nullable: 1
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::UserAccount](../modules/Conch::DB::Result::UserAccount)
+Related object: [Conch::DB::Result::UserAccount](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AUserAccount)
 
 # LICENSING
 

--- a/docs/modules/Conch::DB::Result::UserWorkspaceRole.md
+++ b/docs/modules/Conch::DB::Result::UserWorkspaceRole.md
@@ -2,7 +2,7 @@
 
 Conch::DB::Result::UserWorkspaceRole
 
-# BASE CLASS: [Conch::DB::Result](../modules/Conch::DB::Result)
+# BASE CLASS: [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult)
 
 # TABLE: `user_workspace_role`
 
@@ -46,13 +46,13 @@ is_nullable: 0
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::UserAccount](../modules/Conch::DB::Result::UserAccount)
+Related object: [Conch::DB::Result::UserAccount](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AUserAccount)
 
 ## workspace
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::Workspace](../modules/Conch::DB::Result::Workspace)
+Related object: [Conch::DB::Result::Workspace](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AWorkspace)
 
 # LICENSING
 

--- a/docs/modules/Conch::DB::Result::Validation.md
+++ b/docs/modules/Conch::DB::Result::Validation.md
@@ -2,7 +2,7 @@
 
 Conch::DB::Result::Validation
 
-# BASE CLASS: [Conch::DB::Result](../modules/Conch::DB::Result)
+# BASE CLASS: [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult)
 
 # TABLE: `validation`
 
@@ -87,13 +87,13 @@ is_nullable: 1
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::ValidationPlanMember](../modules/Conch::DB::Result::ValidationPlanMember)
+Related object: [Conch::DB::Result::ValidationPlanMember](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AValidationPlanMember)
 
 ## validation\_results
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::ValidationResult](../modules/Conch::DB::Result::ValidationResult)
+Related object: [Conch::DB::Result::ValidationResult](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AValidationResult)
 
 ## validation\_plans
 

--- a/docs/modules/Conch::DB::Result::ValidationPlan.md
+++ b/docs/modules/Conch::DB::Result::ValidationPlan.md
@@ -2,7 +2,7 @@
 
 Conch::DB::Result::ValidationPlan
 
-# BASE CLASS: [Conch::DB::Result](../modules/Conch::DB::Result)
+# BASE CLASS: [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult)
 
 # TABLE: `validation_plan`
 
@@ -57,19 +57,19 @@ is_nullable: 1
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::HardwareProduct](../modules/Conch::DB::Result::HardwareProduct)
+Related object: [Conch::DB::Result::HardwareProduct](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AHardwareProduct)
 
 ## validation\_plan\_members
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::ValidationPlanMember](../modules/Conch::DB::Result::ValidationPlanMember)
+Related object: [Conch::DB::Result::ValidationPlanMember](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AValidationPlanMember)
 
 ## validation\_states
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::ValidationState](../modules/Conch::DB::Result::ValidationState)
+Related object: [Conch::DB::Result::ValidationState](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AValidationState)
 
 ## validations
 

--- a/docs/modules/Conch::DB::Result::ValidationPlanMember.md
+++ b/docs/modules/Conch::DB::Result::ValidationPlanMember.md
@@ -2,7 +2,7 @@
 
 Conch::DB::Result::ValidationPlanMember
 
-# BASE CLASS: [Conch::DB::Result](../modules/Conch::DB::Result)
+# BASE CLASS: [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult)
 
 # TABLE: `validation_plan_member`
 
@@ -37,13 +37,13 @@ size: 16
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::Validation](../modules/Conch::DB::Result::Validation)
+Related object: [Conch::DB::Result::Validation](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AValidation)
 
 ## validation\_plan
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::ValidationPlan](../modules/Conch::DB::Result::ValidationPlan)
+Related object: [Conch::DB::Result::ValidationPlan](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AValidationPlan)
 
 # LICENSING
 

--- a/docs/modules/Conch::DB::Result::ValidationResult.md
+++ b/docs/modules/Conch::DB::Result::ValidationResult.md
@@ -2,7 +2,7 @@
 
 Conch::DB::Result::ValidationResult
 
-# BASE CLASS: [Conch::DB::Result](../modules/Conch::DB::Result)
+# BASE CLASS: [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult)
 
 # TABLE: `validation_result`
 
@@ -99,25 +99,25 @@ size: 16
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::Device](../modules/Conch::DB::Result::Device)
+Related object: [Conch::DB::Result::Device](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ADevice)
 
 ## hardware\_product
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::HardwareProduct](../modules/Conch::DB::Result::HardwareProduct)
+Related object: [Conch::DB::Result::HardwareProduct](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AHardwareProduct)
 
 ## validation
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::Validation](../modules/Conch::DB::Result::Validation)
+Related object: [Conch::DB::Result::Validation](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AValidation)
 
 ## validation\_state\_members
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::ValidationStateMember](../modules/Conch::DB::Result::ValidationStateMember)
+Related object: [Conch::DB::Result::ValidationStateMember](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AValidationStateMember)
 
 ## validation\_states
 

--- a/docs/modules/Conch::DB::Result::ValidationState.md
+++ b/docs/modules/Conch::DB::Result::ValidationState.md
@@ -2,7 +2,7 @@
 
 Conch::DB::Result::ValidationState
 
-# BASE CLASS: [Conch::DB::Result](../modules/Conch::DB::Result)
+# BASE CLASS: [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult)
 
 # TABLE: `validation_state`
 
@@ -78,25 +78,25 @@ size: 16
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::Device](../modules/Conch::DB::Result::Device)
+Related object: [Conch::DB::Result::Device](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ADevice)
 
 ## device\_report
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::DeviceReport](../modules/Conch::DB::Result::DeviceReport)
+Related object: [Conch::DB::Result::DeviceReport](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ADeviceReport)
 
 ## validation\_plan
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::ValidationPlan](../modules/Conch::DB::Result::ValidationPlan)
+Related object: [Conch::DB::Result::ValidationPlan](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AValidationPlan)
 
 ## validation\_state\_members
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::ValidationStateMember](../modules/Conch::DB::Result::ValidationStateMember)
+Related object: [Conch::DB::Result::ValidationStateMember](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AValidationStateMember)
 
 ## validation\_results
 

--- a/docs/modules/Conch::DB::Result::ValidationStateMember.md
+++ b/docs/modules/Conch::DB::Result::ValidationStateMember.md
@@ -2,7 +2,7 @@
 
 Conch::DB::Result::ValidationStateMember
 
-# BASE CLASS: [Conch::DB::Result](../modules/Conch::DB::Result)
+# BASE CLASS: [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult)
 
 # TABLE: `validation_state_member`
 
@@ -44,13 +44,13 @@ is_nullable: 0
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::ValidationResult](../modules/Conch::DB::Result::ValidationResult)
+Related object: [Conch::DB::Result::ValidationResult](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AValidationResult)
 
 ## validation\_state
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::ValidationState](../modules/Conch::DB::Result::ValidationState)
+Related object: [Conch::DB::Result::ValidationState](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AValidationState)
 
 # LICENSING
 

--- a/docs/modules/Conch::DB::Result::Workspace.md
+++ b/docs/modules/Conch::DB::Result::Workspace.md
@@ -2,7 +2,7 @@
 
 Conch::DB::Result::Workspace
 
-# BASE CLASS: [Conch::DB::Result](../modules/Conch::DB::Result)
+# BASE CLASS: [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult)
 
 # TABLE: `workspace`
 
@@ -56,31 +56,31 @@ size: 16
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::OrganizationWorkspaceRole](../modules/Conch::DB::Result::OrganizationWorkspaceRole)
+Related object: [Conch::DB::Result::OrganizationWorkspaceRole](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AOrganizationWorkspaceRole)
 
 ## parent\_workspace
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::Workspace](../modules/Conch::DB::Result::Workspace)
+Related object: [Conch::DB::Result::Workspace](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AWorkspace)
 
 ## user\_workspace\_roles
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::UserWorkspaceRole](../modules/Conch::DB::Result::UserWorkspaceRole)
+Related object: [Conch::DB::Result::UserWorkspaceRole](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AUserWorkspaceRole)
 
 ## workspace\_racks
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::WorkspaceRack](../modules/Conch::DB::Result::WorkspaceRack)
+Related object: [Conch::DB::Result::WorkspaceRack](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AWorkspaceRack)
 
 ## workspaces
 
 Type: has\_many
 
-Related object: [Conch::DB::Result::Workspace](../modules/Conch::DB::Result::Workspace)
+Related object: [Conch::DB::Result::Workspace](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AWorkspace)
 
 ## organizations
 

--- a/docs/modules/Conch::DB::Result::WorkspaceRack.md
+++ b/docs/modules/Conch::DB::Result::WorkspaceRack.md
@@ -2,7 +2,7 @@
 
 Conch::DB::Result::WorkspaceRack
 
-# BASE CLASS: [Conch::DB::Result](../modules/Conch::DB::Result)
+# BASE CLASS: [Conch::DB::Result](../modules/Conch%3A%3ADB%3A%3AResult)
 
 # TABLE: `workspace_rack`
 
@@ -37,13 +37,13 @@ size: 16
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::Rack](../modules/Conch::DB::Result::Rack)
+Related object: [Conch::DB::Result::Rack](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ARack)
 
 ## workspace
 
 Type: belongs\_to
 
-Related object: [Conch::DB::Result::Workspace](../modules/Conch::DB::Result::Workspace)
+Related object: [Conch::DB::Result::Workspace](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AWorkspace)
 
 # LICENSING
 

--- a/docs/modules/Conch::DB::ResultSet.md
+++ b/docs/modules/Conch::DB::ResultSet.md
@@ -5,35 +5,35 @@ Conch::DB::ResultSet
 # DESCRIPTION
 
 Base class for our resultsets, to allow us to add on additional functionality from what is
-available in core [DBIx::Class](https://metacpan.org/pod/DBIx::Class).
+available in core [DBIx::Class](https://metacpan.org/pod/DBIx%3A%3AClass).
 
 # METHODS
 
 Methods added are:
 
-- [active](../modules/Conch::DB::Helper::ResultSet::Deactivatable#active)
-- [add\_columns](https://metacpan.org/pod/DBIx::Class::Helper::ResultSet::Shortcut#add_columns)
-- [as\_epoch](../modules/Conch::DB::Helper::ResultSet::AsEpoch#as_epoch)
-- [columns](https://metacpan.org/pod/DBIx::Class::Helper::ResultSet::Shortcut#columns)
-- [correlate](https://metacpan.org/pod/DBIx::Class::Helper::ResultSet::CorrelateRelationship#correlate)
-- [deactivate](../modules/Conch::DB::Helper::ResultSet::Deactivatable#deactivate)
-- [distinct](https://metacpan.org/pod/DBIx::Class::Helper::ResultSet::Shortcut#distinct)
-- [except](https://metacpan.org/pod/DBIx::Class::Helper::ResultSet::SetOperations#except)
-- [except\_all](https://metacpan.org/pod/DBIx::Class::Helper::ResultSet::SetOperations#except_all)
-- [exists](../modules/Conch::DB::Helper::ResultSet::ResultsExist#exists)
-- [group\_by](https://metacpan.org/pod/DBIx::Class::Helper::ResultSet::Shortcut#group_by)
-- [hri](https://metacpan.org/pod/DBIx::Class::Helper::ResultSet::Shortcut#hri)
-- [intersect](https://metacpan.org/pod/DBIx::Class::Helper::ResultSet::SetOperations#intersect)
-- [intersect\_all](https://metacpan.org/pod/DBIx::Class::Helper::ResultSet::SetOperations#intersect_all)
-- [one\_row](https://metacpan.org/pod/DBIx::Class::Helper::ResultSet::OneRow#one_row)
-- [order\_by](https://metacpan.org/pod/DBIx::Class::Helper::ResultSet::Shortcut#order_by)
-- [page](https://metacpan.org/pod/DBIx::Class::Helper::ResultSet::Shortcut#page)
-- [prefetch](https://metacpan.org/pod/DBIx::Class::Helper::ResultSet::Shortcut#prefetch)
-- [remove\_columns](https://metacpan.org/pod/DBIx::Class::Helper::ResultSet::RemoveColumns#remove_columns)
-- [rows](https://metacpan.org/pod/DBIx::Class::Helper::ResultSet::Shortcut#rows)
-- [union](https://metacpan.org/pod/DBIx::Class::Helper::ResultSet::SetOperations#union)
-- [union\_all](https://metacpan.org/pod/DBIx::Class::Helper::ResultSet::SetOperations#union_all)
-- [with\_role](../modules/Conch::DB::Helper::ResultSet::WithRole#with_role)
+- [active](../modules/Conch%3A%3ADB%3A%3AHelper%3A%3AResultSet%3A%3ADeactivatable#active)
+- [add\_columns](https://metacpan.org/pod/DBIx%3A%3AClass%3A%3AHelper%3A%3AResultSet%3A%3AShortcut#add_columns)
+- [as\_epoch](../modules/Conch%3A%3ADB%3A%3AHelper%3A%3AResultSet%3A%3AAsEpoch#as_epoch)
+- [columns](https://metacpan.org/pod/DBIx%3A%3AClass%3A%3AHelper%3A%3AResultSet%3A%3AShortcut#columns)
+- [correlate](https://metacpan.org/pod/DBIx%3A%3AClass%3A%3AHelper%3A%3AResultSet%3A%3ACorrelateRelationship#correlate)
+- [deactivate](../modules/Conch%3A%3ADB%3A%3AHelper%3A%3AResultSet%3A%3ADeactivatable#deactivate)
+- [distinct](https://metacpan.org/pod/DBIx%3A%3AClass%3A%3AHelper%3A%3AResultSet%3A%3AShortcut#distinct)
+- [except](https://metacpan.org/pod/DBIx%3A%3AClass%3A%3AHelper%3A%3AResultSet%3A%3ASetOperations#except)
+- [except\_all](https://metacpan.org/pod/DBIx%3A%3AClass%3A%3AHelper%3A%3AResultSet%3A%3ASetOperations#except_all)
+- [exists](../modules/Conch%3A%3ADB%3A%3AHelper%3A%3AResultSet%3A%3AResultsExist#exists)
+- [group\_by](https://metacpan.org/pod/DBIx%3A%3AClass%3A%3AHelper%3A%3AResultSet%3A%3AShortcut#group_by)
+- [hri](https://metacpan.org/pod/DBIx%3A%3AClass%3A%3AHelper%3A%3AResultSet%3A%3AShortcut#hri)
+- [intersect](https://metacpan.org/pod/DBIx%3A%3AClass%3A%3AHelper%3A%3AResultSet%3A%3ASetOperations#intersect)
+- [intersect\_all](https://metacpan.org/pod/DBIx%3A%3AClass%3A%3AHelper%3A%3AResultSet%3A%3ASetOperations#intersect_all)
+- [one\_row](https://metacpan.org/pod/DBIx%3A%3AClass%3A%3AHelper%3A%3AResultSet%3A%3AOneRow#one_row)
+- [order\_by](https://metacpan.org/pod/DBIx%3A%3AClass%3A%3AHelper%3A%3AResultSet%3A%3AShortcut#order_by)
+- [page](https://metacpan.org/pod/DBIx%3A%3AClass%3A%3AHelper%3A%3AResultSet%3A%3AShortcut#page)
+- [prefetch](https://metacpan.org/pod/DBIx%3A%3AClass%3A%3AHelper%3A%3AResultSet%3A%3AShortcut#prefetch)
+- [remove\_columns](https://metacpan.org/pod/DBIx%3A%3AClass%3A%3AHelper%3A%3AResultSet%3A%3ARemoveColumns#remove_columns)
+- [rows](https://metacpan.org/pod/DBIx%3A%3AClass%3A%3AHelper%3A%3AResultSet%3A%3AShortcut#rows)
+- [union](https://metacpan.org/pod/DBIx%3A%3AClass%3A%3AHelper%3A%3AResultSet%3A%3ASetOperations#union)
+- [union\_all](https://metacpan.org/pod/DBIx%3A%3AClass%3A%3AHelper%3A%3AResultSet%3A%3ASetOperations#union_all)
+- [with\_role](../modules/Conch%3A%3ADB%3A%3AHelper%3A%3AResultSet%3A%3AWithRole#with_role)
 
 # LICENSING
 

--- a/docs/modules/Conch::DB::ResultSet.md
+++ b/docs/modules/Conch::DB::ResultSet.md
@@ -29,11 +29,16 @@ Methods added are:
 - [order\_by](https://metacpan.org/pod/DBIx%3A%3AClass%3A%3AHelper%3A%3AResultSet%3A%3AShortcut#order_by)
 - [page](https://metacpan.org/pod/DBIx%3A%3AClass%3A%3AHelper%3A%3AResultSet%3A%3AShortcut#page)
 - [prefetch](https://metacpan.org/pod/DBIx%3A%3AClass%3A%3AHelper%3A%3AResultSet%3A%3AShortcut#prefetch)
-- [remove\_columns](https://metacpan.org/pod/DBIx%3A%3AClass%3A%3AHelper%3A%3AResultSet%3A%3ARemoveColumns#remove_columns)
 - [rows](https://metacpan.org/pod/DBIx%3A%3AClass%3A%3AHelper%3A%3AResultSet%3A%3AShortcut#rows)
 - [union](https://metacpan.org/pod/DBIx%3A%3AClass%3A%3AHelper%3A%3AResultSet%3A%3ASetOperations#union)
 - [union\_all](https://metacpan.org/pod/DBIx%3A%3AClass%3A%3AHelper%3A%3AResultSet%3A%3ASetOperations#union_all)
 - [with\_role](../modules/Conch%3A%3ADB%3A%3AHelper%3A%3AResultSet%3A%3AWithRole#with_role)
+
+# ATTRIBUTES
+
+Resultset attributes added are:
+
+- [remove\_columns](https://metacpan.org/pod/DBIx%3A%3AClass%3A%3AHelper%3A%3AResultSet%3A%3ARemoveColumns#remove_columns)
 
 # LICENSING
 

--- a/docs/modules/Conch::DB::ResultSet::Device.md
+++ b/docs/modules/Conch::DB::ResultSet::Device.md
@@ -11,8 +11,9 @@ Interface to queries involving devices.
 ## with\_user\_role
 
 Constrains the resultset to those where the provided user\_id has (at least) the specified role
-in at least one workspace or build associated with the specified device(s), including parent
-workspaces.
+in at least one workspace or build associated with the specified device(s) (also taking into
+consideration the rack location of the device(s) if its phase is early enough), including
+parent workspaces.
 
 This is a nested query which searches all workspaces and builds in the database, so only use
 this query when its impact is outweighed by the impact of filtering a large resultset of

--- a/docs/modules/Conch::DB::ResultSet::Rack.md
+++ b/docs/modules/Conch::DB::ResultSet::Rack.md
@@ -20,7 +20,8 @@ This is used for identifying potential conflicts when adjusting layouts.
 ## user\_has\_role
 
 Checks that the provided user\_id has (at least) the specified role in at least one workspace
-associated with the specified rack(s) (implicitly including parent workspaces).
+associated with the specified rack(s) (implicitly including parent workspaces), or at least one
+build associated with the rack(s).
 
 Returns a boolean.
 

--- a/docs/modules/Conch::DB::Util.md
+++ b/docs/modules/Conch::DB::Util.md
@@ -6,7 +6,7 @@ Conch::DB:::Util - utility functions for working with the Conch database
 
 ## get\_credentials
 
-Return the credentials and connection options suitable for passing to [Conch::DB](../modules/Conch::DB) for both
+Return the credentials and connection options suitable for passing to [Conch::DB](../modules/Conch%3A%3ADB) for both
 read-write and read-only connections, containing keys:
 
 returns a hashref containing keys:
@@ -33,7 +33,7 @@ If not all credentials can be determined from environment variables, the `$confi
 from. It should be a database configuration hashref (such as that extracted from `conch.conf`
 at the appropriate hash key).
 
-See ["connect" in DBI](https://metacpan.org/pod/DBI#connect) and ["connect" in DBD::Pg](https://metacpan.org/pod/DBD::Pg#connect) for the correct syntax for these values.
+See ["connect" in DBI](https://metacpan.org/pod/DBI#connect) and ["connect" in DBD::Pg](https://metacpan.org/pod/DBD%3A%3APg#connect) for the correct syntax for these values.
 
 ## get\_postgres\_version
 

--- a/docs/modules/Conch::Log.md
+++ b/docs/modules/Conch::Log.md
@@ -16,7 +16,7 @@ $log->info({ raw_data => [1,2,3] });
 
 # ATTRIBUTES
 
-[Conch::Log](../modules/Conch::Log) inherits all attributes from [Mojo::Log](https://metacpan.org/pod/Mojo::Log) and implements the
+[Conch::Log](../modules/Conch%3A%3ALog) inherits all attributes from [Mojo::Log](https://metacpan.org/pod/Mojo%3A%3ALog) and implements the
 following new ones:
 
 ## bunyan
@@ -35,7 +35,7 @@ A boolean option (defaulting to false): include stack trace information. Must be
 
 # METHODS
 
-[Conch::Log](../modules/Conch::Log) inherits all methods from [Mojo::Log](https://metacpan.org/pod/Mojo::Log).
+[Conch::Log](../modules/Conch%3A%3ALog) inherits all methods from [Mojo::Log](https://metacpan.org/pod/Mojo%3A%3ALog).
 
 # SEE ALSO
 

--- a/docs/modules/Conch::Plugin::Database.md
+++ b/docs/modules/Conch::Plugin::Database.md
@@ -13,7 +13,7 @@ and therefore other helpers).
 
 ## schema
 
-Provides read/write access to the database via [DBIx::Class](https://metacpan.org/pod/DBIx::Class). Returns a [Conch::DB](../modules/Conch::DB) object
+Provides read/write access to the database via [DBIx::Class](https://metacpan.org/pod/DBIx%3A%3AClass). Returns a [Conch::DB](../modules/Conch%3A%3ADB) object
 that persists for the lifetime of the application.
 
 ## rw\_schema
@@ -22,18 +22,18 @@ See ["schema"](#schema); can be used interchangeably with it.
 
 ## ro\_schema
 
-Provides (guaranteed) read-only access to the database via [DBIx::Class](https://metacpan.org/pod/DBIx::Class). Returns a
-[Conch::DB](../modules/Conch::DB) object that persists for the lifetime of the application.
+Provides (guaranteed) read-only access to the database via [DBIx::Class](https://metacpan.org/pod/DBIx%3A%3AClass). Returns a
+[Conch::DB](../modules/Conch%3A%3ADB) object that persists for the lifetime of the application.
 
 Note that because of the use of `AutoCommit => 0`, database errors must be explicitly
-cleared with `->txn_rollback`; see ["ReadOnly-(boolean)" in DBD::Pg](https://metacpan.org/pod/DBD::Pg#ReadOnly--boolean).
+cleared with `->txn_rollback`; see ["ReadOnly-(boolean)" in DBD::Pg](https://metacpan.org/pod/DBD%3A%3APg#ReadOnly--boolean).
 
-See also: ["DBIx::Class and AutoCommit" in DBIx::Class::Storage::DBI](https://metacpan.org/pod/DBIx::Class::Storage::DBI#DBIx::Class-and-AutoCommit).
+See also: ["DBIx::Class and AutoCommit" in DBIx::Class::Storage::DBI](https://metacpan.org/pod/DBIx%3A%3AClass%3A%3AStorage%3A%3ADBI#DBIx::Class-and-AutoCommit).
 
 ## db\_&lt;table>s, db\_ro\_&lt;table>s
 
 Provides direct read/write and read-only accessors to resultsets. The table name is used in
-the `alias` attribute (see ["alias" in DBIx::Class::ResultSet](https://metacpan.org/pod/DBIx::Class::ResultSet#alias)).
+the `alias` attribute (see ["alias" in DBIx::Class::ResultSet](https://metacpan.org/pod/DBIx%3A%3AClass%3A%3AResultSet#alias)).
 
 ## txn\_wrapper
 

--- a/docs/modules/Conch::Plugin::JsonValidator.md
+++ b/docs/modules/Conch::Plugin::JsonValidator.md
@@ -49,7 +49,7 @@ using the RequestValidationError json response schema.
 
 ## get\_query\_params\_validator
 
-Returns a [JSON::Validator](https://metacpan.org/pod/JSON::Validator) object suitable for validating an endpoint's query parameters
+Returns a [JSON::Validator](https://metacpan.org/pod/JSON%3A%3AValidator) object suitable for validating an endpoint's query parameters
 (when transformed into a hashref: see ["validate\_query\_params"](#validate_query_params)).
 
 Strings that look like numbers are converted into numbers, so strict 'integer' and 'number'
@@ -58,11 +58,11 @@ typing is possible. No default population is done yet though; see
 
 ## get\_request\_validator
 
-Returns a [JSON::Validator](https://metacpan.org/pod/JSON::Validator) object suitable for validating an endpoint's json request payload.
+Returns a [JSON::Validator](https://metacpan.org/pod/JSON%3A%3AValidator) object suitable for validating an endpoint's json request payload.
 
 ## get\_response\_validator
 
-Returns a [JSON::Validator](https://metacpan.org/pod/JSON::Validator) object suitable for validating an endpoint's json response payload.
+Returns a [JSON::Validator](https://metacpan.org/pod/JSON%3A%3AValidator) object suitable for validating an endpoint's json response payload.
 
 # LICENSING
 

--- a/docs/modules/Conch::Plugin::Mail.md
+++ b/docs/modules/Conch::Plugin::Mail.md
@@ -31,7 +31,7 @@ $c->send_mail(
 
 ## construct\_address\_list
 
-Given a list of [user](../modules/Conch::DB::Result::UserAccount) records, returns a string suitable to be
+Given a list of [user](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AUserAccount) records, returns a string suitable to be
 used in a `To` header, comprising names and email addresses.
 
 # LICENSING

--- a/docs/modules/Conch::Plugin::Rollbar.md
+++ b/docs/modules/Conch::Plugin::Rollbar.md
@@ -19,7 +19,7 @@ Sends exceptions to Rollbar.
 ## dispatch\_message\_payload
 
 Listens to the `dispatch_message_payload` event (which is sent by the dispatch logger in
-[Conch::Plugin::Logging](../modules/Conch::Plugin::Logging)). When an error response is generated (any 4xx response code other
+[Conch::Plugin::Logging](../modules/Conch%3A%3APlugin%3A%3ALogging)). When an error response is generated (any 4xx response code other
 than 401, 403 or 404), and a request header matches a key in the `rollbar` config
 `error_match_header`, and the header value matches the corresponding regular expression, a
 message is sent to Rollbar.

--- a/docs/modules/Conch::Route.md
+++ b/docs/modules/Conch::Route.md
@@ -59,47 +59,47 @@ Error responses will use:
 
 ### `* /dc`, `* /room`, `* /rack_role`, `* /rack`, `* /layout`
 
-See ["routes" in Conch::Route::Datacenter](../modules/Conch::Route::Datacenter#routes)
+See ["routes" in Conch::Route::Datacenter](../modules/Conch%3A%3ARoute%3A%3ADatacenter#routes)
 
 ### `* /device`
 
-See ["routes" in Conch::Route::Device](../modules/Conch::Route::Device#routes)
+See ["routes" in Conch::Route::Device](../modules/Conch%3A%3ARoute%3A%3ADevice#routes)
 
 ### `* /device_report`
 
-See ["routes" in Conch::Route::DeviceReport](../modules/Conch::Route::DeviceReport#routes)
+See ["routes" in Conch::Route::DeviceReport](../modules/Conch%3A%3ARoute%3A%3ADeviceReport#routes)
 
 ### `* /hardware_product`
 
-See ["routes" in Conch::Route::HardwareProduct](../modules/Conch::Route::HardwareProduct#routes)
+See ["routes" in Conch::Route::HardwareProduct](../modules/Conch%3A%3ARoute%3A%3AHardwareProduct#routes)
 
 ### `* /hardware_vendor`
 
-See ["routes" in Conch::Route::HardwareVendor](../modules/Conch::Route::HardwareVendor#routes)
+See ["routes" in Conch::Route::HardwareVendor](../modules/Conch%3A%3ARoute%3A%3AHardwareVendor#routes)
 
 ### `* /organization`
 
-See ["routes" in Conch::Route::Organization](../modules/Conch::Route::Organization#routes)
+See ["routes" in Conch::Route::Organization](../modules/Conch%3A%3ARoute%3A%3AOrganization#routes)
 
 ### `* /relay`
 
-See ["routes" in Conch::Route::Relay](../modules/Conch::Route::Relay#routes)
+See ["routes" in Conch::Route::Relay](../modules/Conch%3A%3ARoute%3A%3ARelay#routes)
 
 ### `* /schema`
 
-See ["routes" in Conch::Route::Schema](../modules/Conch::Route::Schema#routes)
+See ["routes" in Conch::Route::Schema](../modules/Conch%3A%3ARoute%3A%3ASchema#routes)
 
 ### `* /user`
 
-See ["routes" in Conch::Route::User](../modules/Conch::Route::User#routes)
+See ["routes" in Conch::Route::User](../modules/Conch%3A%3ARoute%3A%3AUser#routes)
 
 ### `* /validation`, `* /validation_plan`, `* /validation_state`
 
-See ["routes" in Conch::Route::Validation](../modules/Conch::Route::Validation#routes)
+See ["routes" in Conch::Route::Validation](../modules/Conch%3A%3ARoute%3A%3AValidation#routes)
 
 ### `* /workspace`
 
-See ["routes" in Conch::Route::Workspace](../modules/Conch::Route::Workspace#routes)
+See ["routes" in Conch::Route::Workspace](../modules/Conch%3A%3ARoute%3A%3AWorkspace#routes)
 
 # LICENSING
 

--- a/docs/modules/Conch::Route.md
+++ b/docs/modules/Conch::Route.md
@@ -14,7 +14,8 @@ Set up the full route structure
 
 Unless otherwise specified, all routes require authentication.
 
-Full access is granted to system admin users, regardless of workspace or other role entries.
+Full access is granted to system admin users, regardless of workspace, build or other role
+entries.
 
 Successful (http 2xx code) response structures are as described for each endpoint.
 

--- a/docs/modules/Conch::Route::Build.md
+++ b/docs/modules/Conch::Route::Build.md
@@ -103,7 +103,7 @@ read-only role on the device.
 ### `POST /build/:build_id_or_name/device/:device_id_or_serial_number`
 
 - Requires system admin authorization, or the read/write role on the build and the
-read-only role on the device (via a workspace or a relay registration, see
+read-only role on the device (via a workspace or build or a relay registration, see
 ["routes" in Conch::Route::Device](../modules/Conch%3A%3ARoute%3A%3ADevice#routes))
 - Response: `204 NO CONTENT`
 
@@ -120,7 +120,7 @@ read-only role on the device (via a workspace or a relay registration, see
 ### `POST /build/:build_id_or_name/rack/:rack_id`
 
 - Requires system admin authorization, or the read/write role on the build and the
-read-only role on a workspace that contains the rack
+read-only role on a workspace or build that contains the rack
 - Response: `204 NO CONTENT`
 
 ### `DELETE /build/:build_id_or_name/rack/:rack_id`

--- a/docs/modules/Conch::Route::Build.md
+++ b/docs/modules/Conch::Route::Build.md
@@ -104,7 +104,7 @@ read-only role on the device.
 
 - Requires system admin authorization, or the read/write role on the build and the
 read-only role on the device (via a workspace or a relay registration, see
-["routes" in Conch::Route::Device](../modules/Conch::Route::Device#routes))
+["routes" in Conch::Route::Device](../modules/Conch%3A%3ARoute%3A%3ADevice#routes))
 - Response: `204 NO CONTENT`
 
 ### `DELETE /build/:build_id_or_name/device/:device_id_or_serial_number`

--- a/docs/modules/Conch::Route::Device.md
+++ b/docs/modules/Conch::Route::Device.md
@@ -10,9 +10,11 @@ Sets up the routes for /device:
 
 Unless otherwise noted, all routes require authentication.
 
-The user's role (required for most endpoints) is determined by the rack location of the device,
-and the workspace(s) the rack is contained in (where users are assigned a
-[role](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AUserWorkspaceRole#role) in that workspace).
+The user's role (required for most endpoints) is determined by the build the device is
+contained in (where users are assigned a [role](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AUserBuildRole#role) in that
+build), and the rack location of the device and the workspace(s) or build the rack is contained
+in (where users are assigned a [role](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AUserBuildRole#role) in that build and
+a [role](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AUserWorkspaceRole#role) in that workspace).
 
 Full (admin-level) access is also granted to a device if a report was sent for that device
 using a relay that registered with that user's credentials.

--- a/docs/modules/Conch::Route::Device.md
+++ b/docs/modules/Conch::Route::Device.md
@@ -12,7 +12,7 @@ Unless otherwise noted, all routes require authentication.
 
 The user's role (required for most endpoints) is determined by the rack location of the device,
 and the workspace(s) the rack is contained in (where users are assigned a
-[role](../modules/Conch::DB::Result::UserWorkspaceRole#role) in that workspace).
+[role](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AUserWorkspaceRole#role) in that workspace).
 
 Full (admin-level) access is also granted to a device if a report was sent for that device
 using a relay that registered with that user's credentials.

--- a/docs/modules/Conch::Route::DeviceReport.md
+++ b/docs/modules/Conch::Route::DeviceReport.md
@@ -17,7 +17,7 @@ Unless otherwise noted, all routes require authentication.
 
 ### `GET /device_report/:device_report_id`
 
-- User requires the read-only role, as described in ["routes" in Conch::Route::Device](../modules/Conch::Route::Device#routes).
+- User requires the read-only role, as described in ["routes" in Conch::Route::Device](../modules/Conch%3A%3ARoute%3A%3ADevice#routes).
 - Response: [response.json#/definitions/DeviceReportRow](../json-schema/response.json#/definitions/DeviceReportRow)
 
 # LICENSING

--- a/docs/modules/Conch::Route::User.md
+++ b/docs/modules/Conch::Route::User.md
@@ -99,7 +99,8 @@ an email telling the user their tokens were revoked
 
 ### `DELETE /user/:target_user_id_or_email?clear_tokens=<1|0>`
 
-When a user is deleted, all workspace role entries are removed and are unrecoverable.
+When a user is deleted, all role entries (workspace, build, organization) are removed and are
+unrecoverable.
 
 Optionally takes a query parameter `clear_tokens` (defaults to `1`), to also
 revoke all session tokens for the user forcing all tools to log in again.

--- a/docs/modules/Conch::Route::Workspace.md
+++ b/docs/modules/Conch::Route::Workspace.md
@@ -14,7 +14,7 @@ populated, as well as `workspace_name` if the identifier was not a UUID.
 Unless otherwise noted, all routes require authentication.
 
 Users will require access to the workspace (or one of its ancestors) at a minimum
-[role](../modules/Conch::DB::Result::UserWorkspaceRole#role), as indicated.
+[role](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AUserWorkspaceRole#role), as indicated.
 
 ### `GET /workspace`
 

--- a/docs/modules/Conch::Time.md
+++ b/docs/modules/Conch::Time.md
@@ -23,7 +23,7 @@ Overloads the constructor to use `->from_string` when a single argument is passe
 Conch::Time->new($pg_timestamptz);
 ```
 
-..and all other constructor modes supported by [Time::Moment](https://metacpan.org/pod/Time::Moment).
+..and all other constructor modes supported by [Time::Moment](https://metacpan.org/pod/Time%3A%3AMoment).
 
 ## now
 
@@ -46,7 +46,7 @@ Conch::Time->from_epoch(Time::HiRes::gettimeofday);
 Conch::Time->from_epoch(1234567890, 123);
 ```
 
-See ["from\_epoch" in Time::Moment](https://metacpan.org/pod/Time::Moment#from_epoch).
+See ["from\_epoch" in Time::Moment](https://metacpan.org/pod/Time%3A%3AMoment#from_epoch).
 
 ## CONVERSIONS
 

--- a/docs/modules/Conch::Validation.md
+++ b/docs/modules/Conch::Validation.md
@@ -34,7 +34,7 @@ sub validate {
 
 # DESCRIPTION
 
-[Conch::Validation](../modules/Conch::Validation) provides the base class to define and execute Conch
+[Conch::Validation](../modules/Conch%3A%3AValidation) provides the base class to define and execute Conch
 Validations. Validations extend this class by implementing a ["validate"](#validate)
 method.  This method receives the input data (a `HASHREF`) to be validated.
 
@@ -50,7 +50,7 @@ identification of the validation and validation result storage in the
 Validation System infrastructure.
 
 Testing Conch Validations should be done with
-["test\_validation" in Test::Conch::Validation](../modules/Test::Conch::Validation#test_validation) with TAP-based tests. This
+["test\_validation" in Test::Conch::Validation](../modules/Test%3A%3AConch%3A%3AValidation#test_validation) with TAP-based tests. This
 functions tests that Validations define the required attributes and methods,
 and allow you to test the validation logic by running test cases against
 expected results.
@@ -81,7 +81,7 @@ A logging object.
 
 ## device
 
-[Conch::DB::Result::Device](../modules/Conch::DB::Result::Device) object under validation.  Use in validation
+[Conch::DB::Result::Device](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ADevice) object under validation.  Use in validation
 logic to dispatch on Device attributes.
 
 ```perl
@@ -89,13 +89,13 @@ my $device = $self->device;
 if ($device->asset_tag eq '...') {...}
 ```
 
-Any additional data related to devices may be read as normal using [DBIx::Class](https://metacpan.org/pod/DBIx::Class) interfaces.
+Any additional data related to devices may be read as normal using [DBIx::Class](https://metacpan.org/pod/DBIx%3A%3AClass) interfaces.
 The result object is built using a read-only database handle, so attempts to alter the data
 will **not** be permitted.
 
 ## device\_location
 
-[Conch::DB::Result::DeviceLocation](../modules/Conch::DB::Result::DeviceLocation) object for the device being validated.
+[Conch::DB::Result::DeviceLocation](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ADeviceLocation) object for the device being validated.
 
 This is useful in writing validation logic that may depend on the rack or
 location in the rack a device occupies.
@@ -112,10 +112,10 @@ location.
 
 ## hardware\_product
 
-The [Conch::DB::Result::HardwareProduct](../modules/Conch::DB::Result::HardwareProduct) object for the device being validated
+The [Conch::DB::Result::HardwareProduct](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AHardwareProduct) object for the device being validated
 (originally determined by the sku reported for the device).
 
-Any additional data related to hardware\_products may be read as normal using [DBIx::Class](https://metacpan.org/pod/DBIx::Class)
+Any additional data related to hardware\_products may be read as normal using [DBIx::Class](https://metacpan.org/pod/DBIx%3A%3AClass)
 interfaces.  The result object is built using a read-only database handle, so attempts to alter
 the data will **not** be permitted.
 
@@ -167,7 +167,7 @@ if ($self->hardware_product_vendor eq 'Dell') {...}
 ## hardware\_product\_profile
 
 Get the expected hardware product profile for the device under validation.
-It is a [Conch::DB::Result::HardwareProductProfile](../modules/Conch::DB::Result::HardwareProductProfile) object.
+It is a [Conch::DB::Result::HardwareProductProfile](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AHardwareProductProfile) object.
 
 ```perl
 my $expected_ram = self->hardware_product_profile->ram_total;
@@ -219,7 +219,7 @@ $validation->run($validation_data);
 
 Contains the validation logic for validations.
 
-This method must be re-defined in sub-classes of [Conch::Validation](../modules/Conch::Validation) or it will
+This method must be re-defined in sub-classes of [Conch::Validation](../modules/Conch%3A%3AValidation) or it will
 raise an exception.
 
 ```perl
@@ -343,7 +343,7 @@ You may also provide the following attributes to override validation results
 ## register\_result\_cmp\_details
 
 EXPERIMENTAL. A new way of registering validation results. Pass arguments as you would to
-["cmp\_deeply" in Test::Deep](https://metacpan.org/pod/Test::Deep#cmp_deeply), and a validation result is registered with the result and diagnostics
+["cmp\_deeply" in Test::Deep](https://metacpan.org/pod/Test%3A%3ADeep#cmp_deeply), and a validation result is registered with the result and diagnostics
 as appropriate.
 
 ## die

--- a/docs/modules/Conch::ValidationError.md
+++ b/docs/modules/Conch::ValidationError.md
@@ -4,8 +4,8 @@ Conch::ValidationError - Internal error representation for Conch::Validation
 
 # DESCRIPTION
 
-Extends [Mojo::Exception](https://metacpan.org/pod/Mojo::Exception) to store a `hint` attribute. Intended for use in
-[Conch::Validation](../modules/Conch::Validation).
+Extends [Mojo::Exception](https://metacpan.org/pod/Mojo%3A%3AException) to store a `hint` attribute. Intended for use in
+[Conch::Validation](../modules/Conch%3A%3AValidation).
 
 # METHODS
 

--- a/docs/modules/Test::Conch.md
+++ b/docs/modules/Test::Conch.md
@@ -1,6 +1,6 @@
 # DESCRIPTION
 
-Takes care of setting up a [Test::Mojo](https://metacpan.org/pod/Test::Mojo) with the Conch application pre-configured.
+Takes care of setting up a [Test::Mojo](https://metacpan.org/pod/Test%3A%3AMojo) with the Conch application pre-configured.
 
 Includes JSON validation ability.
 
@@ -15,7 +15,7 @@ $t->get_ok('/')->status_is(200)->json_schema_is('Whatever');
 
 ## pg
 
-Override with your own [Test::PostgreSQL](https://metacpan.org/pod/Test::PostgreSQL) object if you want to use a custom database, perhaps
+Override with your own [Test::PostgreSQL](https://metacpan.org/pod/Test%3A%3APostgreSQL) object if you want to use a custom database, perhaps
 with extra settings or loaded with additional data.
 
 This is the attribute to copy if you want multiple Test::Conch objects to be able to talk to
@@ -25,7 +25,7 @@ the same database.
 
 ## fixtures
 
-Provides access to the fixtures defined in [Test::Conch::Fixtures](../modules/Test::Conch::Fixtures).
+Provides access to the fixtures defined in [Test::Conch::Fixtures](../modules/Test%3A%3AConch%3A%3AFixtures).
 See ["load\_fixture"](#load_fixture).
 
 ## new
@@ -42,19 +42,19 @@ Constructor. Takes the following arguments:
 ## init\_db
 
 Sets up the database for testing, using the final schema rather than running migrations.
-Mirrors functionality in ["initialize\_db" in Conch::DB::Util](../modules/Conch::DB::Util#initialize_db).
+Mirrors functionality in ["initialize\_db" in Conch::DB::Util](../modules/Conch%3A%3ADB%3A%3AUtil#initialize_db).
 No data is added -- you must load all desired fixtures.
 
-Note that the [Test::PostgreSQL](https://metacpan.org/pod/Test::PostgreSQL) object must stay in scope for the duration of your tests.
-Returns the [Conch::DB](../modules/Conch::DB) object as well when called in list context.
+Note that the [Test::PostgreSQL](https://metacpan.org/pod/Test%3A%3APostgreSQL) object must stay in scope for the duration of your tests.
+Returns the [Conch::DB](../modules/Conch%3A%3ADB) object as well when called in list context.
 
 ## ro\_schema
 
-Returns a read-only connection to an existing [Test::PostgreSQL](https://metacpan.org/pod/Test::PostgreSQL) instance.
+Returns a read-only connection to an existing [Test::PostgreSQL](https://metacpan.org/pod/Test%3A%3APostgreSQL) instance.
 
 ## status\_is
 
-Wrapper around ["status\_is" in Test::Mojo](https://metacpan.org/pod/Test::Mojo#status_is), adding some additional checks.
+Wrapper around ["status\_is" in Test::Mojo](https://metacpan.org/pod/Test%3A%3AMojo#status_is), adding some additional checks.
 
 ```
 * successful GET requests should not return 201, 202 (ideally just 200, 204).
@@ -69,7 +69,7 @@ Also, unexpected responses will dump the response payload.
 
 ## location\_is
 
-Stolen from [Test::Mojo](https://metacpan.org/pod/Test::Mojo)'s examples. I don't know why this isn't just part of the interface!
+Stolen from [Test::Mojo](https://metacpan.org/pod/Test%3A%3AMojo)'s examples. I don't know why this isn't just part of the interface!
 
 ## location\_like
 
@@ -84,8 +84,8 @@ the hash as the schema to validate.
 
 ## json\_cmp\_deeply
 
-Like ["json\_is" in Test::Mojo](https://metacpan.org/pod/Test::Mojo#json_is), but uses ["cmp\_deeply" in Test::Deep](https://metacpan.org/pod/Test::Deep#cmp_deeply) for the comparison instead of
-["is\_deep" in Test::More](https://metacpan.org/pod/Test::More#is_deep). This allows for more flexibility in how we test various parts of the
+Like ["json\_is" in Test::Mojo](https://metacpan.org/pod/Test%3A%3AMojo#json_is), but uses ["cmp\_deeply" in Test::Deep](https://metacpan.org/pod/Test%3A%3ADeep#cmp_deeply) for the comparison instead of
+["is\_deep" in Test::More](https://metacpan.org/pod/Test%3A%3AMore#is_deep). This allows for more flexibility in how we test various parts of the
 data.
 
 ## load\_validation\_plans
@@ -135,7 +135,7 @@ Add one or more fixture definition(s), and populate the database with it.
 ## load\_fixture\_set
 
 Generates a set of fixtures by name and optional arguments, then loads them into the database.
-See ["generate\_set" in Test::Conch::Fixtures](../modules/Test::Conch::Fixtures#generate_set) for available sets.
+See ["generate\_set" in Test::Conch::Fixtures](../modules/Test%3A%3AConch%3A%3AFixtures#generate_set) for available sets.
 
 ## generate\_fixtures
 
@@ -163,7 +163,7 @@ or, to get all the defaults with no overrides:
 $t->generate_fixtures('device_location');
 ```
 
-See ["\_generate\_definition" in Test::Conch::Fixtures](../modules/Test::Conch::Fixtures#generate_definition) for the list of recognized types.
+See ["\_generate\_definition" in Test::Conch::Fixtures](../modules/Test%3A%3AConch%3A%3AFixtures#generate_definition) for the list of recognized types.
 
 ## authenticate
 
@@ -181,7 +181,7 @@ subtest and is invoked with the test object as well as any additional provided a
 
 ## email\_cmp\_deeply
 
-Wrapper around ["cmp\_deeply" in Test::Deep](https://metacpan.org/pod/Test::Deep#cmp_deeply) to test the email(s) that were "sent".
+Wrapper around ["cmp\_deeply" in Test::Deep](https://metacpan.org/pod/Test%3A%3ADeep#cmp_deeply) to test the email(s) that were "sent".
 `$got` should contain a hashref, or an arrayref of hashrefs, containing the headers and
 content of the message(s), allowing you to test any portion of these that you like using
 cmp\_deeply constructs.
@@ -200,7 +200,7 @@ $t->email_cmp_deeply([
 A default 'From' header corresponding to the main test user is added as a default to your
 `$expected` message(s) if you don't provide one.
 
-Remember: "Line endings in the body will normalized to CRLF." (see ["create" in Email::Simple](https://metacpan.org/pod/Email::Simple#create))
+Remember: "Line endings in the body will normalized to CRLF." (see ["create" in Email::Simple](https://metacpan.org/pod/Email%3A%3ASimple#create))
 
 ## email\_not\_sent
 
@@ -209,7 +209,7 @@ Tests that **no** email was sent as a result of the last request.
 ## log\_is
 
 Searches the log lines emitted for the last request for one with the provided message,
-which can be either an exact string or anything that [Test::Deep](https://metacpan.org/pod/Test::Deep) recognizes.
+which can be either an exact string or anything that [Test::Deep](https://metacpan.org/pod/Test%3A%3ADeep) recognizes.
 
 If you are expecting a list of message strings (sent at once to the logger), pass a listref
 rather than a list.
@@ -258,11 +258,11 @@ cleared before every request.
 Convenience method to add additional route(s) to the application, without breaking the routes
 that are already in a specific order.
 
-`$routes` should be a [Mojolicious::Routes](https://metacpan.org/pod/Mojolicious::Routes) object that holds the route(s) to be added.
+`$routes` should be a [Mojolicious::Routes](https://metacpan.org/pod/Mojolicious%3A%3ARoutes) object that holds the route(s) to be added.
 
 ## do\_and\_wait\_for\_event
 
-Sets up a [Mojo::Promise](https://metacpan.org/pod/Mojo::Promise) to wait for a specific event name, then executes the first subref
+Sets up a [Mojo::Promise](https://metacpan.org/pod/Mojo%3A%3APromise) to wait for a specific event name, then executes the first subref
 provided. When the event is received **and** the task subref has finished, the success subref is
 invoked with the argument(s) sent to the event. If the timeout is reached, the failure subref
 is called, or if left undefined a test failure is generated.

--- a/docs/modules/Test::Conch::Fixtures.md
+++ b/docs/modules/Test::Conch::Fixtures.md
@@ -17,7 +17,7 @@ my $fixtures = Test::Conch::Fixtures->new(
 );
 ```
 
-See ["fixtures" in Test::Conch](../modules/Test::Conch#fixtures) for main usage.
+See ["fixtures" in Test::Conch](../modules/Test%3A%3AConch#fixtures) for main usage.
 
 # METHODS
 
@@ -64,11 +64,11 @@ Add a new fixture definition.
 
 ## get\_definition
 
-Used by [DBIx::Class::Fixtures](https://metacpan.org/pod/DBIx::Class::Fixtures).
+Used by [DBIx::Class::Fixtures](https://metacpan.org/pod/DBIx%3A%3AClass%3A%3AFixtures).
 
 ## all\_fixture\_names
 
-Used by [DBIx::Class::Fixtures](https://metacpan.org/pod/DBIx::Class::Fixtures).
+Used by [DBIx::Class::Fixtures](https://metacpan.org/pod/DBIx%3A%3AClass%3A%3AFixtures).
 
 # LICENSING
 

--- a/docs/modules/Test::Conch::Validation.md
+++ b/docs/modules/Test::Conch::Validation.md
@@ -86,7 +86,7 @@ A test case is specified with a hashref with the attributes:
 - `debug`
 
     Optional boolean flag to provide additional diagnostic information when running
-    the case using ["diag" in Test::More](https://metacpan.org/pod/Test::More#diag). This is helpful during development of test
+    the case using ["diag" in Test::More](https://metacpan.org/pod/Test%3A%3AMore#diag). This is helpful during development of test
     cases, but should be removed before committing.
 
 Example:

--- a/docs/scripts/conch.md
+++ b/docs/scripts/conch.md
@@ -14,51 +14,51 @@ Usage: APPLICATION COMMAND \[OPTIONS\]
 
 Conch-specific commands are:
 
-- [check\_layouts](../modules/Conch::Command::check_layouts)
+- [check\_layouts](../modules/Conch%3A%3ACommand%3A%3Acheck_layouts)
 
     Check for conflicts in existing rack layouts
 
-- [check\_validation\_plans](../modules/Conch::Command::check_validation_plans)
+- [check\_validation\_plans](../modules/Conch%3A%3ACommand%3A%3Acheck_validation_plans)
 
     check all validations and validation plans
 
-- [check\_workspace\_racks](../modules/Conch::Command::check_workspace_racks)
+- [check\_workspace\_racks](../modules/Conch%3A%3ACommand%3A%3Acheck_workspace_racks)
 
     verify the integrity of all workspace\_rack rows
 
-- [clean\_roles](../modules/Conch::Command::clean_roles)
+- [clean\_roles](../modules/Conch%3A%3ACommand%3A%3Aclean_roles)
 
     Clean up unnecessary user\_workspace\_role entries
 
-- [create\_token](../modules/Conch::Command::create_token)
+- [create\_token](../modules/Conch%3A%3ACommand%3A%3Acreate_token)
 
     Create a new application token
 
-- [create\_user](../modules/Conch::Command::create_user)
+- [create\_user](../modules/Conch%3A%3ACommand%3A%3Acreate_user)
 
     Create a new user
 
-- [fix\_usernames](../modules/Conch::Command::fix_usernames)
+- [fix\_usernames](../modules/Conch%3A%3ACommand%3A%3Afix_usernames)
 
     fixes Joyent usernames so they are not the same as the email
 
-- [merge\_validation\_results](../modules/Conch::Command::merge_validation_results)
+- [merge\_validation\_results](../modules/Conch%3A%3ACommand%3A%3Amerge_validation_results)
 
     Collapse duplicate validation\_result rows together
 
-- [thin\_device\_reports](../modules/Conch::Command::thin_device_reports)
+- [thin\_device\_reports](../modules/Conch%3A%3ACommand%3A%3Athin_device_reports)
 
     remove unwanted device reports
 
-- [update\_validation\_plans](../modules/Conch::Command::update_validation_plans)
+- [update\_validation\_plans](../modules/Conch%3A%3ACommand%3A%3Aupdate_validation_plans)
 
     bring validation\_plans up to date with new versions of all validations
 
-- [workspace\_to\_build](../modules/Conch::Command::workspace_to_build)
+- [workspace\_to\_build](../modules/Conch%3A%3ACommand%3A%3Aworkspace_to_build)
 
     convert workspace content to a build
 
-- [workspaces](../modules/Conch::Command::workspaces)
+- [workspaces](../modules/Conch%3A%3ACommand%3A%3Aworkspaces)
 
     View all workspaces in their heirarchical order
 

--- a/json-schema/other.yaml
+++ b/json-schema/other.yaml
@@ -125,15 +125,13 @@ definitions:
 #                         allOf:
 #                           - if:
 #                               properties:
-#                                 type:
-#                                   const: log
+#                                 const: log
 #                             then:
 #                               required:
 #                                 - message
 #                           - if:
 #                               properties:
-#                                 type:
-#                                   const: network
+#                                 const: network
 #                             then:
 #                               required:
 #                                 - method
@@ -141,15 +139,13 @@ definitions:
 #                                 - status_code
 #                           - if:
 #                               properties:
-#                                 type:
-#                                   const: dom
+#                                 const: dom
 #                             then:
 #                               required:
 #                                 - element
 #                           - if:
 #                               properties:
-#                                 type:
-#                                   const: error
+#                                 const: error
 #                             then:
 #                               required:
 #                                 - message

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -520,7 +520,7 @@ definitions:
                     description: datacenter.region
                     type: string
                   vendor_name:
-                    description: datacenter.vendor_name
+                    description: the vendor's name for the datacenter
                     oneOf:
                       - type: 'null'
                       - type: string
@@ -633,7 +633,7 @@ definitions:
                   description: datacenter.region
                   type: string
                 vendor_name:
-                  description: datacenter.vendor_name
+                  description: the vendor's name for the datacenter
                   oneOf:
                     - type: 'null'
                     - type: string
@@ -1301,6 +1301,7 @@ definitions:
       vendor:
         type: string
       vendor_name:
+        description: the vendor's name for the datacenter
         oneOf:
           - type: string
           - type: 'null'
@@ -1338,6 +1339,7 @@ definitions:
       alias:
         type: string
       vendor_name:
+        description: the vendor's name for the room
         oneOf:
           - type: string
           - type: 'null'

--- a/lib/Conch/Controller/DeviceSettings.pm
+++ b/lib/Conch/Controller/DeviceSettings.pm
@@ -117,7 +117,7 @@ Response uses the DeviceSetting json schema.
 sub get_single ($c) {
     my $setting_key = $c->stash('key');
 
-    # no need to check for the 'ro' role - find_device() already checked the workspace
+    # no need to check for the 'ro' role - find_device() already performed that check
 
     my $setting = $c->stash('device_rs')
         ->search_related('device_settings', { name => $setting_key })

--- a/lib/Conch/Controller/User.pm
+++ b/lib/Conch/Controller/User.pm
@@ -414,7 +414,7 @@ sub update ($c) {
 
 =head2 list
 
-List all active users and their workspaces. System admin only.
+List all active users and their workspaces, builds and organizations. System admin only.
 Response uses the UsersDetailed json schema.
 
 =cut

--- a/lib/Conch/Controller/WorkspaceDevice.pm
+++ b/lib/Conch/Controller/WorkspaceDevice.pm
@@ -75,7 +75,7 @@ sub get_pxe_devices ($c) {
         ->related_resultset('workspace_racks')
         ->search_related('rack', undef, { join => { datacenter_room => 'datacenter' } })
         ->related_resultset('device_locations')
-        # production devices do not consider interface data to be canonical
+        # production devices do not consider location data to be canonical
         ->search_related('device',
             $bad_phase ? { 'device.phase' => { '<' => \[ '?::device_phase_enum', $bad_phase ] } } : ())
         ->columns({

--- a/lib/Conch/DB/Helper/ResultSet/ResultsExist.pm
+++ b/lib/Conch/DB/Helper/ResultSet/ResultsExist.pm
@@ -24,7 +24,7 @@ This code is postgres-specific.
 
 =head2 exists
 
-Efficiently efficiently determines if a result exists, without needing to do a C<< ->count >>.
+Efficiently determines if a result exists, without needing to do a C<< ->count >>.
 Essentially does:
 
     select exists (select 1 from ... rest of your query ...);

--- a/lib/Conch/DB/ResultSet.pm
+++ b/lib/Conch/DB/ResultSet.pm
@@ -56,8 +56,6 @@ Methods added are:
 
 =item * L<prefetch|DBIx::Class::Helper::ResultSet::Shortcut/prefetch>
 
-=item * L<remove_columns|DBIx::Class::Helper::ResultSet::RemoveColumns/remove_columns>
-
 =item * L<rows|DBIx::Class::Helper::ResultSet::Shortcut/rows>
 
 =item * L<union|DBIx::Class::Helper::ResultSet::SetOperations/union>
@@ -68,11 +66,21 @@ Methods added are:
 
 =back
 
+=head1 ATTRIBUTES
+
+Resultset attributes added are:
+
+=over 4
+
+=item * L<remove_columns|DBIx::Class::Helper::ResultSet::RemoveColumns/remove_columns>
+
+=back
+
 =cut
 
 __PACKAGE__->load_components(
     '+Conch::DB::Helper::ResultSet::Deactivatable', # provides active, deactivate
-    'Helper::ResultSet::RemoveColumns',         # provides remove_columns (must be applied early!)
+    'Helper::ResultSet::RemoveColumns',         # provides remove_columns attribute (must be applied early!)
     'Helper::ResultSet::OneRow',                # provides one_row
     'Helper::ResultSet::Shortcut::HRI',         # provides hri: raw unblessed + uninflated data
     'Helper::ResultSet::Shortcut::Prefetch',    # provides prefetch

--- a/lib/Conch/DB/ResultSet/Device.pm
+++ b/lib/Conch/DB/ResultSet/Device.pm
@@ -18,8 +18,9 @@ Interface to queries involving devices.
 =head2 with_user_role
 
 Constrains the resultset to those where the provided user_id has (at least) the specified role
-in at least one workspace or build associated with the specified device(s), including parent
-workspaces.
+in at least one workspace or build associated with the specified device(s) (also taking into
+consideration the rack location of the device(s) if its phase is early enough), including
+parent workspaces.
 
 This is a nested query which searches all workspaces and builds in the database, so only use
 this query when its impact is outweighed by the impact of filtering a large resultset of

--- a/lib/Conch/DB/ResultSet/Device.pm
+++ b/lib/Conch/DB/ResultSet/Device.pm
@@ -55,16 +55,22 @@ sub with_user_role ($self, $user_id, $role) {
         ->with_user_role($user_id, $role)
         ->get_column('id');
 
-    my $devices_in_builds = $self->search(
-        { -or => [
-                { 'rack.build_id' => { -in => $build_ids_rs->as_query } },
-                { $me.'.build_id' => { -in => $build_ids_rs->as_query } },
-            ],
+    my $devices_in_device_builds = $self->search(
+        { $me.'.build_id' => { -in => $build_ids_rs->as_query } },
+    );
+
+    my $devices_in_rack_builds = $self->search(
+        {
+            # production devices do not consider location data to be canonical
+            $me.'.phase' => { '<' => \[ '?::device_phase_enum', 'production' ] },
+            'rack.build_id' => { -in => $build_ids_rs->as_query },
         },
         { join => { device_location => 'rack' } },
     );
 
-    return $devices_in_ws->union($devices_in_builds);
+    return $devices_in_ws
+        ->union($devices_in_device_builds)
+        ->union($devices_in_rack_builds);
 }
 
 =head2 user_has_role

--- a/lib/Conch/DB/ResultSet/Rack.pm
+++ b/lib/Conch/DB/ResultSet/Rack.pm
@@ -46,7 +46,8 @@ sub assigned_rack_units ($self) {
 =head2 user_has_role
 
 Checks that the provided user_id has (at least) the specified role in at least one workspace
-associated with the specified rack(s) (implicitly including parent workspaces).
+associated with the specified rack(s) (implicitly including parent workspaces), or at least one
+build associated with the rack(s).
 
 Returns a boolean.
 

--- a/lib/Conch/DB/ResultSet/UserSessionToken.pm
+++ b/lib/Conch/DB/ResultSet/UserSessionToken.pm
@@ -49,7 +49,7 @@ Chainable resultset to search for login tokens (created via the main C<POST /log
 
 sub login_only ($self) {
     my $me = $self->current_source_alias;
-    $self->search({ $me.'.name' => { '-similar to' => 'login_jwt_[0-9_]+' } });
+    $self->search({ $me.'.name' => { '~' => 'login_jwt_[0-9_]+' } });
 }
 
 =head2 api_only
@@ -60,7 +60,7 @@ Chainable resultset to search for api tokens (NOT created via the main /login fl
 
 sub api_only ($self) {
     my $me = $self->current_source_alias;
-    $self->search({ $me.'.name' => { '-not similar to' => 'login_jwt_[0-9_]+' } });
+    $self->search({ $me.'.name' => { '!~' => 'login_jwt_[0-9_]+' } });
 }
 
 =head2 expire

--- a/lib/Conch/Plugin/Database.pm
+++ b/lib/Conch/Plugin/Database.pm
@@ -168,7 +168,7 @@ use the subref's return value to signal success.
 
     # verify that we are running the version of postgres we expect...
     my $pgsql_version = Conch::DB::Util::get_postgres_version($app->schema);
-    $app->log->info("Running $pgsql_version");
+    $app->log->info($db_credentials->{dsn}.' running '.$pgsql_version);
 
     use constant POSTGRES_MINIMUM_VERSION_MAJOR => 10;
     use constant POSTGRES_MINIMUM_VERSION_MINOR => 10;

--- a/lib/Conch/Route.pm
+++ b/lib/Conch/Route.pm
@@ -134,7 +134,8 @@ __END__
 
 Unless otherwise specified, all routes require authentication.
 
-Full access is granted to system admin users, regardless of workspace or other role entries.
+Full access is granted to system admin users, regardless of workspace, build or other role
+entries.
 
 Successful (http 2xx code) response structures are as described for each endpoint.
 

--- a/lib/Conch/Route/Build.pm
+++ b/lib/Conch/Route/Build.pm
@@ -275,7 +275,7 @@ read-only role on the device.
 =over 4
 
 =item * Requires system admin authorization, or the read/write role on the build and the
-read-only role on the device (via a workspace or a relay registration, see
+read-only role on the device (via a workspace or build or a relay registration, see
 L<Conch::Route::Device/routes>)
 
 =item * Response: C<204 NO CONTENT>
@@ -307,7 +307,7 @@ L<Conch::Route::Device/routes>)
 =over 4
 
 =item * Requires system admin authorization, or the read/write role on the build and the
-read-only role on a workspace that contains the rack
+read-only role on a workspace or build that contains the rack
 
 =item * Response: C<204 NO CONTENT>
 

--- a/lib/Conch/Route/Device.pm
+++ b/lib/Conch/Route/Device.pm
@@ -121,9 +121,11 @@ __END__
 
 Unless otherwise noted, all routes require authentication.
 
-The user's role (required for most endpoints) is determined by the rack location of the device,
-and the workspace(s) the rack is contained in (where users are assigned a
-L<role|Conch::DB::Result::UserWorkspaceRole/role> in that workspace).
+The user's role (required for most endpoints) is determined by the build the device is
+contained in (where users are assigned a L<role|Conch::DB::Result::UserBuildRole/role> in that
+build), and the rack location of the device and the workspace(s) or build the rack is contained
+in (where users are assigned a L<role|Conch::DB::Result::UserBuildRole/role> in that build and
+a L<role|Conch::DB::Result::UserWorkspaceRole/role> in that workspace).
 
 Full (admin-level) access is also granted to a device if a report was sent for that device
 using a relay that registered with that user's credentials.

--- a/lib/Conch/Route/User.pm
+++ b/lib/Conch/Route/User.pm
@@ -295,7 +295,8 @@ an email telling the user their tokens were revoked
 
 =head3 C<< DELETE /user/:target_user_id_or_email?clear_tokens=<1|0> >>
 
-When a user is deleted, all workspace role entries are removed and are unrecoverable.
+When a user is deleted, all role entries (workspace, build, organization) are removed and are
+unrecoverable.
 
 Optionally takes a query parameter C<clear_tokens> (defaults to C<1>), to also
 revoke all session tokens for the user forcing all tools to log in again.

--- a/lib/Test/Conch.pm
+++ b/lib/Test/Conch.pm
@@ -95,6 +95,8 @@ sub new {
     my $pg = exists $args->{pg} ? delete $args->{pg}
         : $class->init_db // Test::More::BAIL_OUT('failed to create test database');
 
+    $ENV{MOJO_MODE} ||= 'test';
+
     my $self = Test::Mojo->new(
         Conch => {
             database => {

--- a/misc/ghch
+++ b/misc/ghch
@@ -2,7 +2,8 @@
 
 use warnings;
 use strict;
-use v5.20;
+use v5.26;
+use open ':std', ':encoding(UTF-8)'; # force stdin, stdout, stderr into utf8
 
 use Mojo::JSON 'decode_json';
 use HTTP::Tiny;

--- a/sql/migrations/0109-device-id-is-uuid.sql
+++ b/sql/migrations/0109-device-id-is-uuid.sql
@@ -15,7 +15,7 @@ SELECT run_migration(109, $$
     alter table device_location drop constraint device_location_device_id_fkey;
     alter table device_relay_connection drop constraint device_relay_connection_device_id_fkey;
 
-    drop index device_id_idx;
+    drop index if exists device_id_idx;
     alter table device drop constraint device_pkey;
     alter table device add primary key (id);
 

--- a/sql/run_migrations.sh
+++ b/sql/run_migrations.sh
@@ -4,7 +4,9 @@ IFS=$'\n\t'
 
 BASEDIR=$(cd `dirname "$0"` && pwd)
 
+date "+%Y-%m-%d %T"
 for migration in $(ls $BASEDIR/migrations | sort); do
     echo $BASEDIR/migrations/$migration
     psql -U conch -v ON_ERROR_STOP=1 -f $BASEDIR/migrations/$migration;
+    date "+%Y-%m-%d %T"
 done

--- a/t/conch-log.t
+++ b/t/conch-log.t
@@ -155,21 +155,32 @@ sub add_test_routes ($t) {
 
 {
     reset_log;
-    my $t = Test::Conch->new(config => {
-        features => { audit => 0 },
-    });
 
     cmp_deeply(
-        $t->app->log,
+        Test::Conch->new(config => { features => { audit => 0 } })->app->log,
         all(
             isa('Conch::Log'),
             methods(
-                path => str(Path::Tiny->cwd->child('log/development.log')),
+                path => str(Path::Tiny->cwd->child('log/test.log')),
                 bunyan => 1,
                 with_trace => 0,
             ),
         ),
         'logger via $app gets good default options',
+    );
+
+    local $ENV{MOJO_MODE} = 'foo';
+    cmp_deeply(
+        Test::Conch->new(config => { features => { audit => 0 } })->app->log,
+        all(
+            isa('Conch::Log'),
+            methods(
+                path => str(Path::Tiny->cwd->child('log/foo.log')),
+                bunyan => 1,
+                with_trace => 0,
+            ),
+        ),
+        'logger via $app uses MOJO_MODE for filename',
     );
 }
 

--- a/t/conch-log.t
+++ b/t/conch-log.t
@@ -157,7 +157,7 @@ sub add_test_routes ($t) {
     reset_log;
 
     cmp_deeply(
-        Test::Conch->new(config => { features => { audit => 0 } })->app->log,
+        Test::Conch->new(config => { features => { audit => 0, no_db => 1 } })->app->log,
         all(
             isa('Conch::Log'),
             methods(
@@ -171,7 +171,7 @@ sub add_test_routes ($t) {
 
     local $ENV{MOJO_MODE} = 'foo';
     cmp_deeply(
-        Test::Conch->new(config => { features => { audit => 0 } })->app->log,
+        Test::Conch->new(config => { features => { audit => 0, no_db => 1 } })->app->log,
         all(
             isa('Conch::Log'),
             methods(
@@ -188,7 +188,7 @@ sub add_test_routes ($t) {
     reset_log;
     my $t = Test::Conch->new(config => {
         logging => { handle => $log_fh },
-        features => { audit => 0 },
+        features => { audit => 0, no_db => 1 },
     });
 
     cmp_deeply(
@@ -549,7 +549,7 @@ sub add_test_routes ($t) {
     my $t = Test::Conch->new(
         config => {
             logging => { handle => $log_fh },
-            features => { audit => 1 },
+            features => { audit => 1, no_db => 1 },
         },
     );
 

--- a/t/database.t
+++ b/t/database.t
@@ -13,7 +13,7 @@ use Crypt::Eksblowfish::Bcrypt 'bcrypt';
 subtest 'assert db version' => sub {
     my ($pgsql, $schema) = Test::Conch->init_db;
     my $pgsql_version = Conch::DB::Util::get_postgres_version($schema);
-    diag 'Running '.$pgsql_version;
+    diag $schema->storage->connect_info->[0].' running '.$pgsql_version;
     my ($major, $minor, $rest) = $pgsql_version =~ /PostgreSQL (\d+)\.(\d+)(\.\d+)?\b/;
     $minor //= 0;
     $rest //= '';


### PR DESCRIPTION
- several documentation fixes, including more clarification of how user roles are calculated
- when determining a user's role for a device, do not use device->rack->build->role when device phase is production or later (bringing consistency with how device phase is used elsewhere in role calculations)
- small fix to an earlier database migration after re-running migrations on conch-v3-staging
- logs for `bin/conch <command>` are now sent to `log/command.log`, and tests to `log/test.log`, maintaining separation from `log/production.log` which gets normal runtime API logs