### PR TITLE
v3 b3 room+rack improvements

### DIFF
--- a/docs/json-schema/request.json
+++ b/docs/json-schema/request.json
@@ -242,7 +242,7 @@
           "$ref" : "common.json#/definitions/uuid"
         },
         "vendor_name" : {
-          "$ref" : "common.json#/definitions/non_empty_string"
+          "$ref" : "common.json#/definitions/mojo_relaxed_placeholder"
         }
       },
       "required" : [
@@ -267,7 +267,7 @@
           "$ref" : "common.json#/definitions/uuid"
         },
         "vendor_name" : {
-          "$ref" : "common.json#/definitions/non_empty_string"
+          "$ref" : "common.json#/definitions/mojo_relaxed_placeholder"
         }
       },
       "type" : "object"

--- a/docs/json-schema/request.json
+++ b/docs/json-schema/request.json
@@ -248,7 +248,8 @@
       "required" : [
         "datacenter_id",
         "az",
-        "alias"
+        "alias",
+        "vendor_name"
       ],
       "type" : "object"
     },

--- a/docs/json-schema/response.json
+++ b/docs/json-schema/response.json
@@ -240,14 +240,7 @@
         },
         "vendor_name" : {
           "description" : "the vendor's name for the room",
-          "oneOf" : [
-            {
-              "type" : "string"
-            },
-            {
-              "type" : "null"
-            }
-          ]
+          "type" : "string"
         }
       },
       "required" : [

--- a/docs/json-schema/response.json
+++ b/docs/json-schema/response.json
@@ -239,8 +239,7 @@
           "type" : "string"
         },
         "vendor_name" : {
-          "description" : "the vendor's name for the room",
-          "type" : "string"
+          "$ref" : "common.json#/definitions/mojo_relaxed_placeholder"
         }
       },
       "required" : [

--- a/docs/json-schema/response.json
+++ b/docs/json-schema/response.json
@@ -874,14 +874,14 @@
     "DeviceLocation" : {
       "additionalProperties" : false,
       "properties" : {
-        "datacenter" : {
-          "$ref" : "/definitions/Datacenter"
+        "az" : {
+          "type" : "string"
         },
         "datacenter_room" : {
-          "$ref" : "/definitions/DatacenterRoomDetailed"
+          "$ref" : "common.json#/definitions/mojo_standard_placeholder"
         },
         "rack" : {
-          "$ref" : "/definitions/Rack"
+          "$ref" : "common.json#/definitions/mojo_relaxed_placeholder"
         },
         "rack_unit_start" : {
           "$ref" : "common.json#/definitions/positive_integer"
@@ -926,7 +926,7 @@
         }
       },
       "required" : [
-        "datacenter",
+        "az",
         "datacenter_room",
         "rack",
         "rack_unit_start",

--- a/docs/json-schema/response.json
+++ b/docs/json-schema/response.json
@@ -1095,55 +1095,7 @@
               "type" : "null"
             },
             {
-              "additionalProperties" : false,
-              "properties" : {
-                "datacenter" : {
-                  "additionalProperties" : false,
-                  "properties" : {
-                    "name" : {
-                      "description" : "datacenter.region",
-                      "type" : "string"
-                    },
-                    "vendor_name" : {
-                      "description" : "the vendor's name for the datacenter",
-                      "oneOf" : [
-                        {
-                          "type" : "null"
-                        },
-                        {
-                          "type" : "string"
-                        }
-                      ]
-                    }
-                  },
-                  "required" : [
-                    "name",
-                    "vendor_name"
-                  ],
-                  "type" : "object"
-                },
-                "rack" : {
-                  "additionalProperties" : false,
-                  "properties" : {
-                    "name" : {
-                      "type" : "string"
-                    },
-                    "rack_unit_start" : {
-                      "$ref" : "common.json#/definitions/positive_integer"
-                    }
-                  },
-                  "required" : [
-                    "name",
-                    "rack_unit_start"
-                  ],
-                  "type" : "object"
-                }
-              },
-              "required" : [
-                "datacenter",
-                "rack"
-              ],
-              "type" : "object"
+              "$ref" : "/definitions/DeviceLocation"
             }
           ]
         },
@@ -2977,55 +2929,7 @@
             ]
           },
           "location" : {
-            "additionalProperties" : false,
-            "properties" : {
-              "datacenter" : {
-                "additionalProperties" : false,
-                "properties" : {
-                  "name" : {
-                    "description" : "datacenter.region",
-                    "type" : "string"
-                  },
-                  "vendor_name" : {
-                    "description" : "the vendor's name for the datacenter",
-                    "oneOf" : [
-                      {
-                        "type" : "null"
-                      },
-                      {
-                        "type" : "string"
-                      }
-                    ]
-                  }
-                },
-                "required" : [
-                  "name",
-                  "vendor_name"
-                ],
-                "type" : "object"
-              },
-              "rack" : {
-                "additionalProperties" : false,
-                "properties" : {
-                  "name" : {
-                    "type" : "string"
-                  },
-                  "rack_unit_start" : {
-                    "$ref" : "common.json#/definitions/positive_integer"
-                  }
-                },
-                "required" : [
-                  "name",
-                  "rack_unit_start"
-                ],
-                "type" : "object"
-              }
-            },
-            "required" : [
-              "datacenter",
-              "rack"
-            ],
-            "type" : "object"
+            "$ref" : "/definitions/DeviceLocation"
           },
           "phase" : {
             "$ref" : "common.json#/definitions/device_phase"

--- a/docs/modules/Conch::Controller::DatacenterRoom.md
+++ b/docs/modules/Conch::Controller::DatacenterRoom.md
@@ -41,10 +41,6 @@ Permanently delete a datacenter room.
 
 Response uses the Racks json schema.
 
-## find\_rack
-
-Response uses the Rack json schema.
-
 # LICENSING
 
 Copyright Joyent, Inc.

--- a/docs/modules/Conch::Controller::DatacenterRoom.md
+++ b/docs/modules/Conch::Controller::DatacenterRoom.md
@@ -10,6 +10,9 @@ Chainable action that uses the `datacenter_room_id_or_alias` value provided in t
 (usually via the request URL) to look up a datacenter\_room, and stashes the query to get to it
 in `datacenter_room_rs`.
 
+If `require_role` is provided, it is used as the minimum required role for the user to
+continue; otherwise the user must be a system admin.
+
 ## get\_all
 
 Get all datacenter rooms.

--- a/docs/modules/Conch::Controller::DatacenterRoom.md
+++ b/docs/modules/Conch::Controller::DatacenterRoom.md
@@ -7,8 +7,8 @@ Conch::Controller::DatacenterRoom
 ## find\_datacenter\_room
 
 Chainable action that uses the `datacenter_room_id_or_alias` value provided in the stash
-(usually via the request URL) to look up a datacenter\_room, and stashes the result in
-`datacenter_room`.
+(usually via the request URL) to look up a datacenter\_room, and stashes the query to get to it
+in `datacenter_room_rs`.
 
 ## get\_all
 

--- a/docs/modules/Conch::Controller::Rack.md
+++ b/docs/modules/Conch::Controller::Rack.md
@@ -7,10 +7,13 @@ Conch::Controller::Rack
 ## find\_rack
 
 Chainable action that uses the `rack_id_or_name` value provided in the stash (usually via the
-request URL) to look up a rack, and stashes the query to get to it in `rack_rs`.
+request URL) to look up a rack (constraining to the datacenter\_room if `datacenter_room_rs` is
+also provided) and stashes the query to get to it in `rack_rs`.
 
-`rack_id_or_name` must be either a uuid or a "long" rack name
-(["vendor\_name" in Conch::DB::Result::DatacenterRoom](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ADatacenterRoom#vendor_name)) plus ["name" in Conch::DB::Result::Rack](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ARack#name)).
+When datacenter\_room information is **not** provided, `rack_id_or_name` must be either a uuid
+or a "long" rack name (["vendor\_name" in Conch::DB::Result::DatacenterRoom](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ADatacenterRoom#vendor_name)) plus
+["name" in Conch::DB::Result::Rack](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ARack#name)); otherwise, it can also be a short rack name
+["name" in Conch::DB::Result::Rack](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ARack#name)).
 
 If `require_role` is provided, it is used as the minimum required role for the user to
 continue; otherwise the user must be a system admin.

--- a/docs/modules/Conch::Controller::Rack.md
+++ b/docs/modules/Conch::Controller::Rack.md
@@ -6,8 +6,11 @@ Conch::Controller::Rack
 
 ## find\_rack
 
-Chainable action that uses the `rack_id` value provided in the stash (usually via the
+Chainable action that uses the `rack_id_or_name` value provided in the stash (usually via the
 request URL) to look up a rack, and stashes the query to get to it in `rack_rs`.
+
+`rack_id_or_name` must be either a uuid or a "long" rack name
+(["vendor\_name" in Conch::DB::Result::DatacenterRoom](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ADatacenterRoom#vendor_name)) plus ["name" in Conch::DB::Result::Rack](../modules/Conch%3A%3ADB%3A%3AResult%3A%3ARack#name)).
 
 If `require_role` is provided, it is used as the minimum required role for the user to
 continue; otherwise the user must be a system admin.

--- a/docs/modules/Conch::Controller::Rack.md
+++ b/docs/modules/Conch::Controller::Rack.md
@@ -28,12 +28,6 @@ Get a single rack
 
 Response uses the Rack json schema.
 
-## get\_all
-
-Get all racks
-
-Response uses the Racks json schema.
-
 ## get\_layouts
 
 Gets all the layouts for the specified rack.

--- a/docs/modules/Conch::DB::Result::DatacenterRoom.md
+++ b/docs/modules/Conch::DB::Result::DatacenterRoom.md
@@ -44,7 +44,7 @@ is_nullable: 0
 
 ```
 data_type: 'text'
-is_nullable: 1
+is_nullable: 0
 ```
 
 ## created
@@ -74,6 +74,10 @@ original: {default_value => \"now()"}
 ## `datacenter_room_alias_key`
 
 - ["alias"](#alias)
+
+## `datacenter_room_vendor_name_key`
+
+- ["vendor\_name"](#vendor_name)
 
 # RELATIONS
 

--- a/docs/modules/Conch::DB::ResultSet::Device.md
+++ b/docs/modules/Conch::DB::ResultSet::Device.md
@@ -73,7 +73,7 @@ Modifies the resultset to add the `sku` column.
 ## location\_data
 
 Returns a resultset that provides location data ([response.json#/definitions/DeviceLocation](../json-schema/response.json#/definitions/DeviceLocation)),
-optionally returned in a subhash using the provided key name.
+optionally returned under a hash using the provided key name.
 
 # LICENSING
 

--- a/docs/modules/Conch::DB::ResultSet::Device.md
+++ b/docs/modules/Conch::DB::ResultSet::Device.md
@@ -70,6 +70,11 @@ Modifies the resultset to add columns `rack_id`, `rack_unit_start` and `rack_nam
 
 Modifies the resultset to add the `sku` column.
 
+## location\_data
+
+Returns a resultset that provides location data ([response.json#/definitions/DeviceLocation](../json-schema/response.json#/definitions/DeviceLocation)),
+optionally returned in a subhash using the provided key name.
+
 # LICENSING
 
 Copyright Joyent, Inc.

--- a/docs/modules/Conch::DB::ResultSet::Rack.md
+++ b/docs/modules/Conch::DB::ResultSet::Rack.md
@@ -17,6 +17,12 @@ you want, so don't do that.)
 
 This is used for identifying potential conflicts when adjusting layouts.
 
+## with\_user\_role
+
+Constrains the resultset to those where the provided user\_id has (at least) the specified role
+in at least one workspace or build associated with the specified rack(s), including parent
+workspaces.
+
 ## user\_has\_role
 
 Checks that the provided user\_id has (at least) the specified role in at least one workspace

--- a/docs/modules/Conch::Route::Build.md
+++ b/docs/modules/Conch::Route::Build.md
@@ -117,7 +117,7 @@ read-write role on the device (via a workspace or build; see ["routes" in Conch:
 - Requires system admin authorization or the read-only role on the build
 - Response: response.yaml#/Racks
 
-### `POST /build/:build_id_or_name/rack/:rack_id`
+### `POST /build/:build_id_or_name/rack/:rack_id_or_name`
 
 - Requires system admin authorization, or the read/write role on the build and the
 read-write role on a workspace or build that contains the rack

--- a/docs/modules/Conch::Route::DatacenterRoom.md
+++ b/docs/modules/Conch::Route::DatacenterRoom.md
@@ -23,7 +23,8 @@ All routes require authentication.
 
 ### `GET /room/:datacenter_room_id_or_alias`
 
-- Requires system admin authorization
+- User requires system admin authorization, or the read-only role on a rack located in
+the room
 - Response: [response.json#/definitions/DatacenterRoomDetailed](../json-schema/response.json#/definitions/DatacenterRoomDetailed)
 
 ### `POST /room/:datacenter_room_id_or_alias`
@@ -39,12 +40,13 @@ All routes require authentication.
 
 ### `GET /room/:datacenter_room_id_or_alias/racks`
 
-- Requires system admin authorization
+- User requires system admin authorization, or the read-only role on a rack located in
+the room (in which case data returned is restricted to those racks)
 - Response: [response.json#/definitions/Racks](../json-schema/response.json#/definitions/Racks)
 
 ### `GET /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name`
 
-- Requires system admin authorization
+- User requires system admin authorization, or the read-only role on the rack
 - Response: [response.json#/definitions/Rack](../json-schema/response.json#/definitions/Rack)
 
 # LICENSING

--- a/docs/modules/Conch::Route::DatacenterRoom.md
+++ b/docs/modules/Conch::Route::DatacenterRoom.md
@@ -42,7 +42,7 @@ All routes require authentication.
 - Requires system admin authorization
 - Response: [response.json#/definitions/Racks](../json-schema/response.json#/definitions/Racks)
 
-### `GET /room/:datacenter_room_id_or_alias/rack/:rack_name`
+### `GET /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name`
 
 - Requires system admin authorization
 - Response: [response.json#/definitions/Rack](../json-schema/response.json#/definitions/Rack)

--- a/docs/modules/Conch::Route::DatacenterRoom.md
+++ b/docs/modules/Conch::Route::DatacenterRoom.md
@@ -46,8 +46,58 @@ the room (in which case data returned is restricted to those racks)
 
 ### `GET /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name`
 
-- User requires system admin authorization, or the read-only role on the rack
+- User requires the read-only role on the rack
 - Response: [response.json#/definitions/Rack](../json-schema/response.json#/definitions/Rack)
+
+### `POST /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name`
+
+- User requires the read/write role on the rack
+- Request: [request.json#/definitions/RackUpdate](../json-schema/request.json#/definitions/RackUpdate)
+- Response: Redirect to the updated rack
+
+### `DELETE /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name`
+
+- Requires system admin authorization
+- Response: `204 NO CONTENT`
+
+### `GET /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name/layouts`
+
+- User requires the read-only role on the rack
+- Response: [response.json#/definitions/RackLayouts](../json-schema/response.json#/definitions/RackLayouts)
+
+### `POST /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name/layouts`
+
+- User requires the read/write role on the rack
+- Request: [request.json#/definitions/RackLayouts](../json-schema/request.json#/definitions/RackLayouts)
+- Response: Redirect to the rack's layouts
+
+### `GET /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name/assignment`
+
+- User requires the read-only role on the rack
+- Response: [response.json#/definitions/RackAssignments](../json-schema/response.json#/definitions/RackAssignments)
+
+### `POST /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name/assignment`
+
+- User requires the read/write role on the rack
+- Request: [request.json#/definitions/RackAssignmentUpdates](../json-schema/request.json#/definitions/RackAssignmentUpdates)
+- Response: Redirect to the updated rack assignment
+
+### `DELETE /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name/assignment`
+
+This method requires a request body.
+
+- User requires the read/write role on the rack
+- Request: [request.json#/definitions/RackAssignmentDeletes](../json-schema/request.json#/definitions/RackAssignmentDeletes)
+- Response: `204 NO CONTENT`
+
+### `POST /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name/phase?rack_only=<0|1>`
+
+The query parameter `rack_only` (defaults to `0`) specifies whether to update
+only the rack's phase, or all the rack's devices' phases as well.
+
+- User requires the read/write role on the rack
+- Request: [request.json#/definitions/RackPhase](../json-schema/request.json#/definitions/RackPhase)
+- Response: Redirect to the updated rack
 
 # LICENSING
 

--- a/docs/modules/Conch::Route::DatacenterRoom.md
+++ b/docs/modules/Conch::Route::DatacenterRoom.md
@@ -38,7 +38,7 @@ the room
 - Requires system admin authorization
 - Response: `204 NO CONTENT`
 
-### `GET /room/:datacenter_room_id_or_alias/racks`
+### `GET /room/:datacenter_room_id_or_alias/rack`
 
 - User requires system admin authorization, or the read-only role on a rack located in
 the room (in which case data returned is restricted to those racks)

--- a/docs/modules/Conch::Route::Rack.md
+++ b/docs/modules/Conch::Route::Rack.md
@@ -18,11 +18,6 @@ Take note: All routes that reference a specific rack (prefix `/rack/:rack_id`) a
 available under `/rack/:rack_id_or_long_name` as well as
 `/room/datacenter_room_id_or_alias/rack/:rack_id_or_name`.
 
-### `GET /rack`
-
-- Requires system admin authorization
-- Response: [response.json#/definitions/Racks](../json-schema/response.json#/definitions/Racks)
-
 ### `POST /rack`
 
 - Requires system admin authorization

--- a/docs/modules/Conch::Route::Rack.md
+++ b/docs/modules/Conch::Route::Rack.md
@@ -21,45 +21,45 @@ All routes require authentication.
 - Request: [request.json#/definitions/RackCreate](../json-schema/request.json#/definitions/RackCreate)
 - Response: Redirect to the created rack
 
-### `GET /rack/:rack_id`
+### `GET /rack/:rack_id_or_name`
 
 - User requires the read-only role on the rack
 - Response: [response.json#/definitions/Rack](../json-schema/response.json#/definitions/Rack)
 
-### `POST /rack/:rack_id`
+### `POST /rack/:rack_id_or_name`
 
 - User requires the read/write role on the rack
 - Request: [request.json#/definitions/RackUpdate](../json-schema/request.json#/definitions/RackUpdate)
 - Response: Redirect to the updated rack
 
-### `DELETE /rack/:rack_id`
+### `DELETE /rack/:rack_id_or_name`
 
 - Requires system admin authorization
 - Response: `204 NO CONTENT`
 
-### `GET /rack/:rack_id/layouts`
+### `GET /rack/:rack_id_or_name/layouts`
 
 - User requires the read-only role on the rack
 - Response: [response.json#/definitions/RackLayouts](../json-schema/response.json#/definitions/RackLayouts)
 
-### `POST /rack/:rack_id/layouts`
+### `POST /rack/:rack_id_or_name/layouts`
 
 - User requires the read/write role on the rack
 - Request: [request.json#/definitions/RackLayouts](../json-schema/request.json#/definitions/RackLayouts)
 - Response: Redirect to the rack's layouts
 
-### `GET /rack/:rack_id/assignment`
+### `GET /rack/:rack_id_or_name/assignment`
 
 - User requires the read-only role on the rack
 - Response: [response.json#/definitions/RackAssignments](../json-schema/response.json#/definitions/RackAssignments)
 
-### `POST /rack/:rack_id/assignment`
+### `POST /rack/:rack_id_or_name/assignment`
 
 - User requires the read/write role on the rack
 - Request: [request.json#/definitions/RackAssignmentUpdates](../json-schema/request.json#/definitions/RackAssignmentUpdates)
 - Response: Redirect to the updated rack assignment
 
-### `DELETE /rack/:rack_id/assignment`
+### `DELETE /rack/:rack_id_or_name/assignment`
 
 This method requires a request body.
 
@@ -67,7 +67,7 @@ This method requires a request body.
 - Request: [request.json#/definitions/RackAssignmentDeletes](../json-schema/request.json#/definitions/RackAssignmentDeletes)
 - Response: `204 NO CONTENT`
 
-### `POST /rack/:rack_id/phase?rack_only=<0|1>`
+### `POST /rack/:rack_id_or_name/phase?rack_only=<0|1>`
 
 The query parameter `rack_only` (defaults to `0`) specifies whether to update
 only the rack's phase, or all the rack's devices' phases as well.

--- a/docs/modules/Conch::Route::Rack.md
+++ b/docs/modules/Conch::Route::Rack.md
@@ -45,12 +45,12 @@ available under `/rack/:rack_id_or_long_name` as well as
 - Requires system admin authorization
 - Response: `204 NO CONTENT`
 
-### `GET /rack/:rack_id_or_name/layouts`
+### `GET /rack/:rack_id_or_name/layout`
 
 - User requires the read-only role on the rack
 - Response: [response.json#/definitions/RackLayouts](../json-schema/response.json#/definitions/RackLayouts)
 
-### `POST /rack/:rack_id_or_name/layouts`
+### `POST /rack/:rack_id_or_name/layout`
 
 - User requires the read/write role on the rack
 - Request: [request.json#/definitions/RackLayouts](../json-schema/request.json#/definitions/RackLayouts)

--- a/docs/modules/Conch::Route::Rack.md
+++ b/docs/modules/Conch::Route::Rack.md
@@ -8,7 +8,15 @@ Conch::Route::Rack
 
 Sets up the routes for /rack:
 
+## one\_rack\_routes
+
+Sets up the routes for working with just one rack, mounted under a provided route prefix.
+
 All routes require authentication.
+
+Take note: All routes that reference a specific rack (prefix `/rack/:rack_id`) are also
+available under `/rack/:rack_id_or_long_name` as well as
+`/room/datacenter_room_id_or_alias/rack/:rack_id_or_name`.
 
 ### `GET /rack`
 

--- a/docs/modules/Conch::Route::Workspace.md
+++ b/docs/modules/Conch::Route::Workspace.md
@@ -68,7 +68,7 @@ Accepts the following optional query parameters:
 - Request: [request.json#/definitions/WorkspaceAddRack](../json-schema/request.json#/definitions/WorkspaceAddRack)
 - Response: Redirect to the workspace's racks
 
-### `DELETE /workspace/:workspace_id_or_name/rack/:rack_id`
+### `DELETE /workspace/:workspace_id_or_name/rack/:rack_id_or_name`
 
 - User requires the admin role
 - Response: `204 NO CONTENT`

--- a/json-schema/request.yaml
+++ b/json-schema/request.yaml
@@ -48,7 +48,7 @@ definitions:
       alias:
         $ref: common.yaml#/definitions/mojo_standard_placeholder
       vendor_name:
-        $ref: common.yaml#/definitions/non_empty_string
+        $ref: common.yaml#/definitions/mojo_relaxed_placeholder
   DatacenterRoomUpdate:
     type: object
     additionalProperties: false
@@ -61,7 +61,7 @@ definitions:
       alias:
         $ref: common.yaml#/definitions/mojo_standard_placeholder
       vendor_name:
-        $ref: common.yaml#/definitions/non_empty_string
+        $ref: common.yaml#/definitions/mojo_relaxed_placeholder
   DeviceReport:
     $ref: device_report.yaml#/definitions/DeviceReport_v3.0.0
   RackCreate:

--- a/json-schema/request.yaml
+++ b/json-schema/request.yaml
@@ -39,6 +39,7 @@ definitions:
       - datacenter_id
       - az
       - alias
+      - vendor_name
     properties:
       datacenter_id:
         $ref: common.yaml#/definitions/uuid

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -1318,8 +1318,8 @@ definitions:
       alias:
         $ref: common.yaml#/definitions/mojo_standard_placeholder
       vendor_name:
-        description: the vendor's name for the room
-        type: string
+        # description: the vendor's name for the room
+        $ref: common.yaml#/definitions/mojo_relaxed_placeholder
       datacenter_id:
         $ref: common.yaml#/definitions/uuid
       created:

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -697,18 +697,20 @@ definitions:
     type: object
     additionalProperties: false
     required:
-      - datacenter
+      - az
       - datacenter_room
       - rack
       - rack_unit_start
       - target_hardware_product
     properties:
-      datacenter:
-        $ref: /definitions/Datacenter
+      az:
+        type: string
       datacenter_room:
-        $ref: /definitions/DatacenterRoomDetailed
+        # description: datacenter_room.alias
+        $ref: common.yaml#/definitions/mojo_standard_placeholder
       rack:
-        $ref: /definitions/Rack
+        # description: rack.full_name (datacenter_room.vendor_name + ':' + rack.name)
+        $ref: common.yaml#/definitions/mojo_relaxed_placeholder
       rack_unit_start:
         $ref: common.yaml#/definitions/positive_integer
       target_hardware_product:

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -1319,9 +1319,7 @@ definitions:
         $ref: common.yaml#/definitions/mojo_standard_placeholder
       vendor_name:
         description: the vendor's name for the room
-        oneOf:
-          - type: string
-          - type: 'null'
+        type: string
       datacenter_id:
         $ref: common.yaml#/definitions/uuid
       created:

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -509,38 +509,7 @@ definitions:
       location:
         oneOf:
           - type: 'null'
-          - type: object
-            additionalProperties: false
-            required:
-              - datacenter
-              - rack
-            properties:
-              datacenter:
-                type: object
-                additionalProperties: false
-                required:
-                  - name
-                  - vendor_name
-                properties:
-                  name:
-                    description: datacenter.region
-                    type: string
-                  vendor_name:
-                    description: the vendor's name for the datacenter
-                    oneOf:
-                      - type: 'null'
-                      - type: string
-              rack:
-                type: object
-                additionalProperties: false
-                required:
-                  - name
-                  - rack_unit_start
-                properties:
-                  name:
-                    type: string
-                  rack_unit_start:
-                    $ref: common.yaml#/definitions/positive_integer
+          - $ref: /definitions/DeviceLocation
       ipmi:
         oneOf:
           - type: 'null'
@@ -622,38 +591,7 @@ definitions:
         phase:
           $ref: common.yaml#/definitions/device_phase
         location:
-          type: object
-          additionalProperties: false
-          required:
-            - datacenter
-            - rack
-          properties:
-            datacenter:
-              type: object
-              additionalProperties: false
-              required:
-                - name
-                - vendor_name
-              properties:
-                name:
-                  description: datacenter.region
-                  type: string
-                vendor_name:
-                  description: the vendor's name for the datacenter
-                  oneOf:
-                    - type: 'null'
-                    - type: string
-            rack:
-              type: object
-              additionalProperties: false
-              required:
-                - name
-                - rack_unit_start
-              properties:
-                name:
-                  type: string
-                rack_unit_start:
-                  $ref: common.yaml#/definitions/positive_integer
+          $ref: /definitions/DeviceLocation
         ipmi:
           oneOf:
             - type: 'null'

--- a/lib/Conch/Controller/DatacenterRoom.pm
+++ b/lib/Conch/Controller/DatacenterRoom.pm
@@ -148,12 +148,14 @@ Response uses the Rack json schema.
 =cut
 
 sub find_rack ($c) {
+    my $identifier = $c->stash('rack_id_or_name');
+
     my $rack_rs = $c->stash('datacenter_room_rs')
         ->related_resultset('racks')
-        ->search({ name => $c->stash('rack_name') });
+        ->search({ 'racks.'.(is_uuid($identifier) ? 'id' : 'name') => $identifier });
 
     if (not $rack_rs->exists) {
-        $c->log->debug('Could not find rack '.$c->stash('rack_name')
+        $c->log->debug('Could not find rack '.$identifier
             .' in room '.$c->stash('datacenter_room_id_or_alias'));
         return $c->status(404);
     }

--- a/lib/Conch/Controller/DatacenterRoom.pm
+++ b/lib/Conch/Controller/DatacenterRoom.pm
@@ -166,40 +166,6 @@ sub racks ($c) {
     return $c->status(200, \@racks);
 }
 
-=head2 find_rack
-
-Response uses the Rack json schema.
-
-=cut
-
-sub find_rack ($c) {
-    my $identifier = $c->stash('rack_id_or_name');
-
-    my $rack_rs = $c->stash('datacenter_room_rs')
-        ->related_resultset('racks')
-        ->search({ 'racks.'.(is_uuid($identifier) ? 'id' : 'name') => $identifier });
-
-    if (not $rack_rs->exists) {
-        $c->log->debug('Could not find rack '.$identifier
-            .' in room '.$c->stash('datacenter_room_id_or_alias'));
-        return $c->status(404);
-    }
-
-    if (not $c->is_system_admin
-            and not $rack_rs->user_has_role($c->stash('user_id'), $c->stash('require_role'))) {
-        $c->log->debug('User lacks the required role ('.$c->stash('require_role')
-            .') for rack '.$c->stash('rack_id_or_name')
-            .' in room'.$c->stash('datacenter_room_id_or_alias'));
-        return $c->status(403);
-    }
-
-    my $rack = $rack_rs->single;
-    $c->log->debug('Found rack '.$rack->id);
-
-    $c->res->headers->location('/rack/'.$rack->id);
-    $c->status(200, $rack);
-}
-
 1;
 __END__
 

--- a/lib/Conch/Controller/DatacenterRoom.pm
+++ b/lib/Conch/Controller/DatacenterRoom.pm
@@ -92,6 +92,9 @@ sub create ($c) {
     return $c->status(409, { error => 'a room already exists with that alias' })
         if $c->db_datacenter_rooms->search({ alias => $input->{alias} })->exists;
 
+    return $c->status(409, { error => 'a room already exists with that vendor_name' })
+        if $c->db_datacenter_rooms->search({ vendor_name => $input->{vendor_name} })->exists;
+
     my $room = $c->db_datacenter_rooms->create($input);
     $c->log->debug('Created datacenter room '.$room->id);
     $c->status(303, '/room/'.$room->id);
@@ -116,6 +119,10 @@ sub update ($c) {
     return $c->status(409, { error => 'a room already exists with that alias' })
         if $input->{alias} and $input->{alias} ne $room->alias
             and $c->db_datacenter_rooms->search({ alias => $input->{alias} })->exists;
+
+    return $c->status(409, { error => 'a room already exists with that vendor_name' })
+        if $input->{vendor_name} and $input->{vendor_name} ne $room->vendor_name
+            and $c->db_datacenter_rooms->search({ vendor_name => $input->{vendor_name} })->exists;
 
     $room->update({ $input->%*, updated => \'now()' });
     $c->log->debug('Updated datacenter room '.$c->stash('datacenter_room_id_or_alias'));

--- a/lib/Conch/Controller/DatacenterRoom.pm
+++ b/lib/Conch/Controller/DatacenterRoom.pm
@@ -73,7 +73,9 @@ Response uses the DatacenterRoomDetailed json schema.
 =cut
 
 sub get_one ($c) {
-    $c->status(200, $c->stash('datacenter_room_rs')->single);
+    my $room = $c->stash('datacenter_room_rs')->single;
+    $c->res->headers->location('/room/'.$room->id);
+    $c->status(200, $room);
 }
 
 =head2 create
@@ -194,6 +196,7 @@ sub find_rack ($c) {
     my $rack = $rack_rs->single;
     $c->log->debug('Found rack '.$rack->id);
 
+    $c->res->headers->location('/rack/'.$rack->id);
     $c->status(200, $rack);
 }
 

--- a/lib/Conch/Controller/Rack.pm
+++ b/lib/Conch/Controller/Rack.pm
@@ -91,6 +91,7 @@ Response uses the Rack json schema.
 =cut
 
 sub get ($c) {
+    $c->res->headers->location('/rack/'.$c->stash('rack_id'));
     $c->status(200, $c->stash('rack_rs')->single);
 }
 
@@ -125,6 +126,7 @@ sub get_layouts ($c) {
         ->all;
 
     $c->log->debug('Found '.scalar(@layouts).' rack layouts');
+    $c->res->headers->location('/rack/'.$c->stash('rack_id').'/layouts');
     $c->status(200, \@layouts);
 }
 
@@ -308,6 +310,7 @@ sub get_assignment ($c) {
         ->all;
 
     $c->log->debug('Found '.scalar(@assignments).' device-rack assignments');
+    $c->res->headers->location('/rack/'.$c->stash('rack_id').'/assignment');
     $c->status(200, \@assignments);
 }
 

--- a/lib/Conch/Controller/Rack.pm
+++ b/lib/Conch/Controller/Rack.pm
@@ -134,21 +134,6 @@ sub get ($c) {
     $c->status(200, $c->stash('rack_rs')->single);
 }
 
-=head2 get_all
-
-Get all racks
-
-Response uses the Racks json schema.
-
-=cut
-
-sub get_all ($c) {
-    my @racks = $c->db_racks->order_by('name')->all;
-    $c->log->debug('Found '.scalar(@racks).' racks');
-
-    $c->status(200, \@racks);
-}
-
 =head2 get_layouts
 
 Gets all the layouts for the specified rack.

--- a/lib/Conch/Controller/Rack.pm
+++ b/lib/Conch/Controller/Rack.pm
@@ -165,7 +165,7 @@ sub get_layouts ($c) {
         ->all;
 
     $c->log->debug('Found '.scalar(@layouts).' rack layouts');
-    $c->res->headers->location('/rack/'.$c->stash('rack_id').'/layouts');
+    $c->res->headers->location('/rack/'.$c->stash('rack_id').'/layout');
     $c->status(200, \@layouts);
 }
 
@@ -247,7 +247,7 @@ sub overwrite_layouts ($c) {
     })
     or return $c->status(400);
 
-    $c->status(303, '/rack/'.$c->stash('rack_id').'/layouts');
+    $c->status(303, '/rack/'.$c->stash('rack_id').'/layout');
 }
 
 =head2 update

--- a/lib/Conch/Controller/WorkspaceRack.pm
+++ b/lib/Conch/Controller/WorkspaceRack.pm
@@ -92,7 +92,7 @@ sub find_workspace_rack ($c) {
     });
 
     if (not $rs->exists) {
-        $c->log->debug('Could not find rack '.$c->stash('rack_id').' in or beneath workspace '.$c->stash('workspace_id'));
+        $c->log->debug('Could not find rack '.$c->stash('rack_id_or_name').' in or beneath workspace '.$c->stash('workspace_id'));
         return $c->status(404);
     }
 
@@ -156,7 +156,7 @@ sub remove ($c) {
     my $row = $c->stash('workspace_rack_rs')->single;
     $row->delete;
 
-    $c->log->debug('deleted workspace_rack entry for workspace_id '.$row->workspace_id.' and rack_id '.$c->stash('rack_id'));
+    $c->log->debug('deleted workspace_rack entry for workspace_id '.$row->workspace_id.' and rack_id '.$c->stash('rack_id_or_name'));
     return $c->status(204);
 }
 

--- a/lib/Conch/DB/Result/DatacenterRoom.pm
+++ b/lib/Conch/DB/Result/DatacenterRoom.pm
@@ -55,7 +55,7 @@ __PACKAGE__->table("datacenter_room");
 =head2 vendor_name
 
   data_type: 'text'
-  is_nullable: 1
+  is_nullable: 0
 
 =head2 created
 
@@ -88,7 +88,7 @@ __PACKAGE__->add_columns(
   "alias",
   { data_type => "text", is_nullable => 0 },
   "vendor_name",
-  { data_type => "text", is_nullable => 1 },
+  { data_type => "text", is_nullable => 0 },
   "created",
   {
     data_type     => "timestamp with time zone",
@@ -131,6 +131,18 @@ __PACKAGE__->set_primary_key("id");
 
 __PACKAGE__->add_unique_constraint("datacenter_room_alias_key", ["alias"]);
 
+=head2 C<datacenter_room_vendor_name_key>
+
+=over 4
+
+=item * L</vendor_name>
+
+=back
+
+=cut
+
+__PACKAGE__->add_unique_constraint("datacenter_room_vendor_name_key", ["vendor_name"]);
+
 =head1 RELATIONS
 
 =head2 datacenter
@@ -165,7 +177,7 @@ __PACKAGE__->has_many(
 
 
 # Created by DBIx::Class::Schema::Loader v0.07049
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:mcbeYZ4W6x5TQUuxkzhy5A
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:/HdkgTQ3OY7FN8f1enwONg
 
 1;
 __END__

--- a/lib/Conch/DB/ResultSet/Device.pm
+++ b/lib/Conch/DB/ResultSet/Device.pm
@@ -214,7 +214,7 @@ sub with_sku ($self) {
 =head2 location_data
 
 Returns a resultset that provides location data (F<response.yaml#/definitions/DeviceLocation>),
-optionally returned in a subhash using the provided key name.
+optionally returned under a hash using the provided key name.
 
 =cut
 

--- a/lib/Conch/DB/ResultSet/Rack.pm
+++ b/lib/Conch/DB/ResultSet/Rack.pm
@@ -43,6 +43,40 @@ sub assigned_rack_units ($self) {
         @layout_data;
 }
 
+=head2 with_user_role
+
+Constrains the resultset to those where the provided user_id has (at least) the specified role
+in at least one workspace or build associated with the specified rack(s), including parent
+workspaces.
+
+=cut
+
+sub with_user_role ($self, $user_id, $role) {
+    return $self if $role eq 'none';
+
+    my $workspace_ids_rs = $self->result_source->schema->resultset('workspace')
+        ->with_user_role($user_id, $role)
+        ->get_column('id');
+
+    # since every workspace_rack entry has an equivalent entry in the parent workspace, we do
+    # not need to search the workspace heirarchy here, but simply look for a role entry for any
+    # workspace the rack is associated with.
+    my $racks_in_ws = $self->search(
+        { 'workspace_racks.workspace_id' => { -in => $workspace_ids_rs->as_query } },
+        { join => 'workspace_racks' },
+    );
+
+    my $build_ids_rs = $self->result_source->schema->resultset('build')
+        ->with_user_role($user_id, $role)
+        ->get_column('id');
+
+    my $racks_in_builds = $self->search({
+        $self->current_source_alias.'.build_id' => { -in => $build_ids_rs->as_query },
+    });
+
+    return $racks_in_ws->union($racks_in_builds);
+}
+
 =head2 user_has_role
 
 Checks that the provided user_id has (at least) the specified role in at least one workspace

--- a/lib/Conch/Route/Build.pm
+++ b/lib/Conch/Route/Build.pm
@@ -91,8 +91,8 @@ sub routes {
         # GET /build/:build_id_or_name/rack
         $with_build_ro->get('/rack')->to('#get_racks');
 
-        # POST /build/:build_id_or_name/rack/:rack_id
-        $with_build_rw->under('/rack/<rack_id:uuid>')
+        # POST /build/:build_id_or_name/rack/:rack_id_or_name
+        $with_build_rw->under('/rack/:rack_id_or_name')
             ->to('rack#find_rack', require_role => 'rw')
             ->post('/')->to('build#add_rack');
     }
@@ -297,7 +297,7 @@ read-write role on the device (via a workspace or build; see L<Conch::Route::Dev
 
 =back
 
-=head3 C<POST /build/:build_id_or_name/rack/:rack_id>
+=head3 C<POST /build/:build_id_or_name/rack/:rack_id_or_name>
 
 =over 4
 

--- a/lib/Conch/Route/DatacenterRoom.pm
+++ b/lib/Conch/Route/DatacenterRoom.pm
@@ -40,8 +40,8 @@ sub routes {
     # GET /room/:datacenter_room_id_or_alias/racks
     $with_datacenter_room->get('/racks')->to('#racks');
 
-    # GET /room/:datacenter_room_id_or_alias/rack/:rack_name
-    $with_datacenter_room->get('/rack/#rack_name')->to('#find_rack');
+    # GET /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name
+    $with_datacenter_room->get('/rack/#rack_id_or_name')->to('#find_rack');
 }
 
 1;
@@ -116,7 +116,7 @@ All routes require authentication.
 
 =back
 
-=head3 C<GET /room/:datacenter_room_id_or_alias/rack/:rack_name>
+=head3 C<GET /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name>
 
 =over 4
 

--- a/lib/Conch/Route/DatacenterRoom.pm
+++ b/lib/Conch/Route/DatacenterRoom.pm
@@ -43,8 +43,8 @@ sub routes {
     # DELETE /room/:datacenter_room_id_or_alias
     $with_datacenter_room_system_admin->delete('/')->to('#delete');
 
-    # GET /room/:datacenter_room_id_or_alias/racks
-    $with_datacenter_room_ro->get('/racks')->to('#racks');
+    # GET /room/:datacenter_room_id_or_alias/rack
+    $with_datacenter_room_ro->get('/rack')->to('#racks');
 
     # GET    /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name
     # POST   /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name
@@ -124,7 +124,7 @@ the room
 
 =back
 
-=head3 C<GET /room/:datacenter_room_id_or_alias/racks>
+=head3 C<GET /room/:datacenter_room_id_or_alias/rack>
 
 =over 4
 

--- a/lib/Conch/Route/DatacenterRoom.pm
+++ b/lib/Conch/Route/DatacenterRoom.pm
@@ -46,10 +46,20 @@ sub routes {
     # GET /room/:datacenter_room_id_or_alias/racks
     $with_datacenter_room_ro->get('/racks')->to('#racks');
 
-    # GET /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name
-    $room->under('/:datacenter_room_id_or_alias')
-        ->to('#find_datacenter_room', require_role => 'none')
-        ->get('/rack/#rack_id_or_name')->to('#find_rack', require_role => 'ro');
+    # GET    /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name
+    # POST   /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name
+    # DELETE /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name
+    # GET    /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name/layouts
+    # POST   /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name/layouts
+    # GET    /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name/assignment
+    # POST   /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name/assignment
+    # DELETE /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name/assignment
+    # POST   /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name/phase?rack_only=<0|1>
+    Conch::Route::Rack->one_rack_routes(
+        $room->under('/:datacenter_room_id_or_alias')
+            ->to('#find_datacenter_room', require_role => 'none')
+            ->any('/rack')->to(require_role => undef)
+    );
 }
 
 1;
@@ -129,9 +139,104 @@ the room (in which case data returned is restricted to those racks)
 
 =over 4
 
-=item * User requires system admin authorization, or the read-only role on the rack
+=item * User requires the read-only role on the rack
 
 =item * Response: F<response.yaml#/definitions/Rack>
+
+=back
+
+=head3 C<POST /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name>
+
+=over 4
+
+=item * User requires the read/write role on the rack
+
+=item * Request: F<request.yaml#/definitions/RackUpdate>
+
+=item * Response: Redirect to the updated rack
+
+=back
+
+=head3 C<DELETE /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name>
+
+=over 4
+
+=item * Requires system admin authorization
+
+=item * Response: C<204 NO CONTENT>
+
+=back
+
+=head3 C<GET /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name/layouts>
+
+=over 4
+
+=item * User requires the read-only role on the rack
+
+=item * Response: F<response.yaml#/definitions/RackLayouts>
+
+=back
+
+=head3 C<POST /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name/layouts>
+
+=over 4
+
+=item * User requires the read/write role on the rack
+
+=item * Request: F<request.yaml#/definitions/RackLayouts>
+
+=item * Response: Redirect to the rack's layouts
+
+=back
+
+=head3 C<GET /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name/assignment>
+
+=over 4
+
+=item * User requires the read-only role on the rack
+
+=item * Response: F<response.yaml#/definitions/RackAssignments>
+
+=back
+
+=head3 C<POST /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name/assignment>
+
+=over 4
+
+=item * User requires the read/write role on the rack
+
+=item * Request: F<request.yaml#/definitions/RackAssignmentUpdates>
+
+=item * Response: Redirect to the updated rack assignment
+
+=back
+
+=head3 C<DELETE /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name/assignment>
+
+This method requires a request body.
+
+=over 4
+
+=item * User requires the read/write role on the rack
+
+=item * Request: F<request.yaml#/definitions/RackAssignmentDeletes>
+
+=item * Response: C<204 NO CONTENT>
+
+=back
+
+=head3 C<< POST /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name/phase?rack_only=<0|1> >>
+
+The query parameter C<rack_only> (defaults to C<0>) specifies whether to update
+only the rack's phase, or all the rack's devices' phases as well.
+
+=over 4
+
+=item * User requires the read/write role on the rack
+
+=item * Request: F<request.yaml#/definitions/RackPhase>
+
+=item * Response: Redirect to the updated rack
 
 =back
 

--- a/lib/Conch/Route/Rack.pm
+++ b/lib/Conch/Route/Rack.pm
@@ -27,28 +27,28 @@ sub routes {
     # POST /rack
     $rack->require_system_admin->post('/')->to('#create');
 
-    my $with_rack = $rack->under('/<rack_id:uuid>')->to('#find_rack');
+    my $with_rack = $rack->under('/#rack_id_or_name')->to('#find_rack');
 
-    # GET /rack/:rack_id
+    # GET /rack/:rack_id_or_name
     $with_rack->get('/')->to('#get');
-    # POST /rack/:rack_id
+    # POST /rack/:rack_id_or_name
     $with_rack->post('/')->to('#update');
-    # DELETE /rack/:rack_id
+    # DELETE /rack/:rack_id_or_name
     $with_rack->require_system_admin->delete('/')->to('#delete');
 
-    # GET /rack/:rack_id/layouts
+    # GET /rack/:rack_id_or_name/layouts
     $with_rack->get('/layouts')->to('#get_layouts');
-    # POST /rack/:rack_id/layouts
+    # POST /rack/:rack_id_or_name/layouts
     $with_rack->post('/layouts')->to('#overwrite_layouts');
 
-    # GET /rack/:rack_id/assignment
+    # GET /rack/:rack_id_or_name/assignment
     $with_rack->get('/assignment')->to('#get_assignment');
-    # POST /rack/:rack_id/assignment
+    # POST /rack/:rack_id_or_name/assignment
     $with_rack->post('/assignment')->to('#set_assignment');
-    # DELETE /rack/:rack_id/assignment
+    # DELETE /rack/:rack_id_or_name/assignment
     $with_rack->delete('/assignment')->to('#delete_assignment');
 
-    # POST /rack/:rack_id/phase?rack_only=<0|1>
+    # POST /rack/:rack_id_or_name/phase?rack_only=<0|1>
     $with_rack->post('/phase')->to('#set_phase');
 }
 
@@ -81,7 +81,7 @@ All routes require authentication.
 
 =back
 
-=head3 C<GET /rack/:rack_id>
+=head3 C<GET /rack/:rack_id_or_name>
 
 =over 4
 
@@ -91,7 +91,7 @@ All routes require authentication.
 
 =back
 
-=head3 C<POST /rack/:rack_id>
+=head3 C<POST /rack/:rack_id_or_name>
 
 =over 4
 
@@ -103,7 +103,7 @@ All routes require authentication.
 
 =back
 
-=head3 C<DELETE /rack/:rack_id>
+=head3 C<DELETE /rack/:rack_id_or_name>
 
 =over 4
 
@@ -113,7 +113,7 @@ All routes require authentication.
 
 =back
 
-=head3 C<GET /rack/:rack_id/layouts>
+=head3 C<GET /rack/:rack_id_or_name/layouts>
 
 =over 4
 
@@ -123,7 +123,7 @@ All routes require authentication.
 
 =back
 
-=head3 C<POST /rack/:rack_id/layouts>
+=head3 C<POST /rack/:rack_id_or_name/layouts>
 
 =over 4
 
@@ -135,7 +135,7 @@ All routes require authentication.
 
 =back
 
-=head3 C<GET /rack/:rack_id/assignment>
+=head3 C<GET /rack/:rack_id_or_name/assignment>
 
 =over 4
 
@@ -145,7 +145,7 @@ All routes require authentication.
 
 =back
 
-=head3 C<POST /rack/:rack_id/assignment>
+=head3 C<POST /rack/:rack_id_or_name/assignment>
 
 =over 4
 
@@ -157,7 +157,7 @@ All routes require authentication.
 
 =back
 
-=head3 C<DELETE /rack/:rack_id/assignment>
+=head3 C<DELETE /rack/:rack_id_or_name/assignment>
 
 This method requires a request body.
 
@@ -171,7 +171,7 @@ This method requires a request body.
 
 =back
 
-=head3 C<< POST /rack/:rack_id/phase?rack_only=<0|1> >>
+=head3 C<< POST /rack/:rack_id_or_name/phase?rack_only=<0|1> >>
 
 The query parameter C<rack_only> (defaults to C<0>) specifies whether to update
 only the rack's phase, or all the rack's devices' phases as well.

--- a/lib/Conch/Route/Rack.pm
+++ b/lib/Conch/Route/Rack.pm
@@ -24,8 +24,6 @@ sub routes {
 
     my $rack_with_system_admin = $rack->require_system_admin;
 
-    # GET /rack
-    $rack_with_system_admin->get('/')->to('#get_all');
     # POST /rack
     $rack_with_system_admin->post('/')->to('#create');
 
@@ -83,16 +81,6 @@ All routes require authentication.
 Take note: All routes that reference a specific rack (prefix C</rack/:rack_id>) are also
 available under C</rack/:rack_id_or_long_name> as well as
 C</room/datacenter_room_id_or_alias/rack/:rack_id_or_name>.
-
-=head3 C<GET /rack>
-
-=over 4
-
-=item * Requires system admin authorization
-
-=item * Response: F<response.yaml#/definitions/Racks>
-
-=back
 
 =head3 C<POST /rack>
 

--- a/lib/Conch/Route/Rack.pm
+++ b/lib/Conch/Route/Rack.pm
@@ -32,8 +32,8 @@ sub routes {
     # GET    /rack/:rack_id_or_name
     # POST   /rack/:rack_id_or_name
     # DELETE /rack/:rack_id_or_name
-    # GET    /rack/:rack_id_or_name/layouts
-    # POST   /rack/:rack_id_or_name/layouts
+    # GET    /rack/:rack_id_or_name/layout
+    # POST   /rack/:rack_id_or_name/layout
     # GET    /rack/:rack_id_or_name/assignment
     # POST   /rack/:rack_id_or_name/assignment
     # DELETE /rack/:rack_id_or_name/assignment
@@ -57,10 +57,10 @@ sub one_rack_routes ($class, $r) {
     # DELETE .../rack/:rack_id_or_name
     $one_rack->require_system_admin->delete('/')->to('#delete');
 
-    # GET .../rack/:rack_id_or_name/layouts
-    $one_rack->get('/layouts')->to('#get_layouts');
-    # POST .../rack/:rack_id_or_name/layouts
-    $one_rack->post('/layouts')->to('#overwrite_layouts');
+    # GET .../rack/:rack_id_or_name/layout
+    $one_rack->get('/layout')->to('#get_layouts');
+    # POST .../rack/:rack_id_or_name/layout
+    $one_rack->post('/layout')->to('#overwrite_layouts');
 
     # GET .../rack/:rack_id_or_name/assignment
     $one_rack->get('/assignment')->to('#get_assignment');
@@ -138,7 +138,7 @@ C</room/datacenter_room_id_or_alias/rack/:rack_id_or_name>.
 
 =back
 
-=head3 C<GET /rack/:rack_id_or_name/layouts>
+=head3 C<GET /rack/:rack_id_or_name/layout>
 
 =over 4
 
@@ -148,7 +148,7 @@ C</room/datacenter_room_id_or_alias/rack/:rack_id_or_name>.
 
 =back
 
-=head3 C<POST /rack/:rack_id_or_name/layouts>
+=head3 C<POST /rack/:rack_id_or_name/layout>
 
 =over 4
 

--- a/lib/Conch/Route/Workspace.pm
+++ b/lib/Conch/Route/Workspace.pm
@@ -55,7 +55,7 @@ sub routes {
 
         {
             my $with_workspace_rack =
-                $with_workspace->under('/rack/<rack_id:uuid>')->to('rack#find_rack')
+                $with_workspace->under('/rack/:rack_id_or_name')->to('rack#find_rack')
                     ->under('/')->to('workspace_rack#find_workspace_rack');
 
             # DELETE /workspace/:workspace_id_or_name/rack/:rack_id
@@ -200,7 +200,7 @@ Accepts the following optional query parameters:
 
 =back
 
-=head3 C<DELETE /workspace/:workspace_id_or_name/rack/:rack_id>
+=head3 C<DELETE /workspace/:workspace_id_or_name/rack/:rack_id_or_name>
 
 =over 4
 

--- a/lib/Test/Conch/Fixtures.pm
+++ b/lib/Test/Conch/Fixtures.pm
@@ -321,11 +321,10 @@ sub generate_set ($self, $set_name, @args) {
                 using => {
                     az => "room-${num}a",
                     alias => "room ${num}a",
+                    vendor_name => "ROOM:${num}.A",
                 },
                 requires => {
                     "datacenter_$num" => { our => 'datacenter_id', their => 'id' },
-                    # this is a hack: should be able to specify requirements without copying values.
-                    global_workspace => { our => 'vendor_name', their => 'name' },
                 },
             },
             rack_role_42u => {
@@ -601,6 +600,7 @@ sub _generate_definition ($self, $fixture_type, $num, $specification) {
                 using => {
                     az => "datacenter_room_az_$num",
                     alias => "room alias $num",
+                    vendor_name => "ROOM:$num",
                     ($specification // {})->%*,
                 },
                 requires => {

--- a/sql/migrations/0138-rack-unique-name-in-room.sql
+++ b/sql/migrations/0138-rack-unique-name-in-room.sql
@@ -1,6 +1,6 @@
 SELECT run_migration(138, $$
 
-    alter table rack drop constraint rack_datacenter_room_id_name_key;
+    alter table rack drop constraint if exists rack_datacenter_room_id_name_key;
     alter table rack add constraint rack_datacenter_room_id_name_key unique (datacenter_room_id, name);
 
 $$);

--- a/sql/migrations/0142-datacenter_room-vendor_name.sql
+++ b/sql/migrations/0142-datacenter_room-vendor_name.sql
@@ -1,0 +1,7 @@
+SELECT run_migration(142, $$
+
+    alter table datacenter_room drop constraint if exists datacenter_room_vendor_name_key;
+    alter table datacenter_room alter column vendor_name set not null;
+    alter table datacenter_room add constraint datacenter_room_vendor_name_key unique (vendor_name);
+
+$$);

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -200,7 +200,7 @@ CREATE TABLE public.datacenter_room (
     datacenter_id uuid NOT NULL,
     az text NOT NULL,
     alias text NOT NULL,
-    vendor_name text,
+    vendor_name text NOT NULL,
     created timestamp with time zone DEFAULT now() NOT NULL,
     updated timestamp with time zone DEFAULT now() NOT NULL
 );
@@ -813,6 +813,14 @@ ALTER TABLE ONLY public.datacenter
 
 ALTER TABLE ONLY public.datacenter_room
     ADD CONSTRAINT datacenter_room_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: datacenter_room datacenter_room_vendor_name_key; Type: CONSTRAINT; Schema: public; Owner: conch
+--
+
+ALTER TABLE ONLY public.datacenter_room
+    ADD CONSTRAINT datacenter_room_vendor_name_key UNIQUE (vendor_name);
 
 
 --

--- a/t/conch-rollbar.t
+++ b/t/conch-rollbar.t
@@ -336,7 +336,7 @@ $t->do_and_wait_for_event(
 $t->do_and_wait_for_event(
     $rollbar_app->plugins, 'rollbar_sent',
     sub ($t) {
-        $t->get_ok('/rack/i_do_not_exist')
+        $t->get_ok('/rack/foo/bar/i_do_not_exist')
             ->status_is(404)
             ->json_is({ error => 'Not Found' });
     },
@@ -351,7 +351,7 @@ $t->do_and_wait_for_event(
             $payload->{data}{request},
             superhashof({
                 method => 'GET',
-                url => re(qr{/rack/i_do_not_exist}),
+                url => re(qr{/rack/foo/bar/i_do_not_exist}),
                 query_string => '',
                 body => '',
             }),
@@ -362,7 +362,7 @@ $t->do_and_wait_for_event(
             $payload->{data}{body},
             {
                 message => {
-                    body => 'no endpoint found for: GET /rack/i_do_not_exist',
+                    body => 'no endpoint found for: GET /rack/foo/bar/i_do_not_exist',
                 },
             },
             'message for endpoint-not-found',

--- a/t/integration/crud/build.t
+++ b/t/integration/crud/build.t
@@ -858,6 +858,7 @@ $t->get_ok('/build/my first build/device')
 my $device1 = first { $_->isa('Conch::DB::Result::Device') } $t->generate_fixtures('device');
 my $rack_layout1 = first { $_->isa('Conch::DB::Result::RackLayout') } $t->generate_fixtures('rack_layouts');
 my $rack1 = $rack_layout1->rack;
+my $room1 = $rack1->datacenter_room;
 
 $t2->post_ok('/build/my first build/rack/'.$rack1->id)
     ->status_is(403)
@@ -870,6 +871,14 @@ $t_build_admin->post_ok('/build/my first build/rack/'.$rack1->id)
 $t->post_ok('/build/my first build/rack/'.$rack1->id)
     ->status_is(204)
     ->log_debug_is('adding rack '.$rack1->id.' to build my first build');
+
+$t->post_ok($_)
+    ->status_is(204)
+    foreach
+        '/build/'.$build->{id}.'/rack/'.$rack1->id,
+        '/build/'.$build->{id}.'/rack/'.$room1->vendor_name.':'.$rack1->name,
+        '/build/my first build/rack/'.$rack1->id,
+        '/build/my first build/rack/'.$room1->vendor_name.':'.$rack1->name;
 
 $t->get_ok('/build/my first build/rack')
     ->status_is(200)

--- a/t/integration/crud/devices.t
+++ b/t/integration/crud/devices.t
@@ -1088,18 +1088,15 @@ subtest 'Device PXE' => sub {
     $t_ro->get_ok('/device/PXE_TEST/pxe')
         ->status_is(200)
         ->json_schema_is('DevicePXE')
-        ->json_is({
+        ->json_cmp_deeply({
             id => $device_pxe->id,
             phase => 'integration',
             location => {
-                datacenter => {
-                    name => $datacenter->region,
-                    vendor_name => $datacenter->vendor_name,
-                },
-                rack => {
-                    name => $layout->rack->name,
-                    rack_unit_start => $layout->rack_unit_start,
-                },
+                az => 'room-0a',
+                datacenter_room => 'room 0a',
+                rack => 'ROOM:0.A:rack.0a',
+                rack_unit_start => 3,
+                target_hardware_product => superhashof({ alias => $layout->hardware_product->alias }),
             },
             ipmi => {
                 mac => '00:00:00:00:00:cc',

--- a/t/integration/crud/devices.t
+++ b/t/integration/crud/devices.t
@@ -369,13 +369,10 @@ subtest 'located device' => sub {
             hardware_product_id => $hardware_product->id,
             sku => $hardware_product->sku,
             location => {
-                rack => {
-                    (map +($_ => $rack->$_), qw(id name datacenter_room_id serial_number asset_tag phase rack_role_id build_id)),
-                    (map +($_ => re(qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/)), qw(created updated)),
-                },
+                az => 'room-0a',
+                datacenter_room => 'room 0a',
+                rack => 'ROOM:0.A:rack.0a',
                 rack_unit_start => 1,
-                datacenter => ignore,
-                datacenter_room => superhashof({ az => 'room-0a' }),
                 target_hardware_product => superhashof({ alias => 'Test Compute' }),
             },
             latest_report => undef,
@@ -1183,9 +1180,9 @@ subtest 'Device location' => sub {
         ->status_is(200)
         ->json_schema_is('DeviceLocation')
         ->json_cmp_deeply({
-            datacenter => superhashof({ id => $rack->datacenter_room->datacenter_id }),
-            datacenter_room => superhashof({ datacenter_id => $rack->datacenter_room->datacenter_id }),
-            rack => superhashof({ id => $rack_id, name => $rack->name }),
+            az => $rack->datacenter_room->az,
+            datacenter_room => $rack->datacenter_room->alias,
+            rack => $rack->datacenter_room->vendor_name.':'.$rack->name,
             rack_unit_start => 3,
             target_hardware_product => {
                 (map +($_ => $layout->hardware_product->$_), qw(id name alias sku hardware_vendor_id)),

--- a/t/integration/crud/rack-layouts.t
+++ b/t/integration/crud/rack-layouts.t
@@ -59,9 +59,9 @@ $t->post_ok('/layout', json => { wat => 'wat' })
     ->json_schema_is('RequestValidationError')
     ->json_cmp_deeply('/details', [ { path => '/', message => re(qr/properties not allowed/i) } ]);
 
-$t->get_ok("/rack/$rack_id/layouts")
+$t->get_ok("/rack/$rack_id/layout")
     ->status_is(200)
-    ->location_is('/rack/'.$rack_id.'/layouts')
+    ->location_is('/rack/'.$rack_id.'/layout')
     ->json_schema_is('RackLayouts')
     ->json_cmp_deeply([
         map +{
@@ -176,7 +176,7 @@ my $room = $rack->datacenter_room;
 
 $t->get_ok($_)
     ->status_is(200)
-    ->location_is('/rack/'.$rack_id.'/layouts')
+    ->location_is('/rack/'.$rack_id.'/layout')
     ->json_schema_is('RackLayouts')
     ->json_cmp_deeply([
         map +{
@@ -192,14 +192,14 @@ $t->get_ok($_)
         { rack_unit_start => 42, rack_unit_size => 1, hardware_product_id => $hw_product_switch->id },
     ])
     foreach
-        '/rack/'.$rack_id.'/layouts',
-        '/rack/'.$room->vendor_name.':'.$rack->name.'/layouts',
-        '/room/'.$room->id.'/rack/'.$rack->id.'/layouts',
-        '/room/'.$room->id.'/rack/'.$room->vendor_name.':'.$rack->name.'/layouts',
-        '/room/'.$room->id.'/rack/'.$rack->name.'/layouts',
-        '/room/'.$room->alias.'/rack/'.$rack->id.'/layouts',
-        '/room/'.$room->alias.'/rack/'.$room->vendor_name.':'.$rack->name.'/layouts',
-        '/room/'.$room->alias.'/rack/'.$rack->name.'/layouts';
+        '/rack/'.$rack_id.'/layout',
+        '/rack/'.$room->vendor_name.':'.$rack->name.'/layout',
+        '/room/'.$room->id.'/rack/'.$rack->id.'/layout',
+        '/room/'.$room->id.'/rack/'.$room->vendor_name.':'.$rack->name.'/layout',
+        '/room/'.$room->id.'/rack/'.$rack->name.'/layout',
+        '/room/'.$room->alias.'/rack/'.$rack->id.'/layout',
+        '/room/'.$room->alias.'/rack/'.$room->vendor_name.':'.$rack->name.'/layout',
+        '/room/'.$room->alias.'/rack/'.$rack->name.'/layout';
 
 my $layout_3_6 = $t->load_fixture('rack_0a_layout_3_6');
 
@@ -244,9 +244,9 @@ $t->get_ok($t->tx->res->headers->location)
 # start 19, width 4     originally start 1, width 2
 # start 42, width 1
 
-$t->get_ok("/rack/$rack_id/layouts")
+$t->get_ok("/rack/$rack_id/layout")
     ->status_is(200)
-    ->location_is('/rack/'.$rack_id.'/layouts')
+    ->location_is('/rack/'.$rack_id.'/layout')
     ->json_schema_is('RackLayouts')
     ->json_cmp_deeply([
         superhashof({ rack_id => $rack_id, rack_unit_start => 3, hardware_product_id => $hw_product_storage->id }),
@@ -275,9 +275,9 @@ $t->post_ok('/layout', json => {
 # start 19, width 4     originally start 1, width 2
 # start 42, width 1
 
-$t->get_ok("/rack/$rack_id/layouts")
+$t->get_ok("/rack/$rack_id/layout")
     ->status_is(200)
-    ->location_is('/rack/'.$rack_id.'/layouts')
+    ->location_is('/rack/'.$rack_id.'/layout')
     ->json_schema_is('RackLayouts')
     ->json_cmp_deeply([
         superhashof({ rack_id => $rack_id, rack_unit_start => 1, hardware_product_id => $hw_product_compute->id }),
@@ -302,9 +302,9 @@ undef $layout_19_22;
 # start 20, width 4     originally start 1, width 2
 # start 42, width 1
 
-$t->get_ok("/rack/$rack_id/layouts")
+$t->get_ok("/rack/$rack_id/layout")
     ->status_is(200)
-    ->location_is('/rack/'.$rack_id.'/layouts')
+    ->location_is('/rack/'.$rack_id.'/layout')
     ->json_schema_is('RackLayouts')
     ->json_cmp_deeply([
         superhashof({ rack_unit_start => 1, hardware_product_id => $hw_product_compute->id }),
@@ -344,17 +344,17 @@ $t->get_ok('/layout/'.$layout_3_6->id)
 # start 20, width 4     # occupied by 'my device'
 # start 42, width 1
 
-$t->post_ok('/rack/'.$rack_id.'/layouts',
+$t->post_ok('/rack/'.$rack_id.'/layout',
         json => [{ rack_unit_start => 1, hardware_product_id => create_uuid_str }])
     ->status_is(409)
     ->json_cmp_deeply({ error => re(qr/^hardware_product_id ${\Conch::UUID::UUID_FORMAT} does not exist$/) });
 
-$t->post_ok('/rack/'.$rack_id.'/layouts',
+$t->post_ok('/rack/'.$rack_id.'/layout',
         json => [{ rack_unit_start => 42, hardware_product_id => $hw_product_compute->id }])
     ->status_is(409)
     ->json_is({ error => 'layout starting at rack_unit 42 will extend beyond the end of the rack' });
 
-$t->post_ok('/rack/'.$rack_id.'/layouts',
+$t->post_ok('/rack/'.$rack_id.'/layout',
         json => [
             { rack_unit_start => 1, hardware_product_id => $hw_product_compute->id },
             { rack_unit_start => 2, hardware_product_id => $hw_product_compute->id },
@@ -362,7 +362,7 @@ $t->post_ok('/rack/'.$rack_id.'/layouts',
     ->status_is(409)
     ->json_is({ error => 'layouts starting at rack_units 1 and 2 overlap' });
 
-$t->post_ok('/rack/'.$rack_id.'/layouts',
+$t->post_ok('/rack/'.$rack_id.'/layout',
         json => [
             # unchanged
             { rack_unit_start => 1, hardware_product_id => $hw_product_compute->id },
@@ -372,12 +372,12 @@ $t->post_ok('/rack/'.$rack_id.'/layouts',
             { rack_unit_start => 26, hardware_product_id => $hw_product_compute->id },
         ])
     ->status_is(303)
-    ->location_is('/rack/'.$rack_id.'/layouts')
+    ->location_is('/rack/'.$rack_id.'/layout')
     ->log_debug_is('deleted 2 rack layouts, created 1 rack layouts for rack '.$rack_id);
 
-$t->get_ok('/rack/'.$rack_id.'/layouts')
+$t->get_ok('/rack/'.$rack_id.'/layout')
     ->status_is(200)
-    ->location_is('/rack/'.$rack_id.'/layouts')
+    ->location_is('/rack/'.$rack_id.'/layout')
     ->json_schema_is('RackLayouts')
     ->json_cmp_deeply([
         superhashof({ rack_unit_start => 1, hardware_product_id => $hw_product_compute->id }),
@@ -394,17 +394,17 @@ $t->get_ok('/rack/'.$rack_id.'/assignment')
         { rack_unit_start => 26, rack_unit_size => 2, hardware_product_name => $hw_product_compute->name, device_id => undef, device_asset_tag => undef },
     ]);
 
-$t->post_ok('/rack/'.$rack_id.'/layouts',
+$t->post_ok('/rack/'.$rack_id.'/layout',
         json => [
             { rack_unit_start => 3, hardware_product_id => $hw_product_compute->id },
         ])
     ->status_is(303)
-    ->location_is('/rack/'.$rack_id.'/layouts')
+    ->location_is('/rack/'.$rack_id.'/layout')
     ->log_debug_is('unlocated 1 devices, deleted 3 rack layouts, created 1 rack layouts for rack '.$rack_id);
 
-$t->get_ok('/rack/'.$rack_id.'/layouts')
+$t->get_ok('/rack/'.$rack_id.'/layout')
     ->status_is(200)
-    ->location_is('/rack/'.$rack_id.'/layouts')
+    ->location_is('/rack/'.$rack_id.'/layout')
     ->json_schema_is('RackLayouts')
     ->json_cmp_deeply([
         superhashof({ rack_unit_start => 3, hardware_product_id => $hw_product_compute->id }),
@@ -417,14 +417,14 @@ $t->get_ok('/rack/'.$rack_id.'/assignment')
         { rack_unit_start => 3, rack_unit_size => 2, hardware_product_name => $hw_product_compute->name, device_id => undef, device_asset_tag => undef },
     ]);
 
-$t->post_ok('/rack/'.$rack_id.'/layouts', json => [])
+$t->post_ok('/rack/'.$rack_id.'/layout', json => [])
     ->status_is(303)
-    ->location_is('/rack/'.$rack_id.'/layouts')
+    ->location_is('/rack/'.$rack_id.'/layout')
     ->log_debug_is('deleted 1 rack layouts for rack '.$rack_id);
 
-$t->get_ok('/rack/'.$rack_id.'/layouts')
+$t->get_ok('/rack/'.$rack_id.'/layout')
     ->status_is(200)
-    ->location_is('/rack/'.$rack_id.'/layouts')
+    ->location_is('/rack/'.$rack_id.'/layout')
     ->json_schema_is('RackLayouts')
     ->json_is([]);
 

--- a/t/integration/crud/rack-layouts.t
+++ b/t/integration/crud/rack-layouts.t
@@ -61,6 +61,7 @@ $t->post_ok('/layout', json => { wat => 'wat' })
 
 $t->get_ok("/rack/$rack_id/layouts")
     ->status_is(200)
+    ->location_is('/rack/'.$rack_id.'/layouts')
     ->json_schema_is('RackLayouts')
     ->json_cmp_deeply([
         map +{
@@ -165,6 +166,7 @@ $t->post_ok('/layout', json => {
 
 $t->get_ok("/rack/$rack_id/layouts")
     ->status_is(200)
+    ->location_is('/rack/'.$rack_id.'/layouts')
     ->json_schema_is('RackLayouts');
 
 # at the moment, we have these assigned slots:
@@ -175,6 +177,7 @@ $t->get_ok("/rack/$rack_id/layouts")
 
 $t->get_ok("/rack/$rack_id/layouts")
     ->status_is(200)
+    ->location_is('/rack/'.$rack_id.'/layouts')
     ->json_schema_is('RackLayouts')
     ->json_cmp_deeply([
         map +{
@@ -235,6 +238,7 @@ $t->get_ok($t->tx->res->headers->location)
 
 $t->get_ok("/rack/$rack_id/layouts")
     ->status_is(200)
+    ->location_is('/rack/'.$rack_id.'/layouts')
     ->json_schema_is('RackLayouts')
     ->json_cmp_deeply([
         superhashof({ rack_id => $rack_id, rack_unit_start => 3, hardware_product_id => $hw_product_storage->id }),
@@ -265,6 +269,7 @@ $t->post_ok('/layout', json => {
 
 $t->get_ok("/rack/$rack_id/layouts")
     ->status_is(200)
+    ->location_is('/rack/'.$rack_id.'/layouts')
     ->json_schema_is('RackLayouts')
     ->json_cmp_deeply([
         superhashof({ rack_id => $rack_id, rack_unit_start => 1, hardware_product_id => $hw_product_compute->id }),
@@ -291,6 +296,7 @@ undef $layout_19_22;
 
 $t->get_ok("/rack/$rack_id/layouts")
     ->status_is(200)
+    ->location_is('/rack/'.$rack_id.'/layouts')
     ->json_schema_is('RackLayouts')
     ->json_cmp_deeply([
         superhashof({ rack_unit_start => 1, hardware_product_id => $hw_product_compute->id }),
@@ -363,6 +369,7 @@ $t->post_ok('/rack/'.$rack_id.'/layouts',
 
 $t->get_ok('/rack/'.$rack_id.'/layouts')
     ->status_is(200)
+    ->location_is('/rack/'.$rack_id.'/layouts')
     ->json_schema_is('RackLayouts')
     ->json_cmp_deeply([
         superhashof({ rack_unit_start => 1, hardware_product_id => $hw_product_compute->id }),
@@ -389,6 +396,7 @@ $t->post_ok('/rack/'.$rack_id.'/layouts',
 
 $t->get_ok('/rack/'.$rack_id.'/layouts')
     ->status_is(200)
+    ->location_is('/rack/'.$rack_id.'/layouts')
     ->json_schema_is('RackLayouts')
     ->json_cmp_deeply([
         superhashof({ rack_unit_start => 3, hardware_product_id => $hw_product_compute->id }),
@@ -408,6 +416,7 @@ $t->post_ok('/rack/'.$rack_id.'/layouts', json => [])
 
 $t->get_ok('/rack/'.$rack_id.'/layouts')
     ->status_is(200)
+    ->location_is('/rack/'.$rack_id.'/layouts')
     ->json_schema_is('RackLayouts')
     ->json_is([]);
 

--- a/t/integration/crud/rack-roles.t
+++ b/t/integration/crud/rack-roles.t
@@ -29,7 +29,7 @@ $t->get_ok('/rack_role/'.$role->id)
     ->json_schema_is('RackRole')
     ->json_cmp_deeply(superhashof({ name => 'rack_role 42U', rack_size => 42 }));
 
-$t->get_ok('/rack_role/name=rack_role 42U')
+$t->get_ok('/rack_role/rack_role 42U')
     ->status_is(200)
     ->json_schema_is('RackRole')
     ->json_cmp_deeply(superhashof({ name => 'rack_role 42U', rack_size => 42 }));

--- a/t/integration/crud/racks.t
+++ b/t/integration/crud/racks.t
@@ -11,11 +11,6 @@ $t->load_fixture('super_user');
 
 $t->authenticate;
 
-$t->get_ok('/rack')
-    ->status_is(200)
-    ->json_schema_is('Racks')
-    ->json_is([]);
-
 $t->load_fixture_set('workspace_room_rack_layout', 0);
 my $build = $t->generate_fixtures('build');
 
@@ -31,7 +26,7 @@ $t->get_ok('/room/'.$room->id)
         superhashof({ az => 'room-0a', alias => 'room 0a', vendor_name => 'ROOM:0.A' }),
     );
 
-$t->get_ok('/rack')
+$t->get_ok('/room/room 0a/rack')
     ->status_is(200)
     ->json_schema_is('Racks')
     ->json_cmp_deeply([ superhashof({ name => 'rack.0a' }) ]);

--- a/t/integration/crud/racks.t
+++ b/t/integration/crud/racks.t
@@ -171,7 +171,12 @@ $t->post_ok("/rack/$new_rack_id", json => { rack_role_id => $small_rack_role->id
 $t->get_ok($t->tx->res->headers->location)
     ->status_is(200)
     ->json_schema_is('Rack')
-    ->json_cmp_deeply(superhashof({ name => 'rack', serial_number => 'abc', asset_tag => 'deadbeef' }));
+    ->json_cmp_deeply(superhashof({
+        name => 'rack',
+        serial_number => 'abc',
+        asset_tag => 'deadbeef',
+        rack_role_id => $small_rack_role->id,
+    }));
 
 $t->get_ok("/rack/$new_rack_id/assignment")
     ->status_is(200)

--- a/t/integration/crud/racks.t
+++ b/t/integration/crud/racks.t
@@ -31,6 +31,7 @@ $t->get_ok('/rack')
 
 $t->get_ok($_)
     ->status_is(200)
+    ->location_is('/rack/'.$rack->id)
     ->json_schema_is('Rack')
     ->json_cmp_deeply(superhashof({
         id => $rack->id,
@@ -129,6 +130,7 @@ my $new_rack = $t->tx->res->json;
 
 $t->get_ok($_)
     ->status_is(200)
+    ->location_is('/rack/'.$new_rack->{id})
     ->json_schema_is('Rack')
     ->json_is($new_rack)
     foreach
@@ -203,6 +205,7 @@ $t->get_ok($t->tx->res->headers->location)
 
 $t->get_ok("/rack/$new_rack->{id}/assignment")
     ->status_is(200)
+    ->location_is('/rack/'.$new_rack->{id}.'/assignment')
     ->json_schema_is('RackAssignments')
     ->json_is([]);
 
@@ -240,6 +243,7 @@ my $hardware_product_storage = $t->load_fixture('hardware_product_storage');
 
 $t->get_ok('/rack/'.$rack->id.'/assignment')
     ->status_is(200)
+    ->location_is('/rack/'.$rack->id.'/assignment')
     ->json_schema_is('RackAssignments')
     ->json_is([
         {
@@ -300,6 +304,7 @@ $assignments->[1]->@{qw(device_id device_asset_tag)} = ($bar->id,'hello');
 
 $t->get_ok($t->tx->res->headers->location)
     ->status_is(200)
+    ->location_is('/rack/'.$rack->id.'/assignment')
     ->json_schema_is('RackAssignments')
     ->json_is($assignments);
 
@@ -323,6 +328,7 @@ subtest 'rack phases' => sub {
 
     $t->get_ok('/rack/'.$rack->id)
         ->status_is(200)
+        ->location_is('/rack/'.$rack->id)
         ->json_schema_is('Rack')
         ->json_is('/phase', 'production');
 
@@ -428,6 +434,7 @@ $t->app->schema->txn_do(sub {
 
 $t->get_ok('/rack/'.$rack->id.'/assignment')
     ->status_is(200)
+    ->location_is('/rack/'.$rack->id.'/assignment')
     ->json_schema_is('RackAssignments')
     ->json_is($assignments);
 
@@ -455,6 +462,7 @@ $assignments->@[0,1] = (
 
 $t->get_ok('/rack/'.$rack->id.'/assignment')
     ->status_is(200)
+    ->location_is('/rack/'.$rack->id.'/assignment')
     ->json_schema_is('RackAssignments')
     ->json_is($assignments);
 
@@ -531,6 +539,7 @@ $assignments->[0]->@{qw(device_id device_asset_tag)} = ();
 
 $t->get_ok('/rack/'.$rack->id.'/assignment')
     ->status_is(200)
+    ->location_is('/rack/'.$rack->id.'/assignment')
     ->json_schema_is('RackAssignments')
     ->json_is($assignments);
 

--- a/t/integration/crud/racks.t
+++ b/t/integration/crud/racks.t
@@ -50,9 +50,15 @@ $t->get_ok($_)
         '/rack/'.$rack->id,
         '/rack/ROOM:0.A:rack.0a',
         '/room/'.$room->id.'/rack/'.$rack->id,
+        '/room/'.$room->id.'/rack/ROOM:0.A:rack.0a',
         '/room/'.$room->id.'/rack/rack.0a',
         '/room/'.$room->alias.'/rack/'.$rack->id,
+        '/room/'.$room->alias.'/rack/ROOM:0.A:rack.0a',
         '/room/'.$room->alias.'/rack/rack.0a';
+
+$t->get_ok('/rack/rack.0a')
+    ->status_is(400)
+    ->json_is({ error => 'cannot look up rack by short name without qualifying by room' });
 
 $t->post_ok('/rack', json => { wat => 'wat' })
     ->status_is(400)
@@ -145,8 +151,10 @@ $t->get_ok($_)
         '/rack/'.$new_rack->{id},
         '/rack/'.$room->vendor_name.':'.$new_rack->{name},
         '/room/'.$room->id.'/rack/'.$new_rack->{id},
+        '/room/'.$room->id.'/rack/'.$room->vendor_name.':'.$new_rack->{name},
         '/room/'.$room->id.'/rack/'.$new_rack->{name},
         '/room/'.$room->alias.'/rack/'.$new_rack->{id},
+        '/room/'.$room->alias.'/rack/'.$room->vendor_name.':'.$new_rack->{name},
         '/room/'.$room->alias.'/rack/'.$new_rack->{name};
 
 my $small_rack_role = $t->app->db_rack_roles->create({ name => '10U', rack_size => 10 });
@@ -200,7 +208,13 @@ $t->post_ok($_, json => { rack_role_id => $small_rack_role->id })
     ->location_is('/rack/'.$new_rack->{id})
     foreach
         '/rack/'.$new_rack->{id},
-        '/rack/'.$room->vendor_name.':'.$new_rack->{name};
+        '/rack/'.$room->vendor_name.':'.$new_rack->{name},
+        '/room/'.$room->id.'/rack/'.$new_rack->{id},
+        '/room/'.$room->id.'/rack/'.$room->vendor_name.':'.$new_rack->{name},
+        '/room/'.$room->id.'/rack/'.$new_rack->{name},
+        '/room/'.$room->alias.'/rack/'.$new_rack->{id},
+        '/room/'.$room->alias.'/rack/'.$room->vendor_name.':'.$new_rack->{name},
+        '/room/'.$room->alias.'/rack/'.$new_rack->{name};
 
 $t->get_ok($t->tx->res->headers->location)
     ->status_is(200)
@@ -219,7 +233,13 @@ $t->get_ok($_)
     ->json_is([])
     foreach
         '/rack/'.$new_rack->{id}.'/assignment',
-        '/rack/'.$room->vendor_name.':'.$new_rack->{name}.'/assignment';
+        '/rack/'.$room->vendor_name.':'.$new_rack->{name}.'/assignment',
+        '/room/'.$room->id.'/rack/'.$new_rack->{id}.'/assignment',
+        '/room/'.$room->id.'/rack/'.$room->vendor_name.':'.$new_rack->{name}.'/assignment',
+        '/room/'.$room->id.'/rack/'.$new_rack->{name}.'/assignment',
+        '/room/'.$room->alias.'/rack/'.$new_rack->{id}.'/assignment',
+        '/room/'.$room->alias.'/rack/'.$room->vendor_name.':'.$new_rack->{name}.'/assignment',
+        '/room/'.$room->alias.'/rack/'.$new_rack->{name}.'/assignment';
 
 $t->delete_ok('/rack/'.$rack->id)
     ->status_is(409)
@@ -327,7 +347,13 @@ $t->get_ok($_)
     ->json_is($assignments)
     foreach
         '/rack/'.$rack->id.'/assignment',
-        '/rack/'.$room->vendor_name.':'.$rack->name.'/assignment';
+        '/rack/'.$room->vendor_name.':'.$rack->name.'/assignment',
+        '/room/'.$room->id.'/rack/'.$rack->id.'/assignment',
+        '/room/'.$room->id.'/rack/'.$room->vendor_name.':'.$rack->name.'/assignment',
+        '/room/'.$room->id.'/rack/'.$rack->name.'/assignment',
+        '/room/'.$room->alias.'/rack/'.$rack->id.'/assignment',
+        '/room/'.$room->alias.'/rack/'.$room->vendor_name.':'.$rack->name.'/assignment',
+        '/room/'.$room->alias.'/rack/'.$rack->name.'/assignment';
 
 subtest 'rack phases' => sub {
     my $device_phase_rs = $t->app->db_devices
@@ -565,7 +591,13 @@ $t->get_ok($_)
     ->json_is($assignments)
     foreach
         '/rack/'.$rack->id.'/assignment',
-        '/rack/'.$room->vendor_name.':'.$rack->name.'/assignment';
+        '/rack/'.$room->vendor_name.':'.$rack->name.'/assignment',
+        '/room/'.$room->id.'/rack/'.$rack->id.'/assignment',
+        '/room/'.$room->id.'/rack/'.$room->vendor_name.':'.$rack->name.'/assignment',
+        '/room/'.$room->id.'/rack/'.$rack->name.'/assignment',
+        '/room/'.$room->alias.'/rack/'.$rack->id.'/assignment',
+        '/room/'.$room->alias.'/rack/'.$room->vendor_name.':'.$rack->name.'/assignment',
+        '/room/'.$room->alias.'/rack/'.$rack->name.'/assignment';
 
 done_testing;
 # vim: set ts=4 sts=4 sw=4 et :

--- a/t/integration/crud/rooms.t
+++ b/t/integration/crud/rooms.t
@@ -23,27 +23,26 @@ $t->get_ok('/room')
     ->json_cmp_deeply([
         superhashof({ az => 'room-0a', alias => 'room 0a' }),
     ]);
+my $rooms = $t->tx->res->json;
+my $room = $rooms->[0];
 
 my $datacenter = $t->load_fixture('datacenter_0');
-my $room = $t->load_fixture('datacenter_room_0a');
 
-$t->get_ok('/room/'.$room->id)
+$t->get_ok($_)
     ->status_is(200)
     ->json_schema_is('DatacenterRoomDetailed')
-    ->json_cmp_deeply(superhashof({ az => 'room-0a', alias => 'room 0a' }));
+    ->json_is($room)
+    foreach
+        '/room/'.$room->{id},
+        '/room/'.$room->{alias};
 
-$t->get_ok('/room/'.$room->alias)
-    ->status_is(200)
-    ->json_schema_is('DatacenterRoomDetailed')
-    ->json_cmp_deeply(superhashof({ az => 'room-0a', alias => 'room 0a' }));
-
-$t->get_ok('/room/'.$room->id.'/racks')
+$t->get_ok('/room/'.$room->{id}.'/racks')
     ->status_is(200)
     ->json_schema_is('Racks')
     ->json_cmp_deeply([ superhashof({ name => 'rack.0a' }) ]);
 my $rack = $t->tx->res->json->[0];
 
-$t->get_ok('/room/'.$room->alias.'/racks')
+$t->get_ok('/room/'.$room->{alias}.'/racks')
     ->status_is(200)
     ->json_schema_is('Racks')
     ->json_is([ $rack ]);
@@ -53,10 +52,95 @@ $t->get_ok($_)
     ->json_schema_is('Rack')
     ->json_is($rack)
     foreach
-        '/room/'.$room->id.'/rack/'.$rack->{id},
-        '/room/'.$room->id.'/rack/rack.0a',
-        '/room/'.$room->alias.'/rack/'.$rack->{id},
-        '/room/'.$room->alias.'/rack/rack.0a';
+        '/room/'.$room->{id}.'/rack/'.$rack->{id},
+        '/room/'.$room->{id}.'/rack/rack.0a',
+        '/room/'.$room->{alias}.'/rack/'.$rack->{id},
+        '/room/'.$room->{alias}.'/rack/rack.0a';
+
+my $build_user = $t->generate_fixtures('user_account', { name => 'build_user' });
+my $build = $t->generate_fixtures('build');
+$build->create_related('user_build_roles', { user_id => $build_user->id, role => 'admin' });
+
+my $t2 = Test::Conch->new(pg => $t->pg);
+$t2->authenticate(email => $build_user->email);
+
+$t2->get_ok($_)
+    ->status_is(403)
+    foreach
+        '/room',
+        '/room/'.$room->{id},
+        '/room/'.$room->{alias},
+        '/room/'.$room->{id}.'/racks',
+        '/room/'.$room->{alias}.'/racks',
+        '/room/'.$room->{id}.'/rack/'.$rack->{id},
+        '/room/'.$room->{id}.'/rack/rack.0a',
+        '/room/'.$room->{alias}.'/rack/'.$rack->{id},
+        '/room/'.$room->{alias}.'/rack/rack.0a';
+
+$t->app->db_racks->search({ id => $rack->{id} })->update({ build_id => $build->id });
+$rack->{build_id} = $build->id;
+
+$t2->get_ok('/room')
+    ->status_is(403);
+
+$t2->get_ok($_)
+    ->status_is(200)
+    ->json_schema_is('DatacenterRoomDetailed')
+    ->json_is($room)
+    foreach
+        '/room/'.$room->{id},
+        '/room/'.$room->{alias};
+
+$t2->get_ok($_)
+    ->status_is(200)
+    ->json_schema_is('Racks')
+    ->json_is([ $rack ])
+    foreach
+        '/room/'.$room->{id}.'/racks',
+        '/room/'.$room->{alias}.'/racks';
+
+$t2->get_ok($_)
+    ->status_is(200)
+    ->json_schema_is('Rack')
+    ->json_is($rack)
+    foreach
+        '/room/'.$room->{id}.'/rack/'.$rack->{id},
+        '/room/'.$room->{id}.'/rack/rack.0a',
+        '/room/'.$room->{alias}.'/rack/'.$rack->{id},
+        '/room/'.$room->{alias}.'/rack/rack.0a';
+
+$t->app->db_racks->create({
+    datacenter_room_id => $room->{id},
+    name => 'rack2',
+    rack_role_id => $rack->{rack_role_id},
+});
+
+$t->get_ok('/room/'.$room->{id}.'/rack/rack2')
+    ->status_is(200)
+    ->json_schema_is('Rack')
+    ->json_cmp_deeply(superhashof({ name => 'rack2' }));
+my $rack2 = $t->tx->res->json;
+
+$t->get_ok('/room/'.$room->{id}.'/racks')
+    ->status_is(200)
+    ->json_schema_is('Racks')
+    ->json_is([ $rack, $rack2 ]);
+
+$t2->get_ok($_)
+    ->status_is(403)
+    foreach
+        '/room/'.$room->{id}.'/rack/'.$rack2->{id},
+        '/room/'.$room->{id}.'/rack/rack2',
+        '/room/'.$room->{alias}.'/rack/'.$rack2->{id},
+        '/room/'.$room->{alias}.'/rack/rack2';
+
+$t2->get_ok($_)
+    ->status_is(200)
+    ->json_schema_is('Racks')
+    ->json_is([ $rack ])
+    foreach
+        '/room/'.$room->{id}.'/racks',
+        '/room/'.$room->{alias}.'/racks';
 
 $t->post_ok('/room', json => { wat => 'wat' })
     ->status_is(400)
@@ -66,6 +150,9 @@ $t->post_ok('/room', json => { wat => 'wat' })
 $t->post_ok('/room', json => { datacenter_id => create_uuid_str, az => 'sungo-test-1', alias => 'me'})
     ->status_is(409)
     ->json_is({ error => 'Datacenter does not exist' });
+
+$t2->post_ok('/room', json => { datacenter_id => $datacenter->id })
+    ->status_is(403);
 
 $t->post_ok('/room', json => { datacenter_id => $datacenter->id, az => 'sungo-test-1', alias => 'me' })
     ->status_is(303);
@@ -88,9 +175,12 @@ $t->post_ok("/room/$idr", json => { datacenter_id => create_uuid_str })
     ->status_is(409)
     ->json_is({ error => 'Datacenter does not exist' });
 
-$t->post_ok("/room/$idr", json => { alias => $room->alias })
+$t->post_ok("/room/$idr", json => { alias => $room->{alias} })
     ->status_is(409)
     ->json_is({ error => 'a room already exists with that alias' });
+
+$t2->post_ok("/room/$idr", json => { vendor_name => 'sungo' })
+    ->status_is(403);
 
 $t->post_ok("/room/$idr", json => { vendor_name => 'sungo', alias => 'you' })
     ->status_is(303);
@@ -104,10 +194,13 @@ $t->get_ok($t->tx->res->headers->location)
         vendor_name => 'sungo',
     }));
 
-$t->delete_ok('/room/'.$room->id)
+$t->delete_ok('/room/'.$room->{id})
     ->status_is(409)
     ->json_schema_is('Error')
     ->json_is({ error => 'cannot delete a datacenter_room when a rack is referencing it' });
+
+$t2->delete_ok("/room/$idr")
+    ->status_is(403);
 
 $t->delete_ok("/room/$idr")
     ->status_is(204);

--- a/t/integration/crud/rooms.t
+++ b/t/integration/crud/rooms.t
@@ -30,6 +30,7 @@ my $datacenter = $t->load_fixture('datacenter_0');
 
 $t->get_ok($_)
     ->status_is(200)
+    ->location_is('/room/'.$room->{id})
     ->json_schema_is('DatacenterRoomDetailed')
     ->json_is($room)
     foreach
@@ -49,6 +50,7 @@ $t->get_ok('/room/'.$room->{alias}.'/racks')
 
 $t->get_ok($_)
     ->status_is(200)
+    ->location_is('/rack/'.$rack->{id})
     ->json_schema_is('Rack')
     ->json_is($rack)
     foreach
@@ -85,6 +87,7 @@ $t2->get_ok('/room')
 
 $t2->get_ok($_)
     ->status_is(200)
+    ->location_is('/room/'.$room->{id})
     ->json_schema_is('DatacenterRoomDetailed')
     ->json_is($room)
     foreach
@@ -101,6 +104,7 @@ $t2->get_ok($_)
 
 $t2->get_ok($_)
     ->status_is(200)
+    ->location_is('/rack/'.$rack->{id})
     ->json_schema_is('Rack')
     ->json_is($rack)
     foreach
@@ -109,16 +113,17 @@ $t2->get_ok($_)
         '/room/'.$room->{alias}.'/rack/'.$rack->{id},
         '/room/'.$room->{alias}.'/rack/rack.0a';
 
-$t->app->db_racks->create({
+my $rack2_id = $t->app->db_racks->create({
     datacenter_room_id => $room->{id},
     name => 'rack2',
     rack_role_id => $rack->{rack_role_id},
-});
+})->id;
 
 $t->get_ok('/room/'.$room->{id}.'/rack/rack2')
     ->status_is(200)
+    ->location_is('/rack/'.$rack2_id)
     ->json_schema_is('Rack')
-    ->json_cmp_deeply(superhashof({ name => 'rack2' }));
+    ->json_cmp_deeply(superhashof({ id => $rack2_id, name => 'rack2' }));
 my $rack2 = $t->tx->res->json;
 
 $t->get_ok('/room/'.$room->{id}.'/racks')

--- a/t/integration/crud/rooms.t
+++ b/t/integration/crud/rooms.t
@@ -37,13 +37,13 @@ $t->get_ok($_)
         '/room/'.$room->{id},
         '/room/'.$room->{alias};
 
-$t->get_ok('/room/'.$room->{id}.'/racks')
+$t->get_ok('/room/'.$room->{id}.'/rack')
     ->status_is(200)
     ->json_schema_is('Racks')
     ->json_cmp_deeply([ superhashof({ name => 'rack.0a' }) ]);
 my $rack = $t->tx->res->json->[0];
 
-$t->get_ok('/room/'.$room->{alias}.'/racks')
+$t->get_ok('/room/'.$room->{alias}.'/rack')
     ->status_is(200)
     ->json_schema_is('Racks')
     ->json_is([ $rack ]);
@@ -74,8 +74,8 @@ $t2->get_ok($_)
         '/room',
         '/room/'.$room->{id},
         '/room/'.$room->{alias},
-        '/room/'.$room->{id}.'/racks',
-        '/room/'.$room->{alias}.'/racks',
+        '/room/'.$room->{id}.'/rack',
+        '/room/'.$room->{alias}.'/rack',
         '/room/'.$room->{id}.'/rack/'.$rack->{id},
         '/room/'.$room->{id}.'/rack/ROOM:0.A:rack.0a',
         '/room/'.$room->{id}.'/rack/rack.0a',
@@ -103,8 +103,8 @@ $t2->get_ok($_)
     ->json_schema_is('Racks')
     ->json_is([ $rack ])
     foreach
-        '/room/'.$room->{id}.'/racks',
-        '/room/'.$room->{alias}.'/racks';
+        '/room/'.$room->{id}.'/rack',
+        '/room/'.$room->{alias}.'/rack';
 
 $t2->get_ok($_)
     ->status_is(200)
@@ -132,7 +132,7 @@ $t->get_ok('/room/'.$room->{id}.'/rack/rack2')
     ->json_cmp_deeply(superhashof({ id => $rack2_id, name => 'rack2' }));
 my $rack2 = $t->tx->res->json;
 
-$t->get_ok('/room/'.$room->{id}.'/racks')
+$t->get_ok('/room/'.$room->{id}.'/rack')
     ->status_is(200)
     ->json_schema_is('Racks')
     ->json_is([ $rack, $rack2 ]);
@@ -152,8 +152,8 @@ $t2->get_ok($_)
     ->json_schema_is('Racks')
     ->json_is([ $rack ])
     foreach
-        '/room/'.$room->{id}.'/racks',
-        '/room/'.$room->{alias}.'/racks';
+        '/room/'.$room->{id}.'/rack',
+        '/room/'.$room->{alias}.'/rack';
 
 $t->post_ok('/room', json => { wat => 'wat' })
     ->status_is(400)

--- a/t/integration/crud/rooms.t
+++ b/t/integration/crud/rooms.t
@@ -41,16 +41,22 @@ $t->get_ok('/room/'.$room->id.'/racks')
     ->status_is(200)
     ->json_schema_is('Racks')
     ->json_cmp_deeply([ superhashof({ name => 'rack.0a' }) ]);
+my $rack = $t->tx->res->json->[0];
 
 $t->get_ok('/room/'.$room->alias.'/racks')
     ->status_is(200)
     ->json_schema_is('Racks')
-    ->json_cmp_deeply([ superhashof({ name => 'rack.0a' }) ]);
+    ->json_is([ $rack ]);
 
-$t->get_ok('/room/'.$room->alias.'/rack/rack.0a')
+$t->get_ok($_)
     ->status_is(200)
     ->json_schema_is('Rack')
-    ->json_cmp_deeply(superhashof({ name => 'rack.0a' }));
+    ->json_is($rack)
+    foreach
+        '/room/'.$room->id.'/rack/'.$rack->{id},
+        '/room/'.$room->id.'/rack/rack.0a',
+        '/room/'.$room->alias.'/rack/'.$rack->{id},
+        '/room/'.$room->alias.'/rack/rack.0a';
 
 $t->post_ok('/room', json => { wat => 'wat' })
     ->status_is(400)

--- a/t/integration/crud/rooms.t
+++ b/t/integration/crud/rooms.t
@@ -55,8 +55,10 @@ $t->get_ok($_)
     ->json_is($rack)
     foreach
         '/room/'.$room->{id}.'/rack/'.$rack->{id},
+        '/room/'.$room->{id}.'/rack/ROOM:0.A:rack.0a',
         '/room/'.$room->{id}.'/rack/rack.0a',
         '/room/'.$room->{alias}.'/rack/'.$rack->{id},
+        '/room/'.$room->{alias}.'/rack/ROOM:0.A:rack.0a',
         '/room/'.$room->{alias}.'/rack/rack.0a';
 
 my $build_user = $t->generate_fixtures('user_account', { name => 'build_user' });
@@ -75,8 +77,10 @@ $t2->get_ok($_)
         '/room/'.$room->{id}.'/racks',
         '/room/'.$room->{alias}.'/racks',
         '/room/'.$room->{id}.'/rack/'.$rack->{id},
+        '/room/'.$room->{id}.'/rack/ROOM:0.A:rack.0a',
         '/room/'.$room->{id}.'/rack/rack.0a',
         '/room/'.$room->{alias}.'/rack/'.$rack->{id},
+        '/room/'.$room->{alias}.'/rack/ROOM:0.A:rack.0a',
         '/room/'.$room->{alias}.'/rack/rack.0a';
 
 $t->app->db_racks->search({ id => $rack->{id} })->update({ build_id => $build->id });
@@ -109,8 +113,10 @@ $t2->get_ok($_)
     ->json_is($rack)
     foreach
         '/room/'.$room->{id}.'/rack/'.$rack->{id},
+        '/room/'.$room->{id}.'/rack/ROOM:0.A:rack.0a',
         '/room/'.$room->{id}.'/rack/rack.0a',
         '/room/'.$room->{alias}.'/rack/'.$rack->{id},
+        '/room/'.$room->{alias}.'/rack/ROOM:0.A:rack.0a',
         '/room/'.$room->{alias}.'/rack/rack.0a';
 
 my $rack2_id = $t->app->db_racks->create({
@@ -135,8 +141,10 @@ $t2->get_ok($_)
     ->status_is(403)
     foreach
         '/room/'.$room->{id}.'/rack/'.$rack2->{id},
+        '/room/'.$room->{id}.'/rack/ROOM:0.A:rack2',
         '/room/'.$room->{id}.'/rack/rack2',
         '/room/'.$room->{alias}.'/rack/'.$rack2->{id},
+        '/room/'.$room->{alias}.'/rack/ROOM:0.A:rack2',
         '/room/'.$room->{alias}.'/rack/rack2';
 
 $t2->get_ok($_)

--- a/t/integration/crud/workspace-devices.t
+++ b/t/integration/crud/workspace-devices.t
@@ -176,8 +176,6 @@ subtest 'Devices with PXE data' => sub {
         },
     );
 
-    my $datacenter = $t->load_fixture('datacenter_0');
-
     $t->get_ok('/workspace/'.$global_ws_id.'/device/pxe')
         ->status_is(200)
         ->json_schema_is('WorkspaceDevicePXEs')
@@ -186,14 +184,11 @@ subtest 'Devices with PXE data' => sub {
                 id => $devices[0]->id,
                 phase => 'integration',
                 location => {
-                    datacenter => {
-                        name => $datacenter->region,
-                        vendor_name => $datacenter->vendor_name,
-                    },
-                    rack => {
-                        name => $layouts[0]->rack->name,
-                        rack_unit_start => $layouts[0]->rack_unit_start,
-                    },
+                    az => 'room-0a',
+                    datacenter_room => 'room 0a',
+                    rack => 'ROOM:0.A:rack.0a',
+                    rack_unit_start => $layouts[0]->rack_unit_start,
+                    target_hardware_product => superhashof({ alias => $layouts[0]->hardware_product->alias }),
                 },
                 ipmi => {
                     mac => '00:00:00:00:00:cc',
@@ -207,14 +202,11 @@ subtest 'Devices with PXE data' => sub {
                 id => $devices[1]->id,
                 phase => 'integration',
                 location => {
-                    datacenter => {
-                        name => $datacenter->region,
-                        vendor_name => $datacenter->vendor_name,
-                    },
-                    rack => {
-                        name => $layouts[1]->rack->name,
-                        rack_unit_start => $layouts[1]->rack_unit_start,
-                    },
+                    az => 'room-0a',
+                    datacenter_room => 'room 0a',
+                    rack => 'ROOM:0.A:rack.0a',
+                    rack_unit_start => $layouts[1]->rack_unit_start,
+                    target_hardware_product => superhashof({ alias => $layouts[1]->hardware_product->alias }),
                 },
                 ipmi => undef,
                 pxe => undef,

--- a/t/integration/crud/workspace-rack.t
+++ b/t/integration/crud/workspace-rack.t
@@ -114,10 +114,10 @@ subtest 'Assign device to a location' => sub {
         ->status_is(200)
         ->json_schema_is('DeviceLocation')
         ->json_cmp_deeply({
-            rack => superhashof({ id => $rack_id }),
+            az => 'room-0a',
+            datacenter_room => 'room 0a',
+            rack => 'ROOM:0.A:rack.0a',
             rack_unit_start => 1,
-            datacenter_room => superhashof({ datacenter_id => $rack->datacenter_room->datacenter_id }),
-            datacenter => superhashof({ id => $rack->datacenter_room->datacenter_id }),
             target_hardware_product => {
                 (map +($_ => $hardware_product_compute->$_), qw(id name alias sku hardware_vendor_id)),
             },


### PR DESCRIPTION
Many improvements and additions to endpoints for racks and rooms.

- room.vendor_name is now a required (not-nullable) column
- whenever you could do `<method> /rack/:rack_id/*`, you can do `<method> /rack/:rack_id_or_full_name/*`, where full name is the room vendor_name + ':' + rack name (e.g. "DC12:1F:211250:0101"), and also `<method> /room/:id_or_alias/rack/:rack_id_or_short_name_or_full_name/*`
- wherever you could do `<method> /room/:id_or_alias/:rack_name/*`, you can do `<method> /room/:id_or_alias/rack/:rack_id/*` and `<method> /room/:id_or_alias/rack/:full_rack_name/*`
- open up `<method> /room/:id_or_alias` endpoints to non-sysadmins, by checking the user role on rack(s) located in the room (racks without user access will be omitted from results)
- `GET /rack_role/name=:name` is now `GET /rack_role/:name`
- `GET /room/*/racks` is now `GET /room/*/rack`
- `GET /rack` is removed entirely (racks should be fetched from the build, room or workspace endpoints)
- the DeviceLocation schema now contains more useful information (affects `GET /device/:id_or_serial`, `GET /device/:id_or_serial/location`)
- pxe endpoints now contain more useful location data
