### PR TITLE
v2.37.3 fixes

### DIFF
--- a/docs/modules/Conch.md
+++ b/docs/modules/Conch.md
@@ -15,6 +15,10 @@ Mojolicious::Commands->start_app('Conch');
 Used by Mojo in the startup process. Loads the config file and sets up the
 helpers, routes and everything else.
 
+## startup\_time
+
+Stores a [Conch::Time](/modules/Conch%3A%3ATime) instance representing the time the server started accepting requests.
+
 # LICENSING
 
 Copyright Joyent, Inc.

--- a/docs/modules/Conch::Time.md
+++ b/docs/modules/Conch::Time.md
@@ -31,7 +31,7 @@ Conch::Time->new($pg_timestamptz);
 my $t = Conch::Time->now;
 ```
 
-Return an object based on the current time.
+Return an object based on the current time, using the UTC timezone.
 
 Time are high resolution and will generate unique timestamps to the
 nanosecond.
@@ -52,7 +52,7 @@ See also ["from\_epoch" in Time::Moment](https://metacpan.org/pod/Time::Moment#f
 
 ### rfc3339
 
-Return an RFC3339 compatible string.
+Return an RFC3339 compatible string as UTC.
 Sub-second precision will use 3, 6 or 9 digits as necessary.
 
 ### timestamp

--- a/lib/Conch.pm
+++ b/lib/Conch.pm
@@ -147,6 +147,15 @@ sub startup {
     $self->plugin(NYTProf => $self->config) if $self->feature('nytprof');
     $self->plugin('Conch::Plugin::Rollbar', $self->config) if $self->feature('rollbar');
 
+=head2 startup_time
+
+Stores a L<Conch::Time> instance representing the time the server started accepting requests.
+
+=cut
+
+    my $startup_time = Conch::Time->now;
+    $self->helper(startup_time => sub ($c) { $startup_time });
+
     push $self->commands->namespaces->@*, 'Conch::Command';
 
     Conch::ValidationSystem->new(log => $self->log, schema => $self->ro_schema)

--- a/lib/Conch/Command/create_user.pm
+++ b/lib/Conch/Command/create_user.pm
@@ -56,10 +56,11 @@ sub run ($self, @opts) {
         return;
     }
 
+    my $password = $opt->password // $self->app->random_string;
     my $user = $self->app->db_user_accounts->create({
         name => $opt->name,
         email => $opt->email,
-        password => $opt->password // $self->app->random_string, # will be hashed in constructor
+        password => $password, # will be hashed in constructor
     });
     my $user_id = $user->id;
 
@@ -72,7 +73,7 @@ sub run ($self, @opts) {
             template_file => 'new_user_account',
             From => 'noreply@conch.joyent.us',
             Subject => 'Welcome to Conch!',
-            password => $opt->password,
+            password => $password,
         );
 
         Mojo::IOLoop->start unless Mojo::IOLoop->is_running;

--- a/lib/Conch/Command/create_user.pm
+++ b/lib/Conch/Command/create_user.pm
@@ -21,6 +21,8 @@ use open ':std', ':encoding(UTF-8)'; # force stdin, stdout, stderr into utf8
 use Mojo::Base 'Mojolicious::Command', -signatures;
 use Getopt::Long::Descriptive;
 use Encode ();
+use Email::Valid;
+use JSON::Validator::Formats;
 
 has description => 'Create a new user';
 
@@ -43,6 +45,11 @@ sub run ($self, @opts) {
         [],
         [ 'help',           'print usage message and exit', { shortcircuit => 1 } ],
     );
+
+    if (JSON::Validator::Formats::check_email($opt->email) or not Email::Valid->address($opt->email)) {
+        say 'cannot create user: email '.$opt->email.' is not a valid RFC822+RFC5322 address';
+        return;
+    }
 
     if ($self->app->db_user_accounts->active->search(\[ 'lower(email) = lower(?)', $opt->email ])->exists) {
         say 'cannot create user: email '.$opt->email.' already exists';

--- a/lib/Conch/Controller/User.pm
+++ b/lib/Conch/Controller/User.pm
@@ -309,6 +309,9 @@ sub update ($c) {
     my $input = $c->validate_input('UpdateUser');
     return if not $input;
 
+    return $c->status(400, { error => 'user email "'.$input->{email}.'" is not a valid RFC822 address' })
+        if exists $input->{email} and not Email::Valid->address($input->{email});
+
     my $user = $c->stash('target_user');
     my %orig_columns = $user->get_columns;
     $user->set_columns($input);
@@ -378,6 +381,9 @@ Response uses the NewUser json schema (or UserError for some error conditions).
 sub create ($c) {
     my $input = $c->validate_input('NewUser');
     return if not $input;
+
+    return $c->status(400, { error => 'user email "'.$input->{email}.'" is not a valid RFC822 address' })
+        if not Email::Valid->address($input->{email});
 
     my $name = $input->{name} // $input->{email};
     my $email = $input->{email};

--- a/lib/Conch/DB/Util.pm
+++ b/lib/Conch/DB/Util.pm
@@ -225,6 +225,7 @@ sub create_validation_plans ($schema, $log = Mojo::Log->new) {
                         Conch::Validation::RaidLunNum
                         Conch::Validation::SataHddNum
                         Conch::Validation::SataSsdNum
+                        Conch::Validation::HddSize
                     )
             ],
         },

--- a/lib/Conch/DB/Util.pm
+++ b/lib/Conch/DB/Util.pm
@@ -221,6 +221,10 @@ sub create_validation_plans ($schema, $log = Mojo::Log->new) {
                         Conch::Validation::SlogSlot
                         Conch::Validation::SwitchPeers
                         Conch::Validation::UsbHddNum
+                        Conch::Validation::NvmeSsdNum
+                        Conch::Validation::RaidLunNum
+                        Conch::Validation::SataHddNum
+                        Conch::Validation::SataSsdNum
                     )
             ],
         },

--- a/lib/Conch/Route.pm
+++ b/lib/Conch/Route.pm
@@ -59,7 +59,10 @@ sub all_routes (
     $root->get('/ping', sub ($c) { $c->status(200, { status => 'ok' }) });
 
     # GET /version
-    $root->get('/version', sub ($c) { $c->status(200, { version => $c->version_tag }) });
+    $root->get('/version', sub ($c) {
+        $c->res->headers->last_modified(Mojo::Date->new($c->startup_time->epoch));
+        $c->status(200, { version => $c->version_tag })
+    });
 
     # POST /login
     $root->post('/login')->to('login#session_login');

--- a/lib/Conch/Time.pm
+++ b/lib/Conch/Time.pm
@@ -49,12 +49,14 @@ sub new {
 
     my $t = Conch::Time->now;
 
-Return an object based on the current time.
+Return an object based on the current time, using the UTC timezone.
 
 Time are high resolution and will generate unique timestamps to the
 nanosecond.
 
 =cut
+
+sub now { return shift->now_utc }
 
 =head2 from_epoch
 
@@ -72,14 +74,13 @@ See also L<Time::Moment/from_epoch>.
 
 =head3 rfc3339
 
-Return an RFC3339 compatible string.
+Return an RFC3339 compatible string as UTC.
 Sub-second precision will use 3, 6 or 9 digits as necessary.
 
 =cut
 
 sub rfc3339 {
-    my $self = shift;
-    return $self->strftime('%Y-%m-%dT%H:%M:%S.%N%Z');
+    return shift->at_utc->strftime('%Y-%m-%dT%H:%M:%S.%N%Z');
 }
 
 =head3 timestamp

--- a/lib/Conch/Validation/SataSsdNum.pm
+++ b/lib/Conch/Validation/SataSsdNum.pm
@@ -26,7 +26,7 @@ sub validate {
     # Intel SATA SSDs and there's no other identifier. Here, we want
     # to avoid missing failed/missing disks, so we jump through a couple
     # extra hoops.
-    if ($self->hardware_product_name eq "Joyent-Compute-Platform-3302") {
+    if ($self->hardware_legacy_product_name // '' eq "Joyent-Compute-Platform-3302") {
         if ($sata_ssd_count <= 8) { $sata_ssd_want = 8; }
         if ($sata_ssd_count > 8)  { $sata_ssd_want = 16; }
     }

--- a/t/conch_log.t
+++ b/t/conch_log.t
@@ -422,7 +422,9 @@ sub add_test_routes ($t) {
                         {
                             class => 'main',
                             file => __FILE__,
-                            func => re('__ANON__'),
+                            # later versions of Mojolicious::Exception, such as those installed
+                            # via a v3 build, have changed the format of this frame
+                            func => Mojolicious->VERSION > '8.15' ? ignore : re('__ANON__'),
                             line => $lines{die},
                         },
                     ),
@@ -617,7 +619,9 @@ sub add_test_routes ($t) {
                         {
                             class => 'main',
                             file => __FILE__,
-                            func => re('__ANON__'),
+                            # later versions of Mojolicious::Exception, such as those installed
+                            # via a v3 build, have changed the format of this frame
+                            func => Mojolicious->VERSION > '8.15' ? ignore : re('__ANON__'),
                             line => $lines{die},
                         },
                     ),

--- a/t/conch_time.t
+++ b/t/conch_time.t
@@ -69,23 +69,28 @@ subtest 'Test parsing of timestamps' => sub {
         },
         {
             input    => '2018-01-02 00:00:00+01',
-            expected => '2018-01-02T00:00:00.000+01:00',
-            message  => 'Appends :00 to positive timezones that do not specify minutes'
+            expected => '2018-01-01T23:00:00.000Z',
+            message  => 'Positive timezone converted to UTC with positive offset',
         },
         {
             input    => '2018-01-02 00:00:00-01',
-            expected => '2018-01-02T00:00:00.000-01:00',
-            message  => 'Appends :00 to negative timezones that do not specify minutes'
+            expected => '2018-01-02T01:00:00.000Z',
+            message  => 'Negative timezone converted to UTC with negative offset',
         },
         {
             input    => '2018-01-02 00:00:00+01:20',
-            expected => '2018-01-02T00:00:00.000+01:20',
-            message  => 'Does not modify timezones that specify minutes'
+            expected => '2018-01-01T22:40:00.000Z',
+            message  => 'Positive timezone with minutes converted to UTC with positive offset',
         },
         {
             input    => '2018-01-02 00:00:00+00:20',
-            expected => '2018-01-02T00:00:00.000+00:20',
-            message  => 'Does not modify 00 timezones that specify minutes'
+            expected => '2018-01-01T23:40:00.000Z',
+            message  => 'Positive timezone with minutes converted to UTC with positive offset',
+        },
+        {
+            input    => '2018-01-02 00:00:00-01:20',
+            expected => '2018-01-02T01:20:00.000Z',
+            message  => 'Negative timezone with minutes converted to UTC with negative offset',
         },
     );
 

--- a/t/integration/crud/unsecured-endpoints.t
+++ b/t/integration/crud/unsecured-endpoints.t
@@ -16,6 +16,7 @@ $t->get_ok('/ping')
 
 $t->get_ok('/version')
     ->status_is(200)
+    ->header_is('Last-Modified', $t->app->startup_time->strftime('%a, %d %b %Y %T GMT'))
     ->json_schema_is('Version')
     ->json_cmp_deeply({ version => re(qr/^v/) });
 

--- a/t/validations/sata_ssd_num_v1.t
+++ b/t/validations/sata_ssd_num_v1.t
@@ -75,7 +75,7 @@ test_validation(
 test_validation(
     'Conch::Validation::SataSsdNum',
     hardware_product => {
-        name    => 'Joyent-Compute-Platform-3302',
+        legacy_product_name => 'Joyent-Compute-Platform-3302',
         hardware_product_profile => { sata_ssd_num => 2 }
     },
     cases => [


### PR DESCRIPTION
All these fixes have been or will also be made in v3.

- proxy Conch::Time->now to now_utc; stringify all times as UTC (needed for tests to work properly)
- include a Last-Modified header with GET /version
- merge inconsistent email format checks, in create_user command too
- fix: the user was not receiving the password if it was randomly-generated
- fix: add <drive>Num validations when creating new server plan
- fix: add new HddSize validation when creating new server plan
- fix: wrong hardware_product field was being checked for this legacy product
