### PR TITLE
v3 b2 moar fixes

### DIFF
--- a/docs/modules/Conch::Controller::Device.md
+++ b/docs/modules/Conch::Controller::Device.md
@@ -22,8 +22,9 @@ Retrieves details about a single device. Response uses the DetailedDevice json s
 **Note:** The results of this endpoint can be cached, but since the checksum is based only on
 the device's last updated time, and not on any other components associated with it (disks,
 network interfaces, location etc) it is only suitable for using to determine if a subsequent
-device report has been submitted for this device. Updates to the device through other means may
-not be reflected in the checksum.
+device report has been submitted for this device (or columns directly on the device have been
+updated). Updates to the device through other means (such as changing its location) may not be
+reflected in the checksum.
 
 ## lookup\_by\_other\_attribute
 

--- a/lib/Conch/Controller/Device.pm
+++ b/lib/Conch/Controller/Device.pm
@@ -123,8 +123,9 @@ Retrieves details about a single device. Response uses the DetailedDevice json s
 B<Note:> The results of this endpoint can be cached, but since the checksum is based only on
 the device's last updated time, and not on any other components associated with it (disks,
 network interfaces, location etc) it is only suitable for using to determine if a subsequent
-device report has been submitted for this device. Updates to the device through other means may
-not be reflected in the checksum.
+device report has been submitted for this device (or columns directly on the device have been
+updated). Updates to the device through other means (such as changing its location) may not be
+reflected in the checksum.
 
 =cut
 

--- a/lib/Conch/Plugin/ClientVerification.pm
+++ b/lib/Conch/Plugin/ClientVerification.pm
@@ -32,11 +32,11 @@ sub register ($self, $app, $config) {
                 return $c->status(403);
             }
         }
-        elsif ($user_agent =~ /^conch shell/) {
+        elsif ($user_agent and $user_agent =~ /^conch shell/) {
             $c->log->error('Conch Shell too old');
             return $c->status(403);
         }
-        elsif ($user_agent =~ /^Conch\/((\d+)\.(\d+)\.(\d+)) /) {
+        elsif ($user_agent and $user_agent =~ /^Conch\/((\d+)\.(\d+)\.(\d+)) /) {
             my ($all, $major, $minor, $rest) = ($1, $2, $3, $4);
             if ($all eq '0.0.0' or $major < 3) {
                 $c->log->error('Conch Shell too old');

--- a/lib/Conch/Plugin/Mail.pm
+++ b/lib/Conch/Plugin/Mail.pm
@@ -82,7 +82,6 @@ sub register ($self, $app, $config) {
 
         my $email = compose_message($c, %args);
         my $log = $c->log;
-        my $rollbar_sender = sub ($e) { $c->send_exception_to_rollbar($e) };
         my $request_id = length($c->req->url) ? $c->req->request_id : undef;
 
         Mojo::IOLoop->subprocess(
@@ -101,7 +100,7 @@ sub register ($self, $app, $config) {
                 }
                 catch {
                     my $exception = $_;
-                    $rollbar_sender->(Mojo::Exception->new($exception));
+                    $c->send_exception_to_rollbar(Mojo::Exception->new($exception));
                     die $exception->$_can('message') ? $exception->message."\n" : $exception;
                 };
 

--- a/lib/Test/Conch.pm
+++ b/lib/Test/Conch.pm
@@ -633,7 +633,7 @@ sub log_is ($self, $expected_msg, $test_name = 'log line', $level = undef) {
         ]),
         $test_name,
     );
-    Test::More::note('got log: ',
+    Test::More::diag('got log: ',
             Data::Dumper->new([ $self->app->log->history ])->Sortkeys(1)->Terse(1)->Dump)
         if not $self->success;
     return $self;
@@ -700,7 +700,7 @@ sub logs_are ($self, $expected_msgs, $test_name = 'log lines', $level = undef) {
         ),
         $test_name,
     );
-    Test::More::note('got log: ',
+    Test::More::diag('got log: ',
             Data::Dumper->new([ $self->app->log->history ])->Sortkeys(1)->Terse(1)->Dump)
         if not $self->success;
     return $self;

--- a/lib/Test/Conch.pm
+++ b/lib/Test/Conch.pm
@@ -109,7 +109,7 @@ sub new {
 
             secrets => ['********'],
             features => { audit => 1, no_db => ($pg ? 0 : 1) },
-            log => { max_history_size => 50 },
+            logging => { max_history_size => 50 },
 
             $args->{config} ? delete($args->{config})->%* : (),
         }

--- a/t/conch-rollbar.t
+++ b/t/conch-rollbar.t
@@ -545,7 +545,10 @@ $t->do_and_wait_for_event(
             $payload->{data}{body},
             {
                 message => {
-                    body => 'payload contains 5 elements: candidate for paging?',
+                    body => 'response payload contains many elements: candidate for paging?',
+                    elements => 5,
+                    action => undef,
+                    url => '/_long_response',
                 },
             },
             'got alert about long response',
@@ -581,7 +584,10 @@ $t->do_and_wait_for_event(
             $payload->{data}{body},
             {
                 message => {
-                    body => 'payload is 201 bytes: candidate for paging or refactoring?',
+                    body => 'response payload size is large: candidate for paging or refactoring?',
+                    bytes => 201,
+                    action => undef,
+                    url => '/_large_response',
                 },
             },
             'got alert about large response',


### PR DESCRIPTION
small fixes for v3.0.0-b2.

- handle absence of User-Agent header
- doc fixes
- nicer rollbar message payloads
- fix test logger history size (as seen on new-buildbot with a different kind of random)