### PR TITLE
v3-b3 build endpoint revisions

### DIFF
--- a/docs/json-schema/request.json
+++ b/docs/json-schema/request.json
@@ -865,6 +865,9 @@
         "asset_tag" : {
           "$ref" : "common.json#/definitions/non_empty_string"
         },
+        "build_id" : {
+          "$ref" : "common.json#/definitions/uuid"
+        },
         "datacenter_room_id" : {
           "$ref" : "common.json#/definitions/uuid"
         },
@@ -884,7 +887,8 @@
       "required" : [
         "name",
         "datacenter_room_id",
-        "rack_role_id"
+        "rack_role_id",
+        "build_id"
       ],
       "type" : "object"
     },
@@ -999,6 +1003,9 @@
               "$ref" : "common.json#/definitions/non_empty_string"
             }
           ]
+        },
+        "build_id" : {
+          "$ref" : "common.json#/definitions/uuid"
         },
         "datacenter_room_id" : {
           "$ref" : "common.json#/definitions/uuid"

--- a/docs/modules/Conch::Controller::Build.md
+++ b/docs/modules/Conch::Controller::Build.md
@@ -144,10 +144,6 @@ Adds the specified rack to the build (removing it from its previous build).
 
 Requires the 'read/write' role on the build.
 
-## remove\_rack
-
-Requires the 'read/write' role on the build.
-
 # LICENSING
 
 Copyright Joyent, Inc.

--- a/docs/modules/Conch::Controller::Build.md
+++ b/docs/modules/Conch::Controller::Build.md
@@ -113,16 +113,15 @@ Response uses the Devices json schema, or DeviceIds iff `ids_only=1`, or DeviceS
 
 ## create\_and\_add\_devices
 
-Adds the specified device to the build (as long as it isn't in another build, or located in a
-rack in another build).  The device is created if necessary with all data provided (or updated
-with the data if it already exists, so the endpoint is idempotent).
+Adds the specified device to the build (removing it from its previous build).  The device is
+created if necessary with all data provided (or updated with the data if it already exists, so
+the endpoint is idempotent).
 
 Requires the 'read/write' role on the build, and the 'read-only' role on the device.
 
 ## add\_device
 
-Adds the specified device to the build (as long as it isn't in another build, or located in a
-rack in another build).
+Adds the specified device to the build (removing it from its previous build).
 
 Requires the 'read/write' role on the build, and the 'read-only' role on the device.
 
@@ -141,8 +140,7 @@ Response uses the Racks json schema.
 
 ## add\_rack
 
-Adds the specified rack to the build (as long as it isn't in another build, or contains devices
-located in another build).
+Adds the specified rack to the build (removing it from its previous build).
 
 Requires the 'read/write' role on the build.
 

--- a/docs/modules/Conch::Controller::Build.md
+++ b/docs/modules/Conch::Controller::Build.md
@@ -113,17 +113,17 @@ Response uses the Devices json schema, or DeviceIds iff `ids_only=1`, or DeviceS
 
 ## create\_and\_add\_devices
 
-Adds the specified device to the build (removing it from its previous build).  The device is
-created if necessary with all data provided (or updated with the data if it already exists, so
-the endpoint is idempotent).
+Adds the specified device(s) to the build (removing them from their previous builds). The
+device is created if necessary with all data provided (or updated with the data if it already
+exists, so the endpoint is idempotent).
 
-Requires the 'read/write' role on the build, and the 'read-only' role on the device.
+Requires the 'read/write' role on the build and on existing device(s).
 
 ## add\_device
 
 Adds the specified device to the build (removing it from its previous build).
 
-Requires the 'read/write' role on the build, and the 'read-only' role on the device.
+Requires the 'read/write' role on the build and on the device.
 
 ## remove\_device
 
@@ -142,7 +142,7 @@ Response uses the Racks json schema.
 
 Adds the specified rack to the build (removing it from its previous build).
 
-Requires the 'read/write' role on the build.
+Requires the 'read/write' role on the build and on the rack.
 
 # LICENSING
 

--- a/docs/modules/Conch::Controller::Build.md
+++ b/docs/modules/Conch::Controller::Build.md
@@ -92,7 +92,9 @@ to all organization members and to all build admins.
 
 ## get\_devices
 
-Get the devices in this build.  (Includes devices located in rack(s) in this build.)
+Get the devices in this build. (Does not includes devices located in rack(s) in this build if
+the devices themselves are in other builds.)
+
 Requires the 'read-only' role on the build.
 
 Supports these query parameters to constrain results (which are ANDed together for the search,

--- a/docs/modules/Conch::Route::Build.md
+++ b/docs/modules/Conch::Route::Build.md
@@ -123,11 +123,6 @@ read-only role on the device (via a workspace or build or a relay registration, 
 read-only role on a workspace or build that contains the rack
 - Response: `204 NO CONTENT`
 
-### `DELETE /build/:build_id_or_name/rack/:rack_id`
-
-- Requires system admin authorization, or the read/write role on the build
-- Response: `204 NO CONTENT`
-
 # LICENSING
 
 Copyright Joyent, Inc.

--- a/docs/modules/Conch::Route::Build.md
+++ b/docs/modules/Conch::Route::Build.md
@@ -96,15 +96,15 @@ Accepts the following optional query parameters:
 ### `POST /build/:build_id_or_name/device`
 
 - Requires system admin authorization, or the read/write role on the build and the
-read-only role on the device.
+read-write role on existing device(s) (via a workspace or build; see
+["routes" in Conch::Route::Device](../modules/Conch%3A%3ARoute%3A%3ADevice#routes))
 - Request: [request.json#/definitions/BuildCreateDevices](../json-schema/request.json#/definitions/BuildCreateDevices)
 - Response: `204 NO CONTENT`
 
 ### `POST /build/:build_id_or_name/device/:device_id_or_serial_number`
 
 - Requires system admin authorization, or the read/write role on the build and the
-read-only role on the device (via a workspace or build or a relay registration, see
-["routes" in Conch::Route::Device](../modules/Conch%3A%3ARoute%3A%3ADevice#routes))
+read-write role on the device (via a workspace or build; see ["routes" in Conch::Route::Device](../modules/Conch%3A%3ARoute%3A%3ADevice#routes))
 - Response: `204 NO CONTENT`
 
 ### `DELETE /build/:build_id_or_name/device/:device_id_or_serial_number`
@@ -120,7 +120,7 @@ read-only role on the device (via a workspace or build or a relay registration, 
 ### `POST /build/:build_id_or_name/rack/:rack_id`
 
 - Requires system admin authorization, or the read/write role on the build and the
-read-only role on a workspace or build that contains the rack
+read-write role on a workspace or build that contains the rack
 - Response: `204 NO CONTENT`
 
 # LICENSING

--- a/json-schema/request.yaml
+++ b/json-schema/request.yaml
@@ -70,6 +70,7 @@ definitions:
       - name
       - datacenter_room_id
       - rack_role_id
+      - build_id
     properties:
       name:
         $ref: common.yaml#/definitions/non_empty_string
@@ -83,6 +84,8 @@ definitions:
         $ref: common.yaml#/definitions/non_empty_string
       phase:
         $ref: common.yaml#/definitions/device_phase
+      build_id:
+        $ref: common.yaml#/definitions/uuid
   RackUpdate:
     type: object
     additionalProperties: false
@@ -104,6 +107,8 @@ definitions:
           - $ref: common.yaml#/definitions/non_empty_string
       phase:
         $ref: common.yaml#/definitions/device_phase
+      build_id:
+        $ref: common.yaml#/definitions/uuid
   RackAssignmentUpdates:
     type: array
     uniqueItems: true

--- a/lib/Conch/Controller/Build.pm
+++ b/lib/Conch/Controller/Build.pm
@@ -704,7 +704,7 @@ sub create_and_add_devices ($c) {
         foreach my $entry ($input->@*) {
             if (not $hardware_products{$entry->{sku}}) {
                 $c->log->error('no hardware_product corresponding to sku '.$entry->{sku});
-                $code = 404;
+                ($code, $payload) = (404, { error => 'no hardware_product corresponding to sku '.$entry->{sku} });
                 die 'rollback';
             }
 
@@ -714,8 +714,7 @@ sub create_and_add_devices ($c) {
                     if (($device->build_id and $device->build_id ne $build_id)
                         or ($device->device_location and $device->device_location->rack->build_id
                             and $device->device_location->rack->build_id ne $build_id)) {
-                        $code = 409;
-                        $payload = { error => 'device '.($entry->{serial_number} // $entry->{id}).' not in build '.$c->stash('build_id_or_name') };
+                        ($code, $payload) = (409, { error => 'device '.($entry->{serial_number} // $entry->{id}).' not in build '.$c->stash('build_id_or_name') });
                         die 'rollback';
                     }
 
@@ -732,7 +731,7 @@ sub create_and_add_devices ($c) {
                 }
                 else {
                     $c->log->error('no device corresponding to device id '.$entry->{id});
-                    $code = 404;
+                    ($code, $payload) = (404, { error => 'no device corresponding to device id '.$entry->{id} });
                     die 'rollback';
                 }
             }

--- a/lib/Conch/Controller/Build.pm
+++ b/lib/Conch/Controller/Build.pm
@@ -830,6 +830,8 @@ sub add_rack ($c) {
     # TODO: check other constraints..
     # - what if the build is completed?
     # - what about device.phase or rack.phase?
+    # - build_id can also change via POST /rack/:id (so copy the checks there or
+    # remove that functionality)
 
     $c->log->debug('adding rack '.$rack->id.' to build '.$c->stash('build_id_or_name'));
     $rack->update({ build_id => $build_id, updated => \'now()' });

--- a/lib/Conch/Controller/Build.pm
+++ b/lib/Conch/Controller/Build.pm
@@ -836,28 +836,6 @@ sub add_rack ($c) {
     return $c->status(204);
 }
 
-=head2 remove_rack
-
-Requires the 'read/write' role on the build.
-
-=cut
-
-sub remove_rack ($c) {
-    my $rs = $c->stash('build_rs')->search_related('racks', { 'racks.id' => $c->stash('rack_id') });
-    if (not $rs->exists) {
-        $c->log->warn('rack '.$c->stash('rack_id').' is not in build '.$c->stash('build_id_or_name').': cannot remove');
-        return $c->status(404);
-    }
-
-    # TODO: check other constraints..
-    # - what if the build is completed?
-    # - what about device.phase or rack.phase?
-
-    $c->log->debug('removing rack '.$c->stash('rack_id').' from build '.$c->stash('build_id_or_name'));
-    $c->stash('rack_rs')->update({ build_id => undef, updated => \'now()' });
-    return $c->status(204);
-}
-
 1;
 __END__
 

--- a/lib/Conch/Controller/Device.pm
+++ b/lib/Conch/Controller/Device.pm
@@ -67,9 +67,9 @@ sub find_device ($c) {
         # HEAD, GET requires 'ro'; everything else (for now) requires 'rw'
         my $method = $c->req->method;
         my $requires_role = $c->stash('require_role') //
-            (any { $method eq $_ } qw(HEAD GET)) ? 'ro'
+           ((any { $method eq $_ } qw(HEAD GET)) ? 'ro'
           : (any { $method eq $_ } qw(POST PUT DELETE)) ? 'rw'
-          : die 'need handling for '.$method.' method';
+          : die 'need handling for '.$method.' method');
 
         last CHECK_ACCESS if $requires_role eq 'none';
 

--- a/lib/Conch/Controller/Rack.pm
+++ b/lib/Conch/Controller/Rack.pm
@@ -64,6 +64,10 @@ sub create ($c) {
         return $c->status(409, { error => 'Rack role does not exist' });
     }
 
+    if (not $c->db_builds->search({ id => $input->{build_id} })->exists) {
+        return $c->status(409, { error => 'Build does not exist' });
+    }
+
     if ($c->db_racks->search({ datacenter_room_id => $input->{datacenter_room_id}, name => $input->{name} })->exists) {
         return $c->status(409, { error => 'The room already contains a rack named '.$input->{name} });
     }
@@ -227,6 +231,10 @@ sub update ($c) {
         if ($c->db_racks->search({ datacenter_room_id => $rack->datacenter_room_id, name => $input->{name} })->exists) {
             return $c->status(409, { error => 'The room already contains a rack named '.($input->{name} // $rack->name) });
         }
+    }
+
+    if ($input->{build_id} and not $c->db_builds->search({ id => $input->{build_id} })->exists) {
+        return $c->status(409, { error => 'Build does not exist' });
     }
 
     # prohibit shrinking rack_size if there are layouts that extend beyond it

--- a/lib/Conch/Controller/Rack.pm
+++ b/lib/Conch/Controller/Rack.pm
@@ -32,9 +32,9 @@ sub find_rack ($c) {
     # HEAD, GET requires 'ro'; everything else (for now) requires 'rw'
     my $method = $c->req->method;
     my $requires_role = $c->stash('require_role') //
-        (any { $method eq $_ } qw(HEAD GET)) ? 'ro'
+       ((any { $method eq $_ } qw(HEAD GET)) ? 'ro'
       : (any { $method eq $_ } qw(POST PUT DELETE)) ? 'rw'
-      : die 'need handling for '.$method.' method';
+      : die 'need handling for '.$method.' method');
 
     if (not $c->is_system_admin and not $rack_rs->user_has_role($c->stash('user_id'), $requires_role)) {
         $c->log->debug('User lacks the required role ('.$requires_role.') for rack '.$c->stash('rack_id'));

--- a/lib/Conch/Route/Build.pm
+++ b/lib/Conch/Route/Build.pm
@@ -95,11 +95,6 @@ sub routes {
         $with_build_rw->under('/rack/<rack_id:uuid>')
             ->to('rack#find_rack', require_role => 'ro')
             ->post('/')->to('build#add_rack');
-
-        # DELETE /build/:build_id_or_name/rack/:rack_id
-        $with_build_rw->under('/rack/<rack_id:uuid>')
-            ->to('rack#find_rack', require_role => 'none')
-            ->delete('/')->to('build#remove_rack');
     }
 }
 
@@ -308,16 +303,6 @@ L<Conch::Route::Device/routes>)
 
 =item * Requires system admin authorization, or the read/write role on the build and the
 read-only role on a workspace or build that contains the rack
-
-=item * Response: C<204 NO CONTENT>
-
-=back
-
-=head3 C<DELETE /build/:build_id_or_name/rack/:rack_id>
-
-=over 4
-
-=item * Requires system admin authorization, or the read/write role on the build
 
 =item * Response: C<204 NO CONTENT>
 

--- a/lib/Conch/Route/Build.pm
+++ b/lib/Conch/Route/Build.pm
@@ -80,7 +80,7 @@ sub routes {
 
         # POST /build/:build_id_or_name/device/:device_id_or_serial_number
         $with_build_rw->under('/device/:device_id_or_serial_number')
-            ->to('device#find_device', require_role => 'ro')
+            ->to('device#find_device', require_role => 'rw')
             ->post('/')->to('build#add_device');
 
         # DELETE /build/:build_id_or_name/device/:device_id_or_serial_number
@@ -93,7 +93,7 @@ sub routes {
 
         # POST /build/:build_id_or_name/rack/:rack_id
         $with_build_rw->under('/rack/<rack_id:uuid>')
-            ->to('rack#find_rack', require_role => 'ro')
+            ->to('rack#find_rack', require_role => 'rw')
             ->post('/')->to('build#add_rack');
     }
 }
@@ -257,7 +257,8 @@ Accepts the following optional query parameters:
 =over 4
 
 =item * Requires system admin authorization, or the read/write role on the build and the
-read-only role on the device.
+read-write role on existing device(s) (via a workspace or build; see
+L<Conch::Route::Device/routes>)
 
 =item * Request: F<request.yaml#/definitions/BuildCreateDevices>
 
@@ -270,8 +271,7 @@ read-only role on the device.
 =over 4
 
 =item * Requires system admin authorization, or the read/write role on the build and the
-read-only role on the device (via a workspace or build or a relay registration, see
-L<Conch::Route::Device/routes>)
+read-write role on the device (via a workspace or build; see L<Conch::Route::Device/routes>)
 
 =item * Response: C<204 NO CONTENT>
 
@@ -302,7 +302,7 @@ L<Conch::Route::Device/routes>)
 =over 4
 
 =item * Requires system admin authorization, or the read/write role on the build and the
-read-only role on a workspace or build that contains the rack
+read-write role on a workspace or build that contains the rack
 
 =item * Response: C<204 NO CONTENT>
 

--- a/lib/Test/Conch/Fixtures.pm
+++ b/lib/Test/Conch/Fixtures.pm
@@ -292,6 +292,22 @@ sub generate_set ($self, $set_name, @args) {
                     "sub_workspace_$num" => { our => 'workspace_id', their => 'id' },
                 },
             },
+            "build_$num" => {
+                new => 'build',
+                using => {
+                    name => "build_$num",
+                },
+            },
+            "user_build_role_${num}_admin" => {
+                new => 'user_build_role',
+                using => {
+                    role => 'admin',
+                },
+                requires => {
+                    super_user => { our => 'user_id', their => 'id' },
+                    "build_$num" => { our => 'build_id', their => 'id' },
+                },
+            },
             "datacenter_$num" => {
                 new => 'datacenter',
                 using => {
@@ -333,6 +349,7 @@ sub generate_set ($self, $set_name, @args) {
                 requires => {
                     "datacenter_room_${num}a" => { our => 'datacenter_room_id', their => 'id' },
                     rack_role_42u => { our => 'rack_role_id', their => 'id' },
+                    "build_$num" => { our => 'build_id', their => 'id' },
                     # declare dependency for the all_racks_in_global_workspace trigger to run
                     # This is a hack: should be able to specify requirements without copying values.
                     global_workspace => { our => 'asset_tag', their => 'name' },
@@ -663,6 +680,7 @@ sub _generate_definition ($self, $fixture_type, $num, $specification) {
                 },
             },
         };
+        # TODO: not declaring an admin user; some GET queries may fail json schema validation
     }
     elsif ($fixture_type eq 'build') {
         return +{
@@ -674,6 +692,7 @@ sub _generate_definition ($self, $fixture_type, $num, $specification) {
                 },
             },
         };
+        # TODO: not declaring an admin user; some GET queries may fail json schema validation
     }
     elsif ($fixture_type eq 'validation_plan') {
         return +{

--- a/t/integration/crud/build.t
+++ b/t/integration/crud/build.t
@@ -675,13 +675,15 @@ $t->post_ok('/build/our second build/device', json => [ { sku => 'ugh' } ])
 
 $t->post_ok('/build/our second build/device', json => [ { serial_number => 'FOO', sku => 'nope' } ])
     ->status_is(404)
+    ->json_is({ error => 'no hardware_product corresponding to sku nope' })
     ->log_error_is('no hardware_product corresponding to sku nope');
 
 my $hardware_product = first { $_->isa('Conch::DB::Result::HardwareProduct') } $t->generate_fixtures('hardware_product');
 
 $t->post_ok('/build/our second build/device', json => [ { id => create_uuid_str(), sku => $hardware_product->sku } ])
     ->status_is(404)
-    ->log_error_like(qr/no device corresponding to device id ${\Conch::UUID::UUID_FORMAT}$/);
+    ->json_cmp_deeply({ error => re(qr/^no device corresponding to device id ${\Conch::UUID::UUID_FORMAT}$/) })
+    ->log_error_like(qr/^no device corresponding to device id ${\Conch::UUID::UUID_FORMAT}$/);
 
 $t->post_ok('/build/our second build/device', json => [ { serial_number => 'FOO', sku => $hardware_product->sku } ])
     ->status_is(204)

--- a/t/integration/crud/build.t
+++ b/t/integration/crud/build.t
@@ -1022,26 +1022,9 @@ $t->delete_ok('/build/my first build/device/'.$device1->id)
     ->status_is(404)
     ->log_warn_is('device '.$device1->id.' is not in build my first build: cannot remove');
 
-$t->delete_ok('/build/our second build/rack/'.$rack1->id)
-    ->status_is(404)
-    ->log_warn_is('rack '.$rack1->id.' is not in build our second build: cannot remove');
-
-$t->delete_ok('/build/my first build/rack/'.$rack1->id)
-    ->status_is(204)
-    ->log_debug_is('removing rack '.$rack1->id.' from build my first build');
-
-$t->delete_ok('/build/our second build/rack/'.$rack2->id)
-    ->status_is(204)
-    ->log_debug_is('removing rack '.$rack2->id.' from build our second build');
-
 $t->get_ok('/build/my first build/device')
     ->status_is(200)
     ->json_schema_is('Devices')
-    ->json_is([]);
-
-$t->get_ok('/build/my first build/rack')
-    ->status_is(200)
-    ->json_schema_is('Racks')
     ->json_is([]);
 
 $t->get_ok('/build/our second build/device')
@@ -1060,10 +1043,5 @@ $t->get_ok('/build/our second build/device')
             rack_id => undef,
         }),
     ]);
-
-$t->get_ok('/build/our second build/rack')
-    ->status_is(200)
-    ->json_schema_is('Racks')
-    ->json_is([]);
 
 done_testing;

--- a/t/integration/crud/devices.t
+++ b/t/integration/crud/devices.t
@@ -543,13 +543,13 @@ subtest 'located device' => sub {
         $t->authenticate(email => $ro_user->email);
     };
 
-    # give build user ro access to the device through device->device_location->rack->workspace
-    $global_ws->create_related('user_workspace_roles', { user_id => $build_user->id, role => 'ro' });
+    # give build user rw access to the device through device->device_location->rack->workspace
+    $global_ws->create_related('user_workspace_roles', { user_id => $build_user->id, role => 'rw' });
     $t->authenticate(email => $build_user->email);
     $t->post_ok('/build/'.$build->id.'/device/'.$located_device_id)
         ->status_is(204)
         ->log_debug_is('User has rw access to build '.$build->id.' via role entry')
-        ->log_debug_is('User has ro access to device '.$located_device_id.' via role entry');
+        ->log_debug_is('User has rw access to device '.$located_device_id.' via role entry');
 
     $located_device->update({ phase => 'production' });
     $device_data->{build_id} = $build->id;

--- a/t/integration/crud/devices.t
+++ b/t/integration/crud/devices.t
@@ -369,10 +369,8 @@ subtest 'located device' => sub {
             sku => $hardware_product->sku,
             location => {
                 rack => {
-                    (map +($_ => $rack->$_), qw(id name datacenter_room_id serial_number asset_tag phase)),
-                    rack_role_id => $rack->rack_role_id,
+                    (map +($_ => $rack->$_), qw(id name datacenter_room_id serial_number asset_tag phase rack_role_id build_id)),
                     (map +($_ => re(qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/)), qw(created updated)),
-                    build_id => undef,
                 },
                 rack_unit_start => 1,
                 datacenter => ignore,


### PR DESCRIPTION
Contains visible changes to some build-related endpoints.

- GET /build/*/device no longer includes devices actually located in other builds, even if their rack is in this build.
- allow POST /rack/* to change a rack's build
- allow POST /build/* to change a device's or rack's build
- rack is always created with a build_id
- remove DELETE /build/*/rack endpoint (it is no longer possible to nullify rack.build_id)