### PR TITLE
v3 b2 enhancements

### DIFF
--- a/docs/json-schema/query_params.json
+++ b/docs/json-schema/query_params.json
@@ -4,6 +4,13 @@
   "definitions" : {
     "BuildDevices" : {
       "additionalProperties" : false,
+      "not" : {
+        "required" : [
+          "ids_only",
+          "serials_only"
+        ],
+        "type" : "object"
+      },
       "properties" : {
         "active_minutes" : {
           "$ref" : "common.json#/definitions/non_negative_integer"
@@ -35,6 +42,9 @@
               "$ref" : "common.json#/definitions/device_phase"
             }
           ]
+        },
+        "serials_only" : {
+          "$ref" : "/definitions/boolean_integer_default_false"
         }
       },
       "type" : "object"
@@ -188,6 +198,13 @@
     },
     "WorkspaceDevices" : {
       "additionalProperties" : false,
+      "not" : {
+        "required" : [
+          "ids_only",
+          "serials_only"
+        ],
+        "type" : "object"
+      },
       "properties" : {
         "active_minutes" : {
           "$ref" : "common.json#/definitions/non_negative_integer"
@@ -208,6 +225,9 @@
           ]
         },
         "ids_only" : {
+          "$ref" : "/definitions/boolean_integer_default_false"
+        },
+        "serials_only" : {
           "$ref" : "/definitions/boolean_integer_default_false"
         },
         "validated" : {

--- a/docs/json-schema/request.json
+++ b/docs/json-schema/request.json
@@ -111,7 +111,7 @@
       ],
       "type" : "object"
     },
-    "BuildCreateDevice" : {
+    "BuildCreateDevices" : {
       "items" : {
         "additionalProperties" : false,
         "anyOf" : [

--- a/docs/json-schema/request.json
+++ b/docs/json-schema/request.json
@@ -160,6 +160,7 @@
         ],
         "type" : "object"
       },
+      "minItems" : 1,
       "type" : "array",
       "uniqueItems" : true
     },
@@ -854,6 +855,7 @@
       "items" : {
         "$ref" : "/definitions/RackAssignmentDelete"
       },
+      "minItems" : 1,
       "type" : "array",
       "uniqueItems" : true
     },
@@ -901,6 +903,7 @@
       "items" : {
         "$ref" : "/definitions/RackAssignmentUpdate"
       },
+      "minItems" : 1,
       "type" : "array",
       "uniqueItems" : true
     },

--- a/docs/json-schema/request.json
+++ b/docs/json-schema/request.json
@@ -306,6 +306,18 @@
       ],
       "type" : "object"
     },
+    "DeviceBuild" : {
+      "additionalProperties" : false,
+      "properties" : {
+        "build_id" : {
+          "$ref" : "common.json#/definitions/uuid"
+        }
+      },
+      "required" : [
+        "build_id"
+      ],
+      "type" : "object"
+    },
     "DeviceLinks" : {
       "additionalProperties" : false,
       "properties" : {

--- a/docs/json-schema/response.json
+++ b/docs/json-schema/response.json
@@ -1242,6 +1242,13 @@
       ],
       "type" : "object"
     },
+    "DeviceSerials" : {
+      "items" : {
+        "$ref" : "common.json#/definitions/device_serial_number"
+      },
+      "type" : "array",
+      "uniqueItems" : true
+    },
     "DeviceSetting" : {
       "allOf" : [
         {

--- a/docs/modules/Conch::Controller::Build.md
+++ b/docs/modules/Conch::Controller::Build.md
@@ -101,9 +101,11 @@ health=<value>      only devices with health matching the provided value
     (can be used more than once to search for ANY of the specified health values)
 active_minutes=X    only devices last seen (via a report relay) within X minutes
 ids_only=1          only return device ids, not full data
+serials_only=1      only return device serial numbers, not full data
 ```
 
-Response uses the Devices json schema, or DeviceIds iff `ids_only=1`.
+Response uses the Devices json schema, or DeviceIds iff `ids_only=1`, or DeviceSerials iff
+`serials_only=1`.
 
 ## create\_and\_add\_devices
 

--- a/docs/modules/Conch::Controller::DatacenterRoom.md
+++ b/docs/modules/Conch::Controller::DatacenterRoom.md
@@ -6,7 +6,7 @@ Conch::Controller::DatacenterRoom
 
 ## find\_datacenter\_room
 
-Handles looking up the object by id.
+Handles looking up the object by id or alias.
 
 ## get\_all
 

--- a/docs/modules/Conch::Controller::Device.md
+++ b/docs/modules/Conch::Controller::Device.md
@@ -71,6 +71,12 @@ Appends the provided link(s) to the device record.
 
 Removes all links from the device record.
 
+## set\_build
+
+Moves the device to a new build.
+
+Also requires read/write access to the old and new builds.
+
 # LICENSING
 
 Copyright Joyent, Inc.

--- a/docs/modules/Conch::Controller::WorkspaceDevice.md
+++ b/docs/modules/Conch::Controller::WorkspaceDevice.md
@@ -18,9 +18,11 @@ health=<value>  only devices with health matching the provided value
     (can be used more than once to search for ANY of the specified health values)
 active_minutes=X  only devices last seen within X minutes
 ids_only=1      only return device ids, not full data
+serials_only=1  only return device serial numbers, not full data
 ```
 
-Response uses the Devices json schema, or DeviceIds iff `ids_only=1`.
+Response uses the Devices json schema, or DeviceIds iff `ids_only=1`, or DeviceSerials iff
+`serials_only=1`.
 
 ## get\_pxe\_devices
 

--- a/docs/modules/Conch::Route::Build.md
+++ b/docs/modules/Conch::Route::Build.md
@@ -91,7 +91,7 @@ Accepts the following optional query parameters:
 - `ids_only=1` only return device IDs, not full device details
 
 - Requires system admin authorization or the read-only role on the build
-- Response: response.yaml#/Devices
+- Response: [response.json#/definitions/Devices](../json-schema/response.json#/definitions/Devices), [response.json#/definitions/DeviceIds](../json-schema/response.json#/definitions/DeviceIds) or [response.json#/definitions/DeviceSerials](../json-schema/response.json#/definitions/DeviceSerials)
 
 ### `POST /build/:build_id_or_name/device`
 

--- a/docs/modules/Conch::Route::Build.md
+++ b/docs/modules/Conch::Route::Build.md
@@ -97,7 +97,7 @@ Accepts the following optional query parameters:
 
 - Requires system admin authorization, or the read/write role on the build and the
 read-only role on the device.
-- Request: [request.json#/definitions/BuildCreateDevice](../json-schema/request.json#/definitions/BuildCreateDevice)
+- Request: [request.json#/definitions/BuildCreateDevices](../json-schema/request.json#/definitions/BuildCreateDevices)
 - Response: `204 NO CONTENT`
 
 ### `POST /build/:build_id_or_name/device/:device_id_or_serial_number`

--- a/docs/modules/Conch::Route::DatacenterRoom.md
+++ b/docs/modules/Conch::Route::DatacenterRoom.md
@@ -21,23 +21,23 @@ Unless otherwise noted, all routes require authentication.
 - Request: [request.json#/definitions/DatacenterRoomCreate](../json-schema/request.json#/definitions/DatacenterRoomCreate)
 - Response: Redirect to the created room
 
-### `GET /room/:datacenter_room_id`
+### `GET /room/:datacenter_room_id_or_alias`
 
 - Requires system admin authorization
 - Response: [response.json#/definitions/DatacenterRoomDetailed](../json-schema/response.json#/definitions/DatacenterRoomDetailed)
 
-### `POST /room/:datacenter_room_id`
+### `POST /room/:datacenter_room_id_or_alias`
 
 - Requires system admin authorization
 - Request: [request.json#/definitions/DatacenterRoomUpdate](../json-schema/request.json#/definitions/DatacenterRoomUpdate)
 - Response: Redirect to the updated room
 
-### `DELETE /room/:datacenter_room_id`
+### `DELETE /room/:datacenter_room_id_or_alias`
 
 - Requires system admin authorization
 - Response: `204 NO CONTENT`
 
-### `GET /room/:datacenter_room_id/racks`
+### `GET /room/:datacenter_room_id_or_alias/racks`
 
 - Requires system admin authorization
 - Response: [response.json#/definitions/Racks](../json-schema/response.json#/definitions/Racks)

--- a/docs/modules/Conch::Route::Device.md
+++ b/docs/modules/Conch::Route::Device.md
@@ -88,6 +88,12 @@ below.
 - User requires the read/write role
 - Response: 204 NO CONTENT
 
+### `POST /device/:device_id_or_serial_number/build`
+
+- User requires the read/write role for the device, as well as the old and new builds
+- Request: [request.json#/definitions/DeviceBuild](../json-schema/request.json#/definitions/DeviceBuild)
+- Response: Redirect to the updated device
+
 ### `GET /device/:device_id_or_serial_number/location`
 
 - User requires the read-only role

--- a/docs/modules/Conch::Route::Workspace.md
+++ b/docs/modules/Conch::Route::Workspace.md
@@ -50,7 +50,7 @@ Accepts the following optional query parameters:
 - `ids_only=1` only return device IDs, not full device details
 
 - User requires the read-only role
-- Response: [response.json#/definitions/Devices](../json-schema/response.json#/definitions/Devices)
+- Response: [response.json#/definitions/Devices](../json-schema/response.json#/definitions/Devices), [response.json#/definitions/DeviceIds](../json-schema/response.json#/definitions/DeviceIds) or [response.json#/definitions/DeviceSerials](../json-schema/response.json#/definitions/DeviceSerials)
 
 ### `GET /workspace/:workspace_id_or_name/device/pxe`
 

--- a/json-schema/query_params.yaml
+++ b/json-schema/query_params.yaml
@@ -132,6 +132,13 @@ definitions:
         $ref: common.yaml#/definitions/non_negative_integer
       ids_only:
         $ref: /definitions/boolean_integer_default_false
+      serials_only:
+        $ref: /definitions/boolean_integer_default_false
+    not:
+      type: object
+      required:
+        - ids_only
+        - serials_only
   WorkspaceRelays:
     type: object
     additionalProperties: false
@@ -164,5 +171,12 @@ definitions:
         $ref: common.yaml#/definitions/non_negative_integer
       ids_only:
         $ref: /definitions/boolean_integer_default_false
+      serials_only:
+        $ref: /definitions/boolean_integer_default_false
+    not:
+      type: object
+      required:
+        - ids_only
+        - serials_only
 
 # vim: set sts=2 sw=2 et :

--- a/json-schema/request.yaml
+++ b/json-schema/request.yaml
@@ -523,6 +523,14 @@ definitions:
         items:
           type: string
           format: uri
+  DeviceBuild:
+    type: object
+    additionalProperties: false
+    required:
+      - build_id
+    properties:
+      build_id:
+        $ref: common.yaml#/definitions/uuid
   DeviceSetting:
     allOf:
       - $ref: /definitions/DeviceSettings

--- a/json-schema/request.yaml
+++ b/json-schema/request.yaml
@@ -107,6 +107,7 @@ definitions:
   RackAssignmentUpdates:
     type: array
     uniqueItems: true
+    minItems: 1
     items:
       $ref: /definitions/RackAssignmentUpdate
   RackAssignmentUpdate:
@@ -133,6 +134,7 @@ definitions:
   RackAssignmentDeletes:
     type: array
     uniqueItems: true
+    minItems: 1
     items:
       $ref: /definitions/RackAssignmentDelete
   RackAssignmentDelete:
@@ -694,6 +696,7 @@ definitions:
   BuildCreateDevices:
     type: array
     uniqueItems: true
+    minItems: 1
     items:
       type: object
       additionalProperties: false

--- a/json-schema/request.yaml
+++ b/json-schema/request.yaml
@@ -691,7 +691,7 @@ definitions:
         $ref: common.yaml#/definitions/uuid
       role:
         $ref: common.yaml#/definitions/role
-  BuildCreateDevice:
+  BuildCreateDevices:
     type: array
     uniqueItems: true
     items:

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -318,6 +318,11 @@ definitions:
     uniqueItems: true
     items:
       $ref: common.yaml#/definitions/uuid
+  DeviceSerials:
+    type: array
+    uniqueItems: true
+    items:
+      $ref: common.yaml#/definitions/device_serial_number
   Devices:
     type: array
     uniqueItems: true

--- a/lib/Conch/Controller/Build.pm
+++ b/lib/Conch/Controller/Build.pm
@@ -664,7 +664,7 @@ Requires the 'read/write' role on the build, and the 'read-only' role on the dev
 =cut
 
 sub create_and_add_devices ($c) {
-    my $input = $c->validate_request('BuildCreateDevice');
+    my $input = $c->validate_request('BuildCreateDevices');
     return if not $input;
 
     foreach my $entry ($input->@*) {

--- a/lib/Conch/Controller/Build.pm
+++ b/lib/Conch/Controller/Build.pm
@@ -614,8 +614,10 @@ not ORed):
         (can be used more than once to search for ANY of the specified health values)
     active_minutes=X    only devices last seen (via a report relay) within X minutes
     ids_only=1          only return device ids, not full data
+    serials_only=1      only return device serial numbers, not full data
 
-Response uses the Devices json schema, or DeviceIds iff C<ids_only=1>.
+Response uses the Devices json schema, or DeviceIds iff C<ids_only=1>, or DeviceSerials iff
+C<serials_only=1>.
 
 =cut
 
@@ -646,8 +648,8 @@ sub get_devices ($c) {
     $rs = $rs->search({ last_seen => { '>' => \[ 'now() - ?::interval', $params->{active_minutes}.' minutes' ] } })
         if $params->{active_minutes};
 
-    $rs = $params->{ids_only}
-        ? $rs->get_column('id')
+    $rs = $params->{ids_only} ? $rs->get_column('id')
+        : $params->{serials_only} ? $rs->get_column('serial_number')
         : $rs->with_device_location->with_sku;
 
     $c->status(200, [ $rs->all ]);

--- a/lib/Conch/Controller/WorkspaceDevice.pm
+++ b/lib/Conch/Controller/WorkspaceDevice.pm
@@ -25,8 +25,10 @@ not ORed):
         (can be used more than once to search for ANY of the specified health values)
     active_minutes=X  only devices last seen within X minutes
     ids_only=1      only return device ids, not full data
+    serials_only=1  only return device serial numbers, not full data
 
-Response uses the Devices json schema, or DeviceIds iff C<ids_only=1>.
+Response uses the Devices json schema, or DeviceIds iff C<ids_only=1>, or DeviceSerials iff
+C<serials_only=1>.
 
 =cut
 
@@ -52,8 +54,8 @@ sub list ($c) {
     $devices_rs = $devices_rs->search({ last_seen => { '>' => \[ 'now() - ?::interval', $params->{active_minutes}.' minutes' ] } })
         if $params->{active_minutes};
 
-    $devices_rs = $params->{ids_only}
-        ? $devices_rs->get_column('id')
+    $devices_rs = $params->{ids_only} ? $devices_rs->get_column('id')
+        : $params->{serials_only} ? $devices_rs->get_column('serial_number')
         : $devices_rs->with_device_location->with_sku;
 
     my @devices = $devices_rs->all;

--- a/lib/Conch/Route/Build.pm
+++ b/lib/Conch/Route/Build.pm
@@ -264,7 +264,7 @@ Accepts the following optional query parameters:
 =item * Requires system admin authorization, or the read/write role on the build and the
 read-only role on the device.
 
-=item * Request: F<request.yaml#/definitions/BuildCreateDevice>
+=item * Request: F<request.yaml#/definitions/BuildCreateDevices>
 
 =item * Response: C<204 NO CONTENT>
 

--- a/lib/Conch/Route/Build.pm
+++ b/lib/Conch/Route/Build.pm
@@ -253,7 +253,7 @@ Accepts the following optional query parameters:
 
 =item * Requires system admin authorization or the read-only role on the build
 
-=item * Response: response.yaml#/Devices
+=item * Response: F<response.yaml#/definitions/Devices>, F<response.yaml#/definitions/DeviceIds> or F<response.yaml#/definitions/DeviceSerials>
 
 =back
 

--- a/lib/Conch/Route/DatacenterRoom.pm
+++ b/lib/Conch/Route/DatacenterRoom.pm
@@ -27,16 +27,16 @@ sub routes {
     # POST /room
     $room->post('/')->to('#create');
 
-    my $with_datacenter_room = $room->under('/<datacenter_room_id:uuid>')
+    my $with_datacenter_room = $room->under('/:datacenter_room_id_or_alias')
         ->to('#find_datacenter_room');
 
-    # GET /room/:datacenter_room_id
+    # GET /room/:datacenter_room_id_or_alias
     $with_datacenter_room->get('/')->to('#get_one');
-    # POST /room/:datacenter_room_id
+    # POST /room/:datacenter_room_id_or_alias
     $with_datacenter_room->post('/')->to('#update');
-    # DELETE /room/:datacenter_room_id
+    # DELETE /room/:datacenter_room_id_or_alias
     $with_datacenter_room->delete('/')->to('#delete');
-    # GET /room/:datacenter_room_id/racks
+    # GET /room/:datacenter_room_id_or_alias/racks
     $with_datacenter_room->get('/racks')->to('#racks');
 }
 
@@ -69,7 +69,7 @@ Unless otherwise noted, all routes require authentication.
 
 =back
 
-=head3 C<GET /room/:datacenter_room_id>
+=head3 C<GET /room/:datacenter_room_id_or_alias>
 
 
 =over 4
@@ -80,7 +80,7 @@ Unless otherwise noted, all routes require authentication.
 
 =back
 
-=head3 C<POST /room/:datacenter_room_id>
+=head3 C<POST /room/:datacenter_room_id_or_alias>
 
 =over 4
 
@@ -92,7 +92,7 @@ Unless otherwise noted, all routes require authentication.
 
 =back
 
-=head3 C<DELETE /room/:datacenter_room_id>
+=head3 C<DELETE /room/:datacenter_room_id_or_alias>
 
 =over 4
 
@@ -102,7 +102,7 @@ Unless otherwise noted, all routes require authentication.
 
 =back
 
-=head3 C<GET /room/:datacenter_room_id/racks>
+=head3 C<GET /room/:datacenter_room_id_or_alias/racks>
 
 =over 4
 

--- a/lib/Conch/Route/Device.pm
+++ b/lib/Conch/Route/Device.pm
@@ -56,6 +56,8 @@ sub routes {
         $with_device->post('/links')->to('device#add_links');
         # DELETE /device/:device_id_or_serial_number/links
         $with_device->delete('/links')->to('device#remove_links');
+        # POST /device/:device_id_or_serial_number/build
+        $with_device->post('/build')->to('device#set_build');
 
         {
             my $with_device_location = $with_device_phase_earlier_than_prod->any('/location')
@@ -261,6 +263,18 @@ below.
 =item * User requires the read/write role
 
 =item * Response: 204 NO CONTENT
+
+=back
+
+=head3 C<POST /device/:device_id_or_serial_number/build>
+
+=over 4
+
+=item * User requires the read/write role for the device, as well as the old and new builds
+
+=item * Request: F<request.yaml#/definitions/DeviceBuild>
+
+=item * Response: Redirect to the updated device
 
 =back
 

--- a/lib/Conch/Route/Workspace.pm
+++ b/lib/Conch/Route/Workspace.pm
@@ -164,7 +164,7 @@ Accepts the following optional query parameters:
 
 =item * User requires the read-only role
 
-=item * Response: F<response.yaml#/definitions/Devices>
+=item * Response: F<response.yaml#/definitions/Devices>, F<response.yaml#/definitions/DeviceIds> or F<response.yaml#/definitions/DeviceSerials>
 
 =back
 

--- a/t/integration/crud/build.t
+++ b/t/integration/crud/build.t
@@ -698,10 +698,20 @@ $t->get_ok('/build/our second build/device?health=unknown')
     ->json_schema_is('Devices')
     ->json_is($devices);
 
+$t->get_ok('/build/our second build/device?ids_only=1&serials_only=1')
+    ->status_is(400)
+    ->json_schema_is('QueryParamsValidationError')
+    ->json_cmp_deeply('/details', [ { path => '/', message => re(qr{should not match}i) } ]);
+
 $t->get_ok('/build/our second build/device?ids_only=1')
     ->status_is(200)
     ->json_schema_is('DeviceIds')
     ->json_is([ $devices->[0]{id} ]);
+
+$t->get_ok('/build/our second build/device?serials_only=1')
+    ->status_is(200)
+    ->json_schema_is('DeviceSerials')
+    ->json_is([ $devices->[0]{serial_number} ]);
 
 $t->get_ok('/build/our second build/device?active_minutes=5')
     ->status_is(200)

--- a/t/integration/crud/rooms.t
+++ b/t/integration/crud/rooms.t
@@ -31,7 +31,17 @@ $t->get_ok('/room/'.$room->id)
     ->json_schema_is('DatacenterRoomDetailed')
     ->json_cmp_deeply(superhashof({ az => 'room-0a', alias => 'room 0a' }));
 
+$t->get_ok('/room/'.$room->alias)
+    ->status_is(200)
+    ->json_schema_is('DatacenterRoomDetailed')
+    ->json_cmp_deeply(superhashof({ az => 'room-0a', alias => 'room 0a' }));
+
 $t->get_ok('/room/'.$room->id.'/racks')
+    ->status_is(200)
+    ->json_schema_is('Racks')
+    ->json_cmp_deeply([ superhashof({ name => 'rack 0a' }) ]);
+
+$t->get_ok('/room/'.$room->alias.'/racks')
     ->status_is(200)
     ->json_schema_is('Racks')
     ->json_cmp_deeply([ superhashof({ name => 'rack 0a' }) ]);

--- a/t/integration/crud/workspace-devices.t
+++ b/t/integration/crud/workspace-devices.t
@@ -113,10 +113,20 @@ $t->get_ok("/workspace/$global_ws_id/device?health=bunk")
     ->json_schema_is('QueryParamsValidationError')
     ->json_cmp_deeply('/details', [ { path => '/health', message => re(qr/not in enum list/i) } ]);
 
+$t->get_ok("/workspace/$global_ws_id/device?ids_only=1&serials_only=1")
+    ->status_is(400)
+    ->json_schema_is('QueryParamsValidationError')
+    ->json_cmp_deeply('/details', [ { path => '/', message => re(qr{should not match}i) } ]);
+
 $t->get_ok("/workspace/$global_ws_id/device?ids_only=1")
     ->status_is(200)
     ->json_schema_is('DeviceIds')
     ->json_is([$devices[0]->id, $devices[1]->id]);
+
+$t->get_ok("/workspace/$global_ws_id/device?serials_only=1")
+    ->status_is(200)
+    ->json_schema_is('DeviceSerials')
+    ->json_is([$devices[0]->serial_number, $devices[1]->serial_number]);
 
 $t->get_ok("/workspace/$global_ws_id/device?ids_only=1&health=pass")
     ->status_is(200)


### PR DESCRIPTION
Adds new functionality to existing endpoints:
- all /room/* endponts can now also use room 'alias' in the path
- add ?serials_only to multi-device endpoints

Add `POST /device/:id_or_serial/build` for #931.
