### PR TITLE
v3 b4 api enhancements and fixes

### DIFF
--- a/docs/json-schema/common.json
+++ b/docs/json-schema/common.json
@@ -28,7 +28,7 @@
       ]
     },
     "device_phase" : {
-      "description" : "corresponds to device_phase_enum in the database",
+      "description" : "corresponds to device_phase_enum in the database (also used for racks)",
       "enum" : [
         "integration",
         "installation",

--- a/docs/json-schema/query_params.json
+++ b/docs/json-schema/query_params.json
@@ -187,10 +187,16 @@
       },
       "type" : "object"
     },
-    "WithDeviceHealth" : {
+    "WithDeviceRackData" : {
       "additionalProperties" : false,
       "properties" : {
         "with_device_health" : {
+          "$ref" : "/definitions/boolean_integer_or_flag"
+        },
+        "with_device_phases" : {
+          "$ref" : "/definitions/boolean_integer_or_flag"
+        },
+        "with_rack_phases" : {
           "$ref" : "/definitions/boolean_integer_or_flag"
         }
       },

--- a/docs/json-schema/response.json
+++ b/docs/json-schema/response.json
@@ -1135,6 +1135,13 @@
       },
       "type" : "object"
     },
+    "DevicePXEs" : {
+      "items" : {
+        "$ref" : "/definitions/DevicePXE"
+      },
+      "type" : "array",
+      "uniqueItems" : true
+    },
     "DevicePhase" : {
       "additionalProperties" : false,
       "properties" : {

--- a/docs/json-schema/response.json
+++ b/docs/json-schema/response.json
@@ -1880,7 +1880,81 @@
     },
     "Organizations" : {
       "items" : {
-        "$ref" : "/definitions/Organization"
+        "additionalProperties" : false,
+        "properties" : {
+          "admins" : {
+            "items" : {
+              "$ref" : "/definitions/UserTerse"
+            },
+            "minItems" : 1,
+            "type" : "array",
+            "uniqueItems" : true
+          },
+          "builds" : {
+            "items" : {
+              "additionalProperties" : false,
+              "properties" : {
+                "description" : {
+                  "oneOf" : [
+                    {
+                      "type" : "string"
+                    },
+                    {
+                      "type" : "null"
+                    }
+                  ]
+                },
+                "id" : {
+                  "$ref" : "common.json#/definitions/uuid"
+                },
+                "name" : {
+                  "$ref" : "common.json#/definitions/mojo_standard_placeholder"
+                },
+                "role" : {
+                  "$ref" : "common.json#/definitions/role"
+                }
+              },
+              "required" : [
+                "id",
+                "name",
+                "description",
+                "role"
+              ],
+              "type" : "object"
+            },
+            "type" : "array",
+            "uniqueItems" : true
+          },
+          "created" : {
+            "format" : "date-time",
+            "type" : "string"
+          },
+          "description" : {
+            "oneOf" : [
+              {
+                "type" : "null"
+              },
+              {
+                "type" : "string"
+              }
+            ]
+          },
+          "id" : {
+            "$ref" : "common.json#/definitions/uuid"
+          },
+          "name" : {
+            "$ref" : "common.json#/definitions/mojo_standard_placeholder"
+          }
+        },
+        "required" : [
+          "id",
+          "name",
+          "description",
+          "created",
+          "admins",
+          "builds"
+        ],
+        "type" : "object"
       },
       "type" : "array",
       "uniqueItems" : true

--- a/docs/json-schema/response.json
+++ b/docs/json-schema/response.json
@@ -59,11 +59,33 @@
           },
           "type" : "object"
         },
+        "device_phases" : {
+          "additionalProperties" : {
+            "$ref" : "common.json#/definitions/non_negative_integer"
+          },
+          "maxProperties" : 5,
+          "minProperties" : 5,
+          "propertyNames" : {
+            "$ref" : "common.json#/definitions/device_phase"
+          },
+          "type" : "object"
+        },
         "id" : {
           "$ref" : "common.json#/definitions/uuid"
         },
         "name" : {
           "$ref" : "common.json#/definitions/mojo_standard_placeholder"
+        },
+        "rack_phases" : {
+          "additionalProperties" : {
+            "$ref" : "common.json#/definitions/non_negative_integer"
+          },
+          "maxProperties" : 5,
+          "minProperties" : 5,
+          "propertyNames" : {
+            "$ref" : "common.json#/definitions/device_phase"
+          },
+          "type" : "object"
         },
         "started" : {
           "oneOf" : [

--- a/docs/json-schema/response.json
+++ b/docs/json-schema/response.json
@@ -322,6 +322,16 @@
             }
           ]
         },
+        "build_name" : {
+          "oneOf" : [
+            {
+              "type" : "null"
+            },
+            {
+              "$ref" : "common.json#/definitions/mojo_standard_placeholder"
+            }
+          ]
+        },
         "created" : {
           "format" : "date-time",
           "type" : "string"
@@ -653,6 +663,7 @@
         "phase",
         "links",
         "build_id",
+        "build_name",
         "latest_report"
       ],
       "then" : {
@@ -719,6 +730,16 @@
             }
           ]
         },
+        "build_name" : {
+          "oneOf" : [
+            {
+              "type" : "null"
+            },
+            {
+              "$ref" : "common.json#/definitions/mojo_standard_placeholder"
+            }
+          ]
+        },
         "created" : {
           "format" : "date-time",
           "type" : "string"
@@ -775,6 +796,7 @@
           ]
         },
         "rack_name" : {
+          "description" : "rack.full_rack_name (datacenter_room.vendor_name + ':' + rack.name)",
           "oneOf" : [
             {
               "$ref" : "common.json#/definitions/mojo_relaxed_placeholder"
@@ -853,7 +875,8 @@
         "validated",
         "phase",
         "links",
-        "build_id"
+        "build_id",
+        "build_name"
       ],
       "then" : {
         "required" : [
@@ -1952,12 +1975,28 @@
             }
           ]
         },
+        "build_name" : {
+          "oneOf" : [
+            {
+              "type" : "null"
+            },
+            {
+              "$ref" : "common.json#/definitions/mojo_standard_placeholder"
+            }
+          ]
+        },
         "created" : {
           "format" : "date-time",
           "type" : "string"
         },
+        "datacenter_room_alias" : {
+          "$ref" : "common.json#/definitions/mojo_standard_placeholder"
+        },
         "datacenter_room_id" : {
           "$ref" : "common.json#/definitions/uuid"
+        },
+        "full_rack_name" : {
+          "$ref" : "common.json#/definitions/mojo_relaxed_placeholder"
         },
         "id" : {
           "$ref" : "common.json#/definitions/uuid"
@@ -1970,6 +2009,9 @@
         },
         "rack_role_id" : {
           "$ref" : "common.json#/definitions/uuid"
+        },
+        "rack_role_name" : {
+          "$ref" : "common.json#/definitions/mojo_standard_placeholder"
         },
         "serial_number" : {
           "oneOf" : [
@@ -1989,14 +2031,18 @@
       "required" : [
         "id",
         "name",
+        "full_rack_name",
         "datacenter_room_id",
+        "datacenter_room_alias",
         "rack_role_id",
+        "rack_role_name",
         "serial_number",
         "asset_tag",
         "phase",
         "created",
         "updated",
-        "build_id"
+        "build_id",
+        "build_name"
       ],
       "type" : "object"
     },
@@ -2031,12 +2077,16 @@
         },
         "rack_unit_start" : {
           "$ref" : "common.json#/definitions/positive_integer"
+        },
+        "sku" : {
+          "$ref" : "common.json#/definitions/mojo_standard_placeholder"
         }
       },
       "required" : [
         "device_id",
         "device_asset_tag",
         "hardware_product_name",
+        "sku",
         "rack_unit_start",
         "rack_unit_size"
       ],
@@ -2065,11 +2115,17 @@
         "rack_id" : {
           "$ref" : "common.json#/definitions/uuid"
         },
+        "rack_name" : {
+          "$ref" : "common.json#/definitions/mojo_relaxed_placeholder"
+        },
         "rack_unit_size" : {
           "$ref" : "common.json#/definitions/positive_integer"
         },
         "rack_unit_start" : {
           "$ref" : "common.json#/definitions/positive_integer"
+        },
+        "sku" : {
+          "$ref" : "common.json#/definitions/mojo_standard_placeholder"
         },
         "updated" : {
           "format" : "date-time",
@@ -2079,7 +2135,9 @@
       "required" : [
         "id",
         "rack_id",
+        "rack_name",
         "hardware_product_id",
+        "sku",
         "rack_unit_start",
         "rack_unit_size",
         "created",

--- a/docs/modules/Conch::Command::copy_user_data.md
+++ b/docs/modules/Conch::Command::copy_user_data.md
@@ -28,7 +28,7 @@ pg_dump -U conch  --inserts -t user_account -t user_session_token conch | psql -
 carton exec bin/conch copy_user_data --from conch_staging_$(date '+%Y%m%d')_user_bak --to conch_prod_$(date '+%Y%m%d')
 
 carton exec hypnotoad -s bin/conch
-psql -U postgres --command="rename database conch conch_staging_$(date '+%Y%m%d')_bak; rename database conch_prod_$(date '+%Y%m%d') conch"
+psql -U postgres --command="alter database conch rename to conch_staging_$(date '+%Y%m%d')_bak; alter database conch_prod_$(date '+%Y%m%d') rename to conch"
 carton exec hypnotoad bin/conch
 ```
 

--- a/docs/modules/Conch::Controller::Build.md
+++ b/docs/modules/Conch::Controller::Build.md
@@ -90,6 +90,14 @@ Requires the 'admin' role on the build.
 Optionally takes a query parameter `send_mail` (defaulting to true), to send an email
 to all organization members and to all build admins.
 
+## find\_devices
+
+Chainable action that stashes the query to get to all devices in `build_devices_rs`.
+
+If `phase_earlier_than` is provided (defaulting to `production`), location data is omitted
+for devices in the provided phase (or later) (and build racks are not used to find such devices
+for such phases).
+
 ## get\_devices
 
 Get the devices in this build. (Does not includes devices located in rack(s) in this build if
@@ -110,6 +118,10 @@ serials_only=1      only return device serial numbers, not full data
 
 Response uses the Devices json schema, or DeviceIds iff `ids_only=1`, or DeviceSerials iff
 `serials_only=1`.
+
+## get\_pxe\_devices
+
+Response uses the DevicePXEs json schema.
 
 ## create\_and\_add\_devices
 

--- a/docs/modules/Conch::Controller::Build.md
+++ b/docs/modules/Conch::Controller::Build.md
@@ -4,7 +4,7 @@ Conch::Controller::Build
 
 # METHODS
 
-## list
+## get\_all
 
 If the user is a system admin, retrieve a list of all builds in the database; otherwise,
 limits the list to those build of which the user is a member.
@@ -37,7 +37,7 @@ Response uses the Build json schema.
 Modifies a build attribute: one or more of name, description, started, completed.
 Requires the 'admin' role on the build.
 
-## list\_users
+## get\_users
 
 Get a list of user members of the current build. (Does not include users who can access the
 build via an organization.)
@@ -66,7 +66,7 @@ to the user and to all build admins.
 
 This endpoint is nearly identical to ["remove\_user" in Conch::Controller::Organization](../modules/Conch%3A%3AController%3A%3AOrganization#remove_user).
 
-## list\_organizations
+## get\_organizations
 
 Get a list of organization members of the current build.
 Requires the 'admin' role on the build.

--- a/docs/modules/Conch::Controller::DeviceValidation.md
+++ b/docs/modules/Conch::Controller::DeviceValidation.md
@@ -4,7 +4,7 @@ Conch::Controller::DeviceValidation
 
 # METHODS
 
-## list\_validation\_states
+## get\_validation\_states
 
 Get the latest validation states for a device. Accepts the query parameter `status`,
 indicating the desired status(es) to search for -- one or more of: pass, fail, error.

--- a/docs/modules/Conch::Controller::HardwareProduct.md
+++ b/docs/modules/Conch::Controller::HardwareProduct.md
@@ -12,11 +12,12 @@ Response uses the HardwareProducts json schema.
 
 ## find\_hardware\_product
 
-Chainable action that uses the `hardware_product_id` or `hardware_product_key` and
+Chainable action that uses the `hardware_product_id_or_sku` or `hardware_product_key` and
 `hardware_product_value` values provided in the stash (usually via the request URL) to look up
 a hardware\_product, and stashes the query to get to it in `hardware_product_rs`.
 
-Supported keys are: `sku`, `name`, and `alias`.
+Supported keys are: `sku`, `name`, and `alias`. This feature is deprecated and will be
+removed in a subsequent release.
 
 ## get
 

--- a/docs/modules/Conch::Controller::HardwareProduct.md
+++ b/docs/modules/Conch::Controller::HardwareProduct.md
@@ -4,7 +4,7 @@ Conch::Controller::HardwareProduct
 
 # METHODS
 
-## list
+## get\_all
 
 Get a list of all available hardware products.
 

--- a/docs/modules/Conch::Controller::HardwareVendor.md
+++ b/docs/modules/Conch::Controller::HardwareVendor.md
@@ -7,7 +7,8 @@ Conch::Controller::HardwareVendor
 ## find\_hardware\_vendor
 
 Chainable action that uses the `hardware_vendor_id_or_name` value provided in the stash
-(usually via the request URL) to look up a build, and stashes the result in `hardware_vendor`.
+(usually via the request URL) to look up a hardware vendor, and stashes the result in
+`hardware_vendor`.
 
 ## get\_all
 

--- a/docs/modules/Conch::Controller::Login.md
+++ b/docs/modules/Conch::Controller::Login.md
@@ -22,12 +22,12 @@ Handle the details of authenticating the user, with one of the following options
 Does not terminate the connection if authentication is successful, allowing for chaining to
 subsequent routes and actions.
 
-## session\_login
+## login
 
 Handles the act of logging in, given a user and password in the form.
 Response uses the Login json schema, containing a JWT.
 
-## session\_logout
+## logout
 
 Logs a user out by expiring their session
 

--- a/docs/modules/Conch::Controller::Organization.md
+++ b/docs/modules/Conch::Controller::Organization.md
@@ -4,7 +4,7 @@ Conch::Controller::Organization
 
 # METHODS
 
-## list
+## get\_all
 
 If the user is a system admin, retrieve a list of all active organizations in the database;
 otherwise, limits the list to those organizations of which the user is a member.

--- a/docs/modules/Conch::Controller::Organization.md
+++ b/docs/modules/Conch::Controller::Organization.md
@@ -6,8 +6,10 @@ Conch::Controller::Organization
 
 ## get\_all
 
-If the user is a system admin, retrieve a list of all active organizations in the database;
-otherwise, limits the list to those organizations of which the user is a member.
+Retrieve a list of organization details (including each organization's admins).
+
+If the user is a system admin, all active organizations are retrieved; otherwise, limits the
+list to those organizations of which the user is a member.
 
 Response uses the Organizations json schema.
 
@@ -28,7 +30,7 @@ continue; otherwise the user must have the 'admin' role.
 
 ## get
 
-Get the details of a single organization.
+Get the details of a single organization, including its members.
 Requires the 'admin' role on the organization.
 
 Response uses the Organization json schema.

--- a/docs/modules/Conch::Controller::Organization.md
+++ b/docs/modules/Conch::Controller::Organization.md
@@ -22,7 +22,7 @@ Requires the user to be a system admin.
 ## find\_organization
 
 Chainable action that uses the `organization_id_or_name` value provided in the stash (usually
-via the request URL) to look up a build, and stashes the query to get to it in
+via the request URL) to look up an organization, and stashes the query to get to it in
 `organization_rs`.
 
 If `require_role` is provided, it is used as the minimum required role for the user to

--- a/docs/modules/Conch::Controller::RackLayout.md
+++ b/docs/modules/Conch::Controller::RackLayout.md
@@ -7,7 +7,7 @@ Conch::Controller::RackLayout
 ## find\_rack\_layout
 
 Chainable action that uses the `layout_id` value provided in the stash (usually via the
-request URL) to look up a build, and stashes the query to get to it in `layout_rs`.
+request URL) to look up a layout, and stashes the query to get to it in `layout_rs`.
 
 ## create
 

--- a/docs/modules/Conch::Controller::RackLayout.md
+++ b/docs/modules/Conch::Controller::RackLayout.md
@@ -6,8 +6,9 @@ Conch::Controller::RackLayout
 
 ## find\_rack\_layout
 
-Chainable action that uses the `layout_id` value provided in the stash (usually via the
-request URL) to look up a layout, and stashes the query to get to it in `layout_rs`.
+Chainable action that uses the `layout_id_or_rack_unit_start` value provided in the stash
+(usually via the request URL) to look up a layout, and stashes the query to get to it in
+`layout_rs`.
 
 ## create
 

--- a/docs/modules/Conch::Controller::RackRole.md
+++ b/docs/modules/Conch::Controller::RackRole.md
@@ -7,7 +7,7 @@ Conch::Controller::RackRole
 ## find\_rack\_role
 
 Chainable action that uses the `rack_role_id_or_name` value provided in the stash (usually via
-the request URL) to look up a build, and stashes the result in `rack_role`.
+the request URL) to look up a rack role, and stashes the result in `rack_role`.
 
 ## create
 

--- a/docs/modules/Conch::Controller::Relay.md
+++ b/docs/modules/Conch::Controller::Relay.md
@@ -9,7 +9,7 @@ Conch::Controller::Relay
 Registers a relay and connects it with the current user. The relay is created if the relay does
 not already exist, or is updated with additional payload information otherwise.
 
-## list
+## get\_all
 
 Retrieve a list of all active relays in the database.
 

--- a/docs/modules/Conch::Controller::User.md
+++ b/docs/modules/Conch::Controller::User.md
@@ -102,7 +102,7 @@ Sends an email to the affected user, unless `?send_mail=0` is included in the qu
 The response uses the UserError json schema for some error conditions; on success, redirects to
 `GET /user/:id`.
 
-## list
+## get\_all
 
 List all active users and their workspaces, builds and organizations. System admin only.
 Response uses the UsersDetailed json schema.

--- a/docs/modules/Conch::Controller::Validation.md
+++ b/docs/modules/Conch::Controller::Validation.md
@@ -6,7 +6,7 @@ Controller for managing Validations, **NOT** executing them.
 
 # METHODS
 
-## list
+## get\_all
 
 List all Validations.
 

--- a/docs/modules/Conch::Controller::ValidationPlan.md
+++ b/docs/modules/Conch::Controller::ValidationPlan.md
@@ -6,7 +6,7 @@ Controller for managing Validation Plans
 
 # METHODS
 
-## list
+## get\_all
 
 List all available Validation Plans.
 
@@ -24,7 +24,7 @@ Get the (active) Validation Plan specified by uuid or name.
 
 Response uses the ValidationPlan json schema.
 
-## list\_validations
+## get\_validations
 
 List all Validations associated with the Validation Plan, both active and deactivated.
 

--- a/docs/modules/Conch::Controller::Workspace.md
+++ b/docs/modules/Conch::Controller::Workspace.md
@@ -14,7 +14,7 @@ If the workspace name is provided, `workspace_id` is looked up and stashed.
 `require_role` is used as the minimum required role for the user to continue; otherwise the
 user must be a system admin.
 
-## list
+## get\_all
 
 Get a list of all workspaces available to the currently authenticated user.
 

--- a/docs/modules/Conch::Controller::WorkspaceDevice.md
+++ b/docs/modules/Conch::Controller::WorkspaceDevice.md
@@ -4,7 +4,7 @@ Conch::Controller::WorkspaceDevice
 
 # METHODS
 
-## list
+## get\_all
 
 Get a list of all devices in the indicated workspace.
 

--- a/docs/modules/Conch::Controller::WorkspaceRack.md
+++ b/docs/modules/Conch::Controller::WorkspaceRack.md
@@ -4,7 +4,7 @@ Conch::Controller::WorkspaceRack
 
 # METHODS
 
-## list
+## get\_all
 
 Get a list of racks for the indicated workspace.
 

--- a/docs/modules/Conch::Controller::WorkspaceRelay.md
+++ b/docs/modules/Conch::Controller::WorkspaceRelay.md
@@ -4,7 +4,7 @@ Conch::Controller::WorkspaceRelay
 
 # METHODS
 
-## list
+## get\_all
 
 List all relays located in the indicated workspace and sub-workspaces beneath it.
 Note that this information is only accurate if the device the relay(s) reported

--- a/docs/modules/Conch::Controller::WorkspaceUser.md
+++ b/docs/modules/Conch::Controller::WorkspaceUser.md
@@ -4,7 +4,7 @@ Conch::Controller::WorkspaceUser
 
 # METHODS
 
-## list
+## get\_all
 
 Get a list of users for the indicated workspace (not including system admin users).
 Requires the 'admin' role on the workspace.

--- a/docs/modules/Conch::DB::ResultSet::Build.md
+++ b/docs/modules/Conch::DB::ResultSet::Build.md
@@ -27,8 +27,18 @@ Returns a boolean.
 
 ## with\_device\_health\_counts
 
-Modifies the resultset to add on a column named `device_health`) containing an array of arrays
+Modifies the resultset to add on a column named `device_health` containing an array of arrays
 of correlated counts of device.health values for each build.
+
+## with\_device\_phase\_counts
+
+Modifies the resultset to add on a column named `device_phases` containing an array of arrays
+of correlated counts of device.phase values for each build.
+
+## with\_rack\_phase\_counts
+
+Modifies the resultset to add on a column named `rack_phases` containing an array of arrays
+of correlated counts of rack.phase values for each build.
 
 # LICENSING
 

--- a/docs/modules/Conch::DB::ResultSet::Device.md
+++ b/docs/modules/Conch::DB::ResultSet::Device.md
@@ -67,11 +67,16 @@ you want, so don't do that.)
 
 ## with\_device\_location
 
-Modifies the resultset to add columns `rack_id`, `rack_unit_start` and `rack_name`.
+Modifies the resultset to add columns `rack_id`, `rack_name` (the full rack name including
+room data) and `rack_unit_start`.
 
 ## with\_sku
 
 Modifies the resultset to add the `sku` column.
+
+## with\_build\_name
+
+Modifies the resultset to add the `build_name` column.
 
 ## location\_data
 

--- a/docs/modules/Conch::DB::ResultSet::Rack.md
+++ b/docs/modules/Conch::DB::ResultSet::Rack.md
@@ -31,6 +31,22 @@ build associated with the rack(s).
 
 Returns a boolean.
 
+## with\_build\_name
+
+Modifies the resultset to add the `build_name` column.
+
+## with\_full\_rack\_name
+
+Modifies the resultset to add the `full_rack_name` column.
+
+## with\_datacenter\_room\_alias
+
+Modifies the resultset to add the `datacenter_room_alias` column.
+
+## with\_rack\_role\_name
+
+Modifies the resultset to add the `rack_role_name` column.
+
 # LICENSING
 
 Copyright Joyent, Inc.

--- a/docs/modules/Conch::DB::ResultSet::RackLayout.md
+++ b/docs/modules/Conch::DB::ResultSet::RackLayout.md
@@ -12,6 +12,14 @@ Interface to queries involving rack layouts.
 
 Chainable resultset that adds `rack_unit_size` to the results.
 
+## with\_rack\_name
+
+Modifies the resultset to add the `rack_name` column (the full rack name).
+
+## with\_sku
+
+Modifies the resultset to add the `sku` column.
+
 # LICENSING
 
 Copyright Joyent, Inc.

--- a/docs/modules/Conch::Plugin::DeprecatedAction.md
+++ b/docs/modules/Conch::Plugin::DeprecatedAction.md
@@ -1,0 +1,24 @@
+# NAME
+
+Conch::Plugin::DeprecationAction
+
+# DESCRIPTION
+
+Mojo plugin to detect and report the usage of deprecated controller actions.
+
+# HOOKS
+
+## around\_action
+
+Sets the `X-Deprecated` header in the response.
+
+Also sends a message to rollbar when a deprecated action is invoked, if the
+`report_deprecated_actions` feature is enabled.
+
+# LICENSING
+
+Copyright Joyent, Inc.
+
+This Source Code Form is subject to the terms of the Mozilla Public License,
+v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+one at [http://mozilla.org/MPL/2.0/](http://mozilla.org/MPL/2.0/).

--- a/docs/modules/Conch::Route::Build.md
+++ b/docs/modules/Conch::Route::Build.md
@@ -91,9 +91,9 @@ an email to the organization members and build admins.
 
 Accepts the following optional query parameters:
 
-- `health=<value>` show only devices with the health matching the provided value
+- `health=:value` show only devices with the health matching the provided value
 (can be used more than once)
-- `active_minutes=X` show only devices which have reported within the last X minutes
+- `active_minutes=:X` show only devices which have reported within the last X minutes
 - `ids_only=1` only return device IDs, not full device details
 
 - Requires system admin authorization or the read-only role on the build

--- a/docs/modules/Conch::Route::Build.md
+++ b/docs/modules/Conch::Route::Build.md
@@ -93,6 +93,11 @@ Accepts the following optional query parameters:
 - Requires system admin authorization or the read-only role on the build
 - Response: [response.json#/definitions/Devices](../json-schema/response.json#/definitions/Devices), [response.json#/definitions/DeviceIds](../json-schema/response.json#/definitions/DeviceIds) or [response.json#/definitions/DeviceSerials](../json-schema/response.json#/definitions/DeviceSerials)
 
+### `GET /build/:build_id_or_name/device/pxe`
+
+- Requires system admin authorization or the read-only role on the build
+- Response: [response.json#/definitions/DevicePXEs](../json-schema/response.json#/definitions/DevicePXEs)
+
 ### `POST /build/:build_id_or_name/device`
 
 - Requires system admin authorization, or the read/write role on the build and the

--- a/docs/modules/Conch::Route::Build.md
+++ b/docs/modules/Conch::Route::Build.md
@@ -12,8 +12,11 @@ All routes require authentication.
 
 ### `GET /build`
 
-Takes one optional query parameter `device_health` (defaults to false) to include
-correlated counts of devices having each health value.
+Supports the following optional query parameters:
+
+- `with_device_health` - includes correlated counts of devices having each health value
+- `with_device_phases` - includes correlated counts of devices having each phase value
+- `with_rack_phases` - includes correlated counts of racks having each phase value
 
 - Response: response.yaml#/Builds
 
@@ -25,8 +28,11 @@ correlated counts of devices having each health value.
 
 ### `GET /build/:build_id_or_name`
 
-Takes one optional query parameter `device_health` (defaults to false) to include counts
-of devices having each health value.
+Supports the following optional query parameters:
+
+- `with_device_health` - includes correlated counts of devices having each health value
+- `with_device_phases` - includes correlated counts of devices having each phase value
+- `with_rack_phases` - includes correlated counts of racks having each phase value
 
 - Requires system admin authorization or the read-only role on the build
 - Response: response.yaml#/Build

--- a/docs/modules/Conch::Route::DatacenterRoom.md
+++ b/docs/modules/Conch::Route::DatacenterRoom.md
@@ -101,15 +101,15 @@ only the rack's phase, or all the rack's devices' phases as well.
 
 ### `GET /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name/layout/:layout_id_or_rack_unit_start`
 
-See ["`GET /layout/:layout_id`" in Conch::Route::RackLayout](../modules/Conch%3A%3ARoute%3A%3ARackLayout#GET-layout-:layout_id).
+See ["`GET /layout/:layout_id`" in Conch::Route::RackLayout](../modules/Conch%3A%3ARoute%3A%3ARackLayout#get-layoutlayout_id).
 
 ### `POST /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name/layout/:layout_id_or_rack_unit_start`
 
-See ["`POST /layout/:layout_id`" in Conch::Route::RackLayout](../modules/Conch%3A%3ARoute%3A%3ARackLayout#POST-layout-:layout_id).
+See ["`POST /layout/:layout_id`" in Conch::Route::RackLayout](../modules/Conch%3A%3ARoute%3A%3ARackLayout#post-layoutlayout_id).
 
 ### `DELETE /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name/layout/:layout_id_or_rack_unit_start`
 
-See ["`DELETE /layout/:layout_id`" in Conch::Route::RackLayout](../modules/Conch%3A%3ARoute%3A%3ARackLayout#DELETE-layout-:layout_id).
+See ["`DELETE /layout/:layout_id`" in Conch::Route::RackLayout](../modules/Conch%3A%3ARoute%3A%3ARackLayout#delete-layoutlayout_id).
 
 # LICENSING
 

--- a/docs/modules/Conch::Route::DatacenterRoom.md
+++ b/docs/modules/Conch::Route::DatacenterRoom.md
@@ -99,6 +99,18 @@ only the rack's phase, or all the rack's devices' phases as well.
 - Request: [request.json#/definitions/RackPhase](../json-schema/request.json#/definitions/RackPhase)
 - Response: Redirect to the updated rack
 
+### `GET /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name/layout/:layout_id_or_rack_unit_start`
+
+See ["`GET /layout/:layout_id`" in Conch::Route::RackLayout](../modules/Conch%3A%3ARoute%3A%3ARackLayout#GET-layout-:layout_id).
+
+### `POST /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name/layout/:layout_id_or_rack_unit_start`
+
+See ["`POST /layout/:layout_id`" in Conch::Route::RackLayout](../modules/Conch%3A%3ARoute%3A%3ARackLayout#POST-layout-:layout_id).
+
+### `DELETE /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name/layout/:layout_id_or_rack_unit_start`
+
+See ["`DELETE /layout/:layout_id`" in Conch::Route::RackLayout](../modules/Conch%3A%3ARoute%3A%3ARackLayout#DELETE-layout-:layout_id).
+
 # LICENSING
 
 Copyright Joyent, Inc.

--- a/docs/modules/Conch::Route::Device.md
+++ b/docs/modules/Conch::Route::Device.md
@@ -28,10 +28,10 @@ using a relay that registered with that user's credentials.
 
 Supports the following query parameters:
 
-- `/device?hostname=:hostname`
-- `/device?mac=:macaddr`
-- `/device?ipaddr=:ipaddr`
-- `/device?:setting_key=:setting_value`
+- `hostname=:hostname`
+- `mac=:macaddr`
+- `ipaddr=:ipaddr`
+- `:setting_key=:setting_value`
 
 The value of `:setting_key` and `:setting_value` are a device setting key and
 value. For information on how to create a setting key or set its value see

--- a/docs/modules/Conch::Route::HardwareProduct.md
+++ b/docs/modules/Conch::Route::HardwareProduct.md
@@ -20,35 +20,23 @@ All routes require authentication.
 - Request: [request.json#/definitions/HardwareProductCreate](../json-schema/request.json#/definitions/HardwareProductCreate)
 - Response: Redirect to the created hardware product
 
-### `GET /hardware_product/:hardware_product_id`
+### `GET /hardware_product/:hardware_product_id_or_other`
 
-### `GET /hardware_product/name=:hardware_product_name`
-
-### `GET /hardware_product/alias=:hardware_product_alias`
-
-### `GET /hardware_product/sku=:hardware_product_sku`
+Identifiers accepted: `id`, `sku`, `name` and `alias`.
 
 - Response: [response.json#/definitions/HardwareProduct](../json-schema/response.json#/definitions/HardwareProduct)
 
-### `POST /hardware_product/:hardware_product_id`
+### `POST /hardware_product/:hardware_product_id_or_other`
 
-### `POST /hardware_product/name=:hardware_product_name`
-
-### `POST /hardware_product/alias=:hardware_product_alias`
-
-### `POST /hardware_product/sku=:hardware_product_sku`
+Identifiers accepted: `id`, `sku`, `name` and `alias`.
 
 - Requires system admin authorization
 - Request: [request.json#/definitions/HardwareProductUpdate](../json-schema/request.json#/definitions/HardwareProductUpdate)
 - Response: Redirect to the updated hardware product
 
-### `DELETE /hardware_product/:hardware_product_id`
+### `DELETE /hardware_product/:hardware_product_id_or_other`
 
-### `DELETE /hardware_product/name=:hardware_product_name`
-
-### `DELETE /hardware_product/alias=:hardware_product_alias`
-
-### `DELETE /hardware_product/sku=:hardware_product_sku`
+Identifiers accepted: `id`, `sku`, `name` and `alias`.
 
 - Requires system admin authorization
 - Response: `204 NO CONTENT`

--- a/docs/modules/Conch::Route::Rack.md
+++ b/docs/modules/Conch::Route::Rack.md
@@ -81,15 +81,15 @@ only the rack's phase, or all the rack's devices' phases as well.
 
 ### `GET /rack/:rack_id_or_name/layout/:layout_id_or_rack_unit_start`
 
-See ["`GET /layout/:layout_id`" in Conch::Route::RackLayout](../modules/Conch%3A%3ARoute%3A%3ARackLayout#GET-layout-:layout_id).
+See ["`GET /layout/:layout_id`" in Conch::Route::RackLayout](../modules/Conch%3A%3ARoute%3A%3ARackLayout#get-layoutlayout_id).
 
 ### `POST /rack/:rack_id_or_name/layout/:layout_id_or_rack_unit_start`
 
-See ["`POST /layout/:layout_id`" in Conch::Route::RackLayout](../modules/Conch%3A%3ARoute%3A%3ARackLayout#POST-layout-:layout_id).
+See ["`POST /layout/:layout_id`" in Conch::Route::RackLayout](../modules/Conch%3A%3ARoute%3A%3ARackLayout#post-layoutlayout_id).
 
 ### `DELETE /rack/:rack_id_or_name/layout/:layout_id_or_rack_unit_start`
 
-See ["`DELETE /layout/:layout_id`" in Conch::Route::RackLayout](../modules/Conch%3A%3ARoute%3A%3ARackLayout#DELETE-layout-:layout_id).
+See ["`DELETE /layout/:layout_id`" in Conch::Route::RackLayout](../modules/Conch%3A%3ARoute%3A%3ARackLayout#delete-layoutlayout_id).
 
 # LICENSING
 

--- a/docs/modules/Conch::Route::Rack.md
+++ b/docs/modules/Conch::Route::Rack.md
@@ -79,6 +79,18 @@ only the rack's phase, or all the rack's devices' phases as well.
 - Request: [request.json#/definitions/RackPhase](../json-schema/request.json#/definitions/RackPhase)
 - Response: Redirect to the updated rack
 
+### `GET /rack/:rack_id_or_name/layout/:layout_id_or_rack_unit_start`
+
+See ["`GET /layout/:layout_id`" in Conch::Route::RackLayout](../modules/Conch%3A%3ARoute%3A%3ARackLayout#GET-layout-:layout_id).
+
+### `POST /rack/:rack_id_or_name/layout/:layout_id_or_rack_unit_start`
+
+See ["`POST /layout/:layout_id`" in Conch::Route::RackLayout](../modules/Conch%3A%3ARoute%3A%3ARackLayout#POST-layout-:layout_id).
+
+### `DELETE /rack/:rack_id_or_name/layout/:layout_id_or_rack_unit_start`
+
+See ["`DELETE /layout/:layout_id`" in Conch::Route::RackLayout](../modules/Conch%3A%3ARoute%3A%3ARackLayout#DELETE-layout-:layout_id).
+
 # LICENSING
 
 Copyright Joyent, Inc.

--- a/docs/modules/Conch::Route::RackLayout.md
+++ b/docs/modules/Conch::Route::RackLayout.md
@@ -8,6 +8,10 @@ Conch::Route::RackLayout
 
 Sets up the routes for /layout:
 
+## one\_layout\_routes
+
+Sets up the routes for working with just one layout, mounted under a provided route prefix.
+
 All routes require authentication.
 
 ### `GET /layout`

--- a/docs/modules/Conch::Route::Workspace.md
+++ b/docs/modules/Conch::Route::Workspace.md
@@ -45,8 +45,8 @@ an email to the parent workspace admins.
 Accepts the following optional query parameters:
 
 - `validated=<1|0>` show only devices where the `validated` attribute is set/not-set
-- `health=<value>` show only devices with the health matching the provided value
-- `active_minutes=X` show only devices which have reported within the last X minutes (this is different from all active devices)
+- `health=:value` show only devices with the health matching the provided value
+- `active_minutes=:X` show only devices which have reported within the last X minutes (this is different from all active devices)
 - `ids_only=1` only return device IDs, not full device details
 
 - User requires the read-only role

--- a/docs/modules/Test::Conch.md
+++ b/docs/modules/Test::Conch.md
@@ -169,7 +169,7 @@ or, to get all the defaults with no overrides:
 $t->generate_fixtures('device_location');
 ```
 
-See ["\_generate\_definition" in Test::Conch::Fixtures](../modules/Test%3A%3AConch%3A%3AFixtures#generate_definition) for the list of recognized types.
+See ["\_generate\_definition" in Test::Conch::Fixtures](../modules/Test%3A%3AConch%3A%3AFixtures#_generate_definition) for the list of recognized types.
 
 ## authenticate
 

--- a/docs/modules/index.md
+++ b/docs/modules/index.md
@@ -104,6 +104,7 @@
 * [Conch::Plugin::AuthHelpers](../modules/Conch::Plugin::AuthHelpers)
 * [Conch::Plugin::ClientVerification](../modules/Conch::Plugin::ClientVerification)
 * [Conch::Plugin::Database](../modules/Conch::Plugin::Database)
+* [Conch::Plugin::DeprecatedAction](../modules/Conch::Plugin::DeprecatedAction)
 * [Conch::Plugin::Features](../modules/Conch::Plugin::Features)
 * [Conch::Plugin::GitVersion](../modules/Conch::Plugin::GitVersion)
 * [Conch::Plugin::JsonValidator](../modules/Conch::Plugin::JsonValidator)

--- a/json-schema/common.yaml
+++ b/json-schema/common.yaml
@@ -38,7 +38,7 @@ definitions:
       - unknown
       - pass
   device_phase:
-    description: corresponds to device_phase_enum in the database
+    description: corresponds to device_phase_enum in the database (also used for racks)
     type: string
     enum:
       - integration

--- a/json-schema/query_params.yaml
+++ b/json-schema/query_params.yaml
@@ -145,11 +145,15 @@ definitions:
     properties:
       active_minutes:
         $ref: common.yaml#/definitions/non_negative_integer
-  WithDeviceHealth:
+  WithDeviceRackData:
     type: object
     additionalProperties: false
     properties:
       with_device_health:
+        $ref: /definitions/boolean_integer_or_flag
+      with_device_phases:
+        $ref: /definitions/boolean_integer_or_flag
+      with_rack_phases:
         $ref: /definitions/boolean_integer_or_flag
   BuildDevices:
     type: object

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -1907,7 +1907,55 @@ definitions:
     type: array
     uniqueItems: true
     items:
-      $ref: /definitions/Organization
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - name
+        - description
+        - created
+        - admins
+        - builds
+      properties:
+        id:
+          $ref: common.yaml#/definitions/uuid
+        name:
+          $ref: common.yaml#/definitions/mojo_standard_placeholder
+        description:
+          oneOf:
+            - type: 'null'
+            - type: string
+        created:
+          type: string
+          format: date-time
+        admins:
+          type: array
+          uniqueItems: true
+          minItems: 1
+          items:
+            $ref: /definitions/UserTerse
+        builds:
+          type: array
+          uniqueItems: true
+          items:
+            type: object
+            additionalProperties: false
+            required:
+              - id
+              - name
+              - description
+              - role
+            properties:
+              id:
+                $ref: common.yaml#/definitions/uuid
+              name:
+                $ref: common.yaml#/definitions/mojo_standard_placeholder
+              description:
+                oneOf:
+                  - type: string
+                  - type: 'null'
+              role:
+                $ref: common.yaml#/definitions/role
   Build:
     type: object
     additionalProperties: false

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -117,6 +117,7 @@ definitions:
       - phase
       - links
       - build_id
+      - build_name
       - latest_report
     properties:
       id:
@@ -174,6 +175,10 @@ definitions:
         oneOf:
           - type: 'null'
           - $ref: common.yaml#/definitions/uuid
+      build_name:
+        oneOf:
+          - type: 'null'
+          - $ref: common.yaml#/definitions/mojo_standard_placeholder
       location:
         $comment: location is included only when device 'phase' is earlier than 'production'
         oneOf:
@@ -348,6 +353,7 @@ definitions:
       - phase
       - links
       - build_id
+      - build_name
     properties:
       id:
         $ref: common.yaml#/definitions/uuid
@@ -404,11 +410,16 @@ definitions:
         oneOf:
           - type: 'null'
           - $ref: common.yaml#/definitions/uuid
+      build_name:
+        oneOf:
+          - type: 'null'
+          - $ref: common.yaml#/definitions/mojo_standard_placeholder
       rack_id:
         oneOf:
           - $ref: common.yaml#/definitions/uuid
           - type: 'null'
       rack_name:
+        description: rack.full_rack_name (datacenter_room.vendor_name + ':' + rack.name)
         oneOf:
           - $ref: common.yaml#/definitions/mojo_relaxed_placeholder
           - type: 'null'
@@ -656,7 +667,7 @@ definitions:
         # description: datacenter_room.alias
         $ref: common.yaml#/definitions/mojo_standard_placeholder
       rack:
-        # description: rack.full_name (datacenter_room.vendor_name + ':' + rack.name)
+        # description: rack.full_rack_name (datacenter_room.vendor_name + ':' + rack.name)
         $ref: common.yaml#/definitions/mojo_relaxed_placeholder
       rack_unit_start:
         $ref: common.yaml#/definitions/positive_integer
@@ -1346,23 +1357,34 @@ definitions:
     required:
       - id
       - name
+      - full_rack_name
       - datacenter_room_id
+      - datacenter_room_alias
       - rack_role_id
+      - rack_role_name
       - serial_number
       - asset_tag
       - phase
       - created
       - updated
       - build_id
+      - build_name
     properties:
       id:
         $ref: common.yaml#/definitions/uuid
       name:
         $ref: common.yaml#/definitions/mojo_relaxed_placeholder
+      full_rack_name:
+        # description: rack.full_rack_name (datacenter_room.vendor_name + ':' + rack.name)
+        $ref: common.yaml#/definitions/mojo_relaxed_placeholder
       datacenter_room_id:
         $ref: common.yaml#/definitions/uuid
+      datacenter_room_alias:
+        $ref: common.yaml#/definitions/mojo_standard_placeholder
       rack_role_id:
         $ref: common.yaml#/definitions/uuid
+      rack_role_name:
+        $ref: common.yaml#/definitions/mojo_standard_placeholder
       serial_number:
         oneOf:
           - type: string
@@ -1383,6 +1405,10 @@ definitions:
         oneOf:
           - type: 'null'
           - $ref: common.yaml#/definitions/uuid
+      build_name:
+        oneOf:
+          - type: 'null'
+          - $ref: common.yaml#/definitions/mojo_standard_placeholder
   RackRole:
     type: object
     additionalProperties: false
@@ -1421,7 +1447,9 @@ definitions:
     required:
       - id
       - rack_id
+      - rack_name
       - hardware_product_id
+      - sku
       - rack_unit_start
       - rack_unit_size
       - created
@@ -1431,8 +1459,13 @@ definitions:
         $ref: common.yaml#/definitions/uuid
       rack_id:
         $ref: common.yaml#/definitions/uuid
+      rack_name:
+        # description: rack.full_rack_name (datacenter_room.vendor_name + ':' + rack.name)
+        $ref: common.yaml#/definitions/mojo_relaxed_placeholder
       hardware_product_id:
         $ref: common.yaml#/definitions/uuid
+      sku:
+        $ref: common.yaml#/definitions/mojo_standard_placeholder
       rack_unit_start:
         $ref: common.yaml#/definitions/positive_integer
       rack_unit_size:
@@ -1455,6 +1488,7 @@ definitions:
       - device_id
       - device_asset_tag
       - hardware_product_name
+      - sku
       - rack_unit_start
       - rack_unit_size
     properties:
@@ -1468,6 +1502,8 @@ definitions:
           - type: 'null'
       hardware_product_name:
         type: string
+      sku:
+        $ref: common.yaml#/definitions/mojo_standard_placeholder
       rack_unit_start:
         $ref: common.yaml#/definitions/positive_integer
       rack_unit_size:

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -2008,6 +2008,22 @@ definitions:
           $ref: common.yaml#/definitions/device_health
         additionalProperties:
           $ref: common.yaml#/definitions/non_negative_integer
+      device_phases:
+        type: object
+        minProperties: 5
+        maxProperties: 5
+        propertyNames:
+          $ref: common.yaml#/definitions/device_phase
+        additionalProperties:
+          $ref: common.yaml#/definitions/non_negative_integer
+      rack_phases:
+        type: object
+        minProperties: 5
+        maxProperties: 5
+        propertyNames:
+          $ref: common.yaml#/definitions/device_phase
+        additionalProperties:
+          $ref: common.yaml#/definitions/non_negative_integer
   Builds:
     type: array
     uniqueItems: true

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -549,6 +549,11 @@ definitions:
       not:
         required:
           - location
+  DevicePXEs:
+    type: array
+    uniqueItems: true
+    items:
+      $ref: /definitions/DevicePXE
   DevicePhase:
     type: object
     additionalProperties: false
@@ -590,6 +595,10 @@ definitions:
           $ref: common.yaml#/definitions/uuid
         phase:
           $ref: common.yaml#/definitions/device_phase
+        # differs from DevicePXEs in that location is always present in the result, if the element
+        # itself is present, because presence in the workspace is only determined via the rack
+        # (location), where phase_earlier_than would remove the entire result, as well as nullify
+        # 'location'
         location:
           $ref: /definitions/DeviceLocation
         ipmi:

--- a/lib/Conch.pm
+++ b/lib/Conch.pm
@@ -115,6 +115,7 @@ Helper method for setting the response status code and json content.
 
         if (not $payload) {
             # no content - hopefully we set an appropriate response code (e.g. 204, 30x)
+            # (note that before_render will not run!)
             $c->rendered($code);
             return 0;
         }
@@ -178,6 +179,7 @@ Helper method for setting the response status code and json content.
 
     $self->plugin(NYTProf => $self->config) if $self->feature('nytprof');
     $self->plugin('Conch::Plugin::Rollbar', $self->config) if $self->feature('rollbar');
+    $self->plugin('Conch::Plugin::DeprecatedAction', $self->config);
 
 =head2 startup_time
 

--- a/lib/Conch/Command/copy_user_data.pm
+++ b/lib/Conch/Command/copy_user_data.pm
@@ -29,7 +29,7 @@ Use this script after restoring a database backup to a separate database, before
     carton exec bin/conch copy_user_data --from conch_staging_$(date '+%Y%m%d')_user_bak --to conch_prod_$(date '+%Y%m%d')
 
     carton exec hypnotoad -s bin/conch
-    psql -U postgres --command="rename database conch conch_staging_$(date '+%Y%m%d')_bak; rename database conch_prod_$(date '+%Y%m%d') conch"
+    psql -U postgres --command="alter database conch rename to conch_staging_$(date '+%Y%m%d')_bak; alter database conch_prod_$(date '+%Y%m%d') rename to conch"
     carton exec hypnotoad bin/conch
 
 =cut

--- a/lib/Conch/Command/copy_user_data.pm
+++ b/lib/Conch/Command/copy_user_data.pm
@@ -57,7 +57,7 @@ sub run ($self, @opts) {
     );
 
     my $app = $self->app;
-    my $app_name = $app->moniker.'-copy_user_data-'.$app->version_tag.' ('.$$.')';
+    my $app_name = join(' ', $app->moniker, 'copy_user_data', $app->version_tag, '('.$$.')');
     my $db_credentials = Conch::DB::Util::get_credentials($app->config->{database}, $app->log);
 
     my ($from_schema, $to_schema) = map Conch::DB->connect(

--- a/lib/Conch/Controller/Build.pm
+++ b/lib/Conch/Controller/Build.pm
@@ -12,7 +12,7 @@ Conch::Controller::Build
 
 =head1 METHODS
 
-=head2 list
+=head2 get_all
 
 If the user is a system admin, retrieve a list of all builds in the database; otherwise,
 limits the list to those build of which the user is a member.
@@ -21,7 +21,7 @@ Response uses the Builds json schema.
 
 =cut
 
-sub list ($c) {
+sub get_all ($c) {
     my $params = $c->validate_query_params('WithDeviceHealth');
     return if not $params;
 
@@ -229,7 +229,7 @@ sub update ($c) {
     $c->status(303, '/build/'.$build->id);
 }
 
-=head2 list_users
+=head2 get_users
 
 Get a list of user members of the current build. (Does not include users who can access the
 build via an organization.)
@@ -240,7 +240,7 @@ Response uses the BuildUsers json schema.
 
 =cut
 
-sub list_users ($c) {
+sub get_users ($c) {
     my $rs = $c->stash('build_rs')
         ->related_resultset('user_build_roles')
         ->related_resultset('user_account')
@@ -399,7 +399,7 @@ sub remove_user ($c) {
     return $c->status(204);
 }
 
-=head2 list_organizations
+=head2 get_organizations
 
 Get a list of organization members of the current build.
 Requires the 'admin' role on the build.
@@ -408,7 +408,7 @@ Response uses the BuildOrganizations json schema.
 
 =cut
 
-sub list_organizations ($c) {
+sub get_organizations ($c) {
     my $rs = $c->db_organizations
         ->search(
             {

--- a/lib/Conch/Controller/Build.pm
+++ b/lib/Conch/Controller/Build.pm
@@ -688,7 +688,7 @@ sub get_devices ($c) {
 
     $rs = $params->{ids_only} ? $rs->get_column('id')
         : $params->{serials_only} ? $rs->get_column('serial_number')
-        : $rs->with_device_location->with_sku;
+        : $rs->with_device_location->with_sku->with_build_name;
 
     $c->status(200, [ $rs->all ]);
 }
@@ -879,7 +879,15 @@ Response uses the Racks json schema.
 =cut
 
 sub get_racks ($c) {
-    $c->status(200, [ $c->stash('build_rs')->related_resultset('racks')->order_by('racks.name')->all ]);
+    my $rs = $c->stash('build_rs')
+        ->related_resultset('racks')
+        ->add_columns({ build_name => 'build.name' })
+        ->with_full_rack_name
+        ->with_datacenter_room_alias
+        ->with_rack_role_name
+        ->order_by('racks.name');
+
+    $c->status(200, [ $rs->all ]);
 }
 
 =head2 add_rack

--- a/lib/Conch/Controller/Build.pm
+++ b/lib/Conch/Controller/Build.pm
@@ -879,7 +879,7 @@ Response uses the Racks json schema.
 =cut
 
 sub get_racks ($c) {
-    $c->status(200, [ $c->stash('build_rs')->related_resultset('racks')->all ]);
+    $c->status(200, [ $c->stash('build_rs')->related_resultset('racks')->order_by('racks.name')->all ]);
 }
 
 =head2 add_rack

--- a/lib/Conch/Controller/Datacenter.pm
+++ b/lib/Conch/Controller/Datacenter.pm
@@ -113,8 +113,9 @@ sub update ($c) {
 
     my $datacenter = $c->stash('datacenter');
     $datacenter->set_columns($input);
-    $datacenter->update({ updated => \'now()' }) if $datacenter->is_changed;
+    return $c->status(204) if not $datacenter->is_changed;
 
+    $datacenter->update({ updated => \'now()' });
     $c->log->debug('Updated datacenter '.$datacenter->id);
     $c->status(303, '/dc/'.$datacenter->id);
 }

--- a/lib/Conch/Controller/DatacenterRoom.pm
+++ b/lib/Conch/Controller/DatacenterRoom.pm
@@ -126,9 +126,14 @@ sub update ($c) {
         if $input->{vendor_name} and $input->{vendor_name} ne $room->vendor_name
             and $c->db_datacenter_rooms->search({ vendor_name => $input->{vendor_name} })->exists;
 
-    $room->update({ $input->%*, updated => \'now()' });
+    $c->res->headers->location('/room/'.$room->id);
+
+    $room->set_columns($input);
+    return $c->status(204) if not $room->is_changed;
+
+    $room->update({ updated => \'now()' });
     $c->log->debug('Updated datacenter room '.$c->stash('datacenter_room_id_or_alias'));
-    $c->status(303, '/room/'.$room->id);
+    $c->status(303);
 }
 
 =head2 delete

--- a/lib/Conch/Controller/DatacenterRoom.pm
+++ b/lib/Conch/Controller/DatacenterRoom.pm
@@ -166,7 +166,14 @@ sub racks ($c) {
     # initial resultset, this could be slow!
     $rs = $rs->with_user_role($c->stash('user_id'), 'ro') if not $c->is_system_admin;
 
-    my @racks = $rs->order_by('racks.name')->all;
+    my @racks = $rs
+        ->as_subselect_rs
+        ->with_build_name
+        ->with_full_rack_name
+        ->with_rack_role_name
+        ->with_datacenter_room_alias
+        ->order_by('racks.name')
+        ->all;
 
     $c->log->debug('Found '.scalar(@racks).' racks for datacenter room '.$c->stash('datacenter_room_id_or_alias'));
     return $c->status(200, \@racks);

--- a/lib/Conch/Controller/DatacenterRoom.pm
+++ b/lib/Conch/Controller/DatacenterRoom.pm
@@ -166,7 +166,8 @@ sub racks ($c) {
     # initial resultset, this could be slow!
     $rs = $rs->with_user_role($c->stash('user_id'), 'ro') if not $c->is_system_admin;
 
-    my @racks = $rs->all;
+    my @racks = $rs->order_by('racks.name')->all;
+
     $c->log->debug('Found '.scalar(@racks).' racks for datacenter room '.$c->stash('datacenter_room_id_or_alias'));
     return $c->status(200, \@racks);
 }

--- a/lib/Conch/Controller/Device.pm
+++ b/lib/Conch/Controller/Device.pm
@@ -138,7 +138,7 @@ sub get ($c) {
     # TODO: this is really a weak etag. requires https://github.com/mojolicious/mojo/pull/1420
     return $c->status(304) if $c->is_fresh(etag => $etag);
 
-    my $device = $c->stash('device_rs')->with_sku->single;
+    my $device = $c->stash('device_rs')->with_sku->with_build_name->single;
     my $latest_report = $c->stash('device_rs')->latest_device_report->get_column('report')->single;
 
     my $detailed_device = +{
@@ -245,6 +245,7 @@ sub lookup_by_other_attribute ($c) {
     my @devices = $device_rs
         ->with_device_location
         ->with_sku
+        ->with_build_name
         ->order_by('device.created')
         ->all;
 

--- a/lib/Conch/Controller/Device.pm
+++ b/lib/Conch/Controller/Device.pm
@@ -170,7 +170,7 @@ sub get ($c) {
             $c->stash('device_rs')
                 ->related_resultset('device_disks')
                 ->active
-                ->order_by('serial_number')
+                ->order_by('slot')
                 ->all
         ];
     }

--- a/lib/Conch/Controller/DeviceValidation.pm
+++ b/lib/Conch/Controller/DeviceValidation.pm
@@ -12,7 +12,7 @@ Conch::Controller::DeviceValidation
 
 =head1 METHODS
 
-=head2 list_validation_states
+=head2 get_validation_states
 
 Get the latest validation states for a device. Accepts the query parameter C<status>,
 indicating the desired status(es) to search for -- one or more of: pass, fail, error.
@@ -23,7 +23,7 @@ Response uses the ValidationStatesWithResults json schema.
 
 =cut
 
-sub list_validation_states ($c) {
+sub get_validation_states ($c) {
     my $params = $c->validate_query_params('GetValidationStates');
     return if not $params;
 

--- a/lib/Conch/Controller/HardwareProduct.pm
+++ b/lib/Conch/Controller/HardwareProduct.pm
@@ -12,7 +12,7 @@ Conch::Controller::HardwareProduct
 
 =head1 METHODS
 
-=head2 list
+=head2 get_all
 
 Get a list of all available hardware products.
 
@@ -20,7 +20,7 @@ Response uses the HardwareProducts json schema.
 
 =cut
 
-sub list ($c) {
+sub get_all ($c) {
     my @hardware_products_raw = $c->db_hardware_products
         ->active
         ->order_by('name')

--- a/lib/Conch/Controller/HardwareVendor.pm
+++ b/lib/Conch/Controller/HardwareVendor.pm
@@ -15,7 +15,8 @@ Conch::Controller::HardwareVendor
 =head2 find_hardware_vendor
 
 Chainable action that uses the C<hardware_vendor_id_or_name> value provided in the stash
-(usually via the request URL) to look up a build, and stashes the result in C<hardware_vendor>.
+(usually via the request URL) to look up a hardware vendor, and stashes the result in
+C<hardware_vendor>.
 
 =cut
 

--- a/lib/Conch/Controller/Login.pm
+++ b/lib/Conch/Controller/Login.pm
@@ -157,14 +157,14 @@ sub authenticate ($c) {
     return $c->status(401);
 }
 
-=head2 session_login
+=head2 login
 
 Handles the act of logging in, given a user and password in the form.
 Response uses the Login json schema, containing a JWT.
 
 =cut
 
-sub session_login ($c) {
+sub login ($c) {
     my $input = $c->validate_request('Login');
     return if not $input;
 
@@ -231,13 +231,13 @@ sub session_login ($c) {
     return $c->_respond_with_jwt($user->id);
 }
 
-=head2 session_logout
+=head2 logout
 
 Logs a user out by expiring their session
 
 =cut
 
-sub session_logout ($c) {
+sub logout ($c) {
     $c->session(expires => 1);
 
     # expire this user's token

--- a/lib/Conch/Controller/Organization.pm
+++ b/lib/Conch/Controller/Organization.pm
@@ -89,7 +89,7 @@ sub create ($c) {
 =head2 find_organization
 
 Chainable action that uses the C<organization_id_or_name> value provided in the stash (usually
-via the request URL) to look up a build, and stashes the query to get to it in
+via the request URL) to look up an organization, and stashes the query to get to it in
 C<organization_rs>.
 
 If C<require_role> is provided, it is used as the minimum required role for the user to

--- a/lib/Conch/Controller/Organization.pm
+++ b/lib/Conch/Controller/Organization.pm
@@ -12,7 +12,7 @@ Conch::Controller::Organization
 
 =head1 METHODS
 
-=head2 list
+=head2 get_all
 
 If the user is a system admin, retrieve a list of all active organizations in the database;
 otherwise, limits the list to those organizations of which the user is a member.
@@ -21,7 +21,7 @@ Response uses the Organizations json schema.
 
 =cut
 
-sub list ($c) {
+sub get_all ($c) {
     my $rs = $c->db_organizations
         ->active
         ->prefetch({

--- a/lib/Conch/Controller/Rack.pm
+++ b/lib/Conch/Controller/Rack.pm
@@ -284,10 +284,14 @@ sub update ($c) {
         }
     }
 
+    $c->res->headers->location('/rack/'.$rack->id);
+
     $rack->set_columns($input);
-    $rack->update({ updated => \'now()' }) if $rack->is_changed;
+    return $c->status(204) if not $rack->is_changed;
+
+    $rack->update({ updated => \'now()' });
     $c->log->debug('Updated rack '.$rack->id);
-    return $c->status(303, '/rack/'.$rack->id);
+    return $c->status(303);
 }
 
 =head2 delete
@@ -516,7 +520,9 @@ sub set_phase ($c) {
     return if not $input;
 
     my $rack = $c->stash('rack_rs')->single;
-    $rack->update({ phase => $input->{phase}, updated => \'now()' });
+    $rack->set_columns($input);
+
+    $rack->update({ updated => \'now()' }) if $rack->is_changed;
     $c->log->debug('set the phase for rack '.$rack->id.' to '.$input->{phase});
 
     if (not $params->{rack_only} // 0) {

--- a/lib/Conch/Controller/Rack.pm
+++ b/lib/Conch/Controller/Rack.pm
@@ -131,7 +131,13 @@ Response uses the Rack json schema.
 
 sub get ($c) {
     $c->res->headers->location('/rack/'.$c->stash('rack_id'));
-    $c->status(200, $c->stash('rack_rs')->single);
+    my $rs = $c->stash('rack_rs')
+        ->with_build_name
+        ->with_full_rack_name
+        ->with_datacenter_room_alias
+        ->with_rack_role_name;
+
+    $c->status(200, $rs->single);
 }
 
 =head2 get_layouts
@@ -145,7 +151,10 @@ Response uses the RackLayouts json schema.
 sub get_layouts ($c) {
     my @layouts = $c->stash('rack_rs')
         ->related_resultset('rack_layouts')
+        ->as_subselect_rs
         ->with_rack_unit_size
+        ->with_rack_name
+        ->with_sku
         ->order_by('rack_unit_start')
         ->all;
 
@@ -329,6 +338,7 @@ sub get_assignment ($c) {
                 device_id => 'device.id',
                 device_asset_tag => 'device.asset_tag',
                 hardware_product_name => 'hardware_product.name',
+                sku => 'hardware_product.sku',
                 rack_unit_size => 'hardware_product.rack_unit_size',
             },
         })

--- a/lib/Conch/Controller/RackLayout.pm
+++ b/lib/Conch/Controller/RackLayout.pm
@@ -96,7 +96,11 @@ Response uses the RackLayout json schema.
 =cut
 
 sub get ($c) {
-    $c->status(200, $c->stash('rack_layout_rs')->with_rack_unit_size->single);
+    my $rs = $c->stash('rack_layout_rs')
+        ->with_rack_unit_size
+        ->with_rack_name
+        ->with_sku;
+    $c->status(200, $rs->single);
 }
 
 =head2 get_all
@@ -110,7 +114,9 @@ Response uses the RackLayouts json schema.
 sub get_all ($c) {
     my @layouts = $c->db_rack_layouts
         ->with_rack_unit_size
-        ->order_by([ qw(rack_id rack_unit_start) ])
+        ->with_rack_name
+        ->with_sku
+        ->order_by([ qw(rack.name rack_unit_start) ])
         ->all;
 
     $c->log->debug('Found '.scalar(@layouts).' rack layouts');

--- a/lib/Conch/Controller/RackLayout.pm
+++ b/lib/Conch/Controller/RackLayout.pm
@@ -15,7 +15,7 @@ Conch::Controller::RackLayout
 =head2 find_rack_layout
 
 Chainable action that uses the C<layout_id> value provided in the stash (usually via the
-request URL) to look up a build, and stashes the query to get to it in C<layout_rs>.
+request URL) to look up a layout, and stashes the query to get to it in C<layout_rs>.
 
 =cut
 

--- a/lib/Conch/Controller/RackLayout.pm
+++ b/lib/Conch/Controller/RackLayout.pm
@@ -201,9 +201,13 @@ sub update ($c) {
         return $c->status(409, { error => 'rack_unit_start conflict' });
     }
 
-    $layout->update({ $input->%*, updated => \'now()' });
+    $c->res->headers->location('/layout/'.$layout->id);
 
-    return $c->status(303, '/layout/'.$layout->id);
+    $layout->set_columns($input);
+    return $c->status(204) if not $layout->is_changed;
+
+    $layout->update({ updated => \'now()' });
+    return $c->status(303);
 }
 
 =head2 delete

--- a/lib/Conch/Controller/RackRole.pm
+++ b/lib/Conch/Controller/RackRole.pm
@@ -126,10 +126,14 @@ sub update ($c) {
         }
     }
 
+    $c->res->headers->location('/rack_role/'.$rack_role->id);
+
     $rack_role->set_columns($input);
+    return $c->status(204) if not $rack_role->is_changed;
+
     $rack_role->update({ updated => \'now()' }) if $rack_role->is_changed;
     $c->log->debug('Updated rack role '.$rack_role->id);
-    $c->status(303, '/rack_role/'.$rack_role->id);
+    $c->status(303);
 }
 
 =head2 delete

--- a/lib/Conch/Controller/RackRole.pm
+++ b/lib/Conch/Controller/RackRole.pm
@@ -15,7 +15,7 @@ Conch::Controller::RackRole
 =head2 find_rack_role
 
 Chainable action that uses the C<rack_role_id_or_name> value provided in the stash (usually via
-the request URL) to look up a build, and stashes the result in C<rack_role>.
+the request URL) to look up a rack role, and stashes the result in C<rack_role>.
 
 =cut
 

--- a/lib/Conch/Controller/Relay.pm
+++ b/lib/Conch/Controller/Relay.pm
@@ -47,7 +47,7 @@ sub register ($c) {
     return;
 }
 
-=head2 list
+=head2 get_all
 
 Retrieve a list of all active relays in the database.
 
@@ -55,7 +55,7 @@ Response uses the Relays json schema.
 
 =cut
 
-sub list ($c) {
+sub get_all ($c) {
     $c->status(200, [ $c->db_relays->active->order_by('serial_number')->all ]);
 }
 

--- a/lib/Conch/Controller/User.pm
+++ b/lib/Conch/Controller/User.pm
@@ -262,7 +262,7 @@ sub change_own_password ($c) {
     $rs = $rs->login_only if $clear_tokens ne 'all';
     $rs->delete;
 
-    # processing continues with Conch::Controller::Login::session_logout
+    # processing continues with Conch::Controller::Login::logout
     return 1;
 }
 
@@ -430,14 +430,14 @@ sub update ($c) {
     $c->status(303, '/user/'.$user->id);
 }
 
-=head2 list
+=head2 get_all
 
 List all active users and their workspaces, builds and organizations. System admin only.
 Response uses the UsersDetailed json schema.
 
 =cut
 
-sub list ($c) {
+sub get_all ($c) {
     my $user_rs = $c->db_user_accounts
         ->active
         ->prefetch({

--- a/lib/Conch/Controller/Validation.pm
+++ b/lib/Conch/Controller/Validation.pm
@@ -14,7 +14,7 @@ Controller for managing Validations, B<NOT> executing them.
 
 =head1 METHODS
 
-=head2 list
+=head2 get_all
 
 List all Validations.
 
@@ -22,7 +22,7 @@ Response uses the Validations json schema (including deactivated ones).
 
 =cut
 
-sub list ($c) {
+sub get_all ($c) {
     my $rs = $c->db_validations->order_by([ qw(name version) ]);
     $c->status(200, [ $rs->all ]);
 }

--- a/lib/Conch/Controller/ValidationPlan.pm
+++ b/lib/Conch/Controller/ValidationPlan.pm
@@ -14,7 +14,7 @@ Controller for managing Validation Plans
 
 =head1 METHODS
 
-=head2 list
+=head2 get_all
 
 List all available Validation Plans.
 
@@ -22,7 +22,7 @@ Response uses the ValidationPlans json schema.
 
 =cut
 
-sub list ($c) {
+sub get_all ($c) {
     my @validation_plans = $c->db_validation_plans->active->order_by('name')->all;
     $c->log->debug('Found '.scalar(@validation_plans).' validation plans');
     $c->status(200, \@validation_plans);
@@ -65,7 +65,7 @@ sub get ($c) {
     return $c->status(200, $c->stash('validation_plan'));
 }
 
-=head2 list_validations
+=head2 get_validations
 
 List all Validations associated with the Validation Plan, both active and deactivated.
 
@@ -73,7 +73,7 @@ Response uses the Validations json schema.
 
 =cut
 
-sub list_validations ($c) {
+sub get_validations ($c) {
     my @validations = $c->stash('validation_plan')
         ->related_resultset('validation_plan_members')
         ->related_resultset('validation')

--- a/lib/Conch/Controller/Workspace.pm
+++ b/lib/Conch/Controller/Workspace.pm
@@ -69,7 +69,7 @@ sub find_workspace ($c) {
     return 1;
 }
 
-=head2 list
+=head2 get_all
 
 Get a list of all workspaces available to the currently authenticated user.
 
@@ -77,7 +77,7 @@ Response uses the WorkspacesAndRoles json schema.
 
 =cut
 
-sub list ($c) {
+sub get_all ($c) {
     if ($c->is_system_admin) {
         my $rs = $c->db_workspaces->add_role_column('admin');
         return $c->status(200, [ $rs->all ]);

--- a/lib/Conch/Controller/WorkspaceDevice.pm
+++ b/lib/Conch/Controller/WorkspaceDevice.pm
@@ -56,7 +56,7 @@ sub list ($c) {
 
     $devices_rs = $params->{ids_only} ? $devices_rs->get_column('id')
         : $params->{serials_only} ? $devices_rs->get_column('serial_number')
-        : $devices_rs->with_device_location->with_sku;
+        : $devices_rs->with_device_location->with_sku->with_build_name;
 
     my @devices = $devices_rs->all;
 

--- a/lib/Conch/Controller/WorkspaceDevice.pm
+++ b/lib/Conch/Controller/WorkspaceDevice.pm
@@ -12,7 +12,7 @@ Conch::Controller::WorkspaceDevice
 
 =head1 METHODS
 
-=head2 list
+=head2 get_all
 
 Get a list of all devices in the indicated workspace.
 
@@ -32,7 +32,7 @@ C<serials_only=1>.
 
 =cut
 
-sub list ($c) {
+sub get_all ($c) {
     my $params = $c->validate_query_params('WorkspaceDevices');
     return if not $params;
 

--- a/lib/Conch/Controller/WorkspaceRack.pm
+++ b/lib/Conch/Controller/WorkspaceRack.pm
@@ -12,7 +12,7 @@ Conch::Controller::WorkspaceRack
 
 =head1 METHODS
 
-=head2 list
+=head2 get_all
 
 Get a list of racks for the indicated workspace.
 
@@ -20,7 +20,7 @@ Response uses the WorkspaceRackSummary json schema.
 
 =cut
 
-sub list ($c) {
+sub get_all ($c) {
     my $racks_rs = $c->stash('workspace_rs')
         ->related_resultset('workspace_racks')
         ->related_resultset('rack');

--- a/lib/Conch/Controller/WorkspaceRelay.pm
+++ b/lib/Conch/Controller/WorkspaceRelay.pm
@@ -101,6 +101,7 @@ sub get_relay_devices ($c) {
             { relay_id => $c->stash('relay_id') }, { join => 'device_relay_connections' })
         ->with_device_location
         ->with_sku
+        ->with_build_name
         ->order_by('device.created');
 
     my @devices = $devices_rs->all;

--- a/lib/Conch/Controller/WorkspaceRelay.pm
+++ b/lib/Conch/Controller/WorkspaceRelay.pm
@@ -10,7 +10,7 @@ Conch::Controller::WorkspaceRelay
 
 =head1 METHODS
 
-=head2 list
+=head2 get_all
 
 List all relays located in the indicated workspace and sub-workspaces beneath it.
 Note that this information is only accurate if the device the relay(s) reported
@@ -22,7 +22,7 @@ Response uses the WorkspaceRelays json schema.
 
 =cut
 
-sub list ($c) {
+sub get_all ($c) {
     my $params = $c->validate_query_params('WorkspaceRelays');
     return if not $params;
 

--- a/lib/Conch/Controller/WorkspaceUser.pm
+++ b/lib/Conch/Controller/WorkspaceUser.pm
@@ -10,7 +10,7 @@ Conch::Controller::WorkspaceUser
 
 =head1 METHODS
 
-=head2 list
+=head2 get_all
 
 Get a list of users for the indicated workspace (not including system admin users).
 Requires the 'admin' role on the workspace.
@@ -19,7 +19,7 @@ Response uses the WorkspaceUsers json schema.
 
 =cut
 
-sub list ($c) {
+sub get_all ($c) {
     my $workspace_id = $c->stash('workspace_id');
 
     # users who can access any ancestor of this workspace (directly)

--- a/lib/Conch/DB/Result/Build.pm
+++ b/lib/Conch/DB/Result/Build.pm
@@ -261,11 +261,27 @@ sub TO_JSON ($self) {
       : undef;
 
     if ($self->has_column_loaded('device_health')) {
-        my @health_enum = $self->related_resultset('devices')->result_source->column_info('health')->{extra}{list}->@*;
-        $data->{device_health}->@{@health_enum} = (0)x@health_enum;
+        my @enum = $self->related_resultset('devices')->result_source->column_info('health')->{extra}{list}->@*;
+        $data->{device_health}->@{@enum} = (0)x@enum;
 
-        my %health_data = map $_->@*, $self->get_column('device_health')->@*;
-        $data->{device_health}->@{keys %health_data} = map int, values %health_data;
+        my %column_data = map $_->@*, $self->get_column('device_health')->@*;
+        $data->{device_health}->@{keys %column_data} = map int, values %column_data;
+    }
+
+    if ($self->has_column_loaded('device_phases')) {
+        my @enum = $self->related_resultset('devices')->result_source->column_info('phase')->{extra}{list}->@*;
+        $data->{device_phases}->@{@enum} = (0)x@enum;
+
+        my %column_data = map $_->@*, $self->get_column('device_phases')->@*;
+        $data->{device_phases}->@{keys %column_data} = map int, values %column_data;
+    }
+
+    if ($self->has_column_loaded('rack_phases')) {
+        my @enum = $self->related_resultset('racks')->result_source->column_info('phase')->{extra}{list}->@*;
+        $data->{rack_phases}->@{@enum} = (0)x@enum;
+
+        my %column_data = map $_->@*, $self->get_column('rack_phases')->@*;
+        $data->{rack_phases}->@{keys %column_data} = map int, values %column_data;
     }
 
     return $data;

--- a/lib/Conch/DB/Result/Device.pm
+++ b/lib/Conch/DB/Result/Device.pm
@@ -409,7 +409,9 @@ use experimental 'signatures';
 sub TO_JSON ($self) {
     my $data = $self->next::method(@_);
 
-    $data->{sku} = $self->get_column('sku') if $self->has_column_loaded('sku');
+    foreach my $key (qw(build_name sku)) {
+        $data->{$key} = $self->get_column($key) if $self->has_column_loaded($key);
+    }
 
     # include location information, when available and still relevant
     # (see $device_rs->with_device_location)

--- a/lib/Conch/DB/Result/Rack.pm
+++ b/lib/Conch/DB/Result/Rack.pm
@@ -294,6 +294,18 @@ __PACKAGE__->add_columns(
     '+phase' => { retrieve_on_insert => 1 },
 );
 
+use experimental 'signatures';
+
+sub TO_JSON ($self) {
+    my $data = $self->next::method(@_);
+
+    foreach my $key (qw(build_name datacenter_room_alias rack_role_name full_rack_name)) {
+        $data->{$key} = $self->get_column($key) if $self->has_column_loaded($key);
+    }
+
+    return $data;
+}
+
 1;
 __END__
 

--- a/lib/Conch/DB/Result/RackLayout.pm
+++ b/lib/Conch/DB/Result/RackLayout.pm
@@ -190,8 +190,9 @@ use experimental 'signatures';
 sub TO_JSON ($self) {
     my $data = $self->next::method(@_);
 
-    $data->{rack_unit_size} = $self->get_column('rack_unit_size')
-        if $self->has_column_loaded('rack_unit_size');
+    foreach my $key (qw(rack_unit_size rack_name sku)) {
+        $data->{$key} = $self->get_column($key) if $self->has_column_loaded($key);
+    }
 
     return $data;
 }

--- a/lib/Conch/DB/ResultSet/Build.pm
+++ b/lib/Conch/DB/ResultSet/Build.pm
@@ -110,7 +110,7 @@ sub user_has_role ($self, $user_id, $role) {
 
 =head2 with_device_health_counts
 
-Modifies the resultset to add on a column named C<device_health>) containing an array of arrays
+Modifies the resultset to add on a column named C<device_health> containing an array of arrays
 of correlated counts of device.health values for each build.
 
 =cut
@@ -121,6 +121,36 @@ sub with_device_health_counts ($self) {
         ->group_by('health');
 
     $self->add_columns({ device_health => { array => $health_rs->as_query } });
+}
+
+=head2 with_device_phase_counts
+
+Modifies the resultset to add on a column named C<device_phases> containing an array of arrays
+of correlated counts of device.phase values for each build.
+
+=cut
+
+sub with_device_phase_counts ($self) {
+    my $phases_rs = $self->correlate('devices')
+        ->search(undef, { select => [ \'array[phase::text, count(*)::text]' ] })
+        ->group_by('phase');
+
+    $self->add_columns({ device_phases => { array => $phases_rs->as_query } });
+}
+
+=head2 with_rack_phase_counts
+
+Modifies the resultset to add on a column named C<rack_phases> containing an array of arrays
+of correlated counts of rack.phase values for each build.
+
+=cut
+
+sub with_rack_phase_counts ($self) {
+    my $phases_rs = $self->correlate('racks')
+        ->search(undef, { select => [ \'array[phase::text, count(*)::text]' ] })
+        ->group_by('phase');
+
+    $self->add_columns({ rack_phases => { array => $phases_rs->as_query } });
 }
 
 1;

--- a/lib/Conch/DB/ResultSet/Device.pm
+++ b/lib/Conch/DB/ResultSet/Device.pm
@@ -192,15 +192,16 @@ sub device_settings_as_hash {
 
 =head2 with_device_location
 
-Modifies the resultset to add columns C<rack_id>, C<rack_unit_start> and C<rack_name>.
+Modifies the resultset to add columns C<rack_id>, C<rack_name> (the full rack name including
+room data) and C<rack_unit_start>.
 
 =cut
 
 sub with_device_location ($self) {
-    $self->search(undef, { join => { device_location => 'rack' } })
+    $self->search(undef, { join => { device_location => { rack => 'datacenter_room' } } })
         ->add_columns({
             (map +($_ => 'device_location.'.$_), qw(rack_id rack_unit_start)),
-            rack_name => 'rack.name',
+            rack_name => \q{datacenter_room.vendor_name || ':' || rack.name},
         });
 }
 
@@ -213,6 +214,17 @@ Modifies the resultset to add the C<sku> column.
 sub with_sku ($self) {
     $self->search(undef, { join => 'hardware_product' })
         ->add_columns({ sku => 'hardware_product.sku' });
+}
+
+=head2 with_build_name
+
+Modifies the resultset to add the C<build_name> column.
+
+=cut
+
+sub with_build_name ($self) {
+    $self->search(undef, { join => 'build' })
+        ->add_columns({ build_name => 'build.name' });
 }
 
 =head2 location_data

--- a/lib/Conch/DB/ResultSet/Rack.pm
+++ b/lib/Conch/DB/ResultSet/Rack.pm
@@ -129,6 +129,51 @@ sub user_has_role ($self, $user_id, $role) {
         ->exists;
 }
 
+=head2 with_build_name
+
+Modifies the resultset to add the C<build_name> column.
+
+=cut
+
+sub with_build_name ($self) {
+    $self->search(undef, { join => 'build' })
+        ->add_columns({ build_name => 'build.name' });
+}
+
+=head2 with_full_rack_name
+
+Modifies the resultset to add the C<full_rack_name> column.
+
+=cut
+
+sub with_full_rack_name ($self) {
+    my $me = $self->current_source_alias;
+    $self->search(undef, { join => 'datacenter_room' })
+        ->add_columns({ full_rack_name => \qq{datacenter_room.vendor_name || ':' || $me.name} });
+}
+
+=head2 with_datacenter_room_alias
+
+Modifies the resultset to add the C<datacenter_room_alias> column.
+
+=cut
+
+sub with_datacenter_room_alias ($self) {
+    $self->search(undef, { join => 'datacenter_room' })
+        ->add_columns({ datacenter_room_alias => 'datacenter_room.alias' });
+}
+
+=head2 with_rack_role_name
+
+Modifies the resultset to add the C<rack_role_name> column.
+
+=cut
+
+sub with_rack_role_name ($self) {
+    $self->search(undef, { join => 'rack_role' })
+        ->add_columns({ rack_role_name => 'rack_role.name' });
+}
+
 1;
 __END__
 

--- a/lib/Conch/DB/ResultSet/RackLayout.pm
+++ b/lib/Conch/DB/ResultSet/RackLayout.pm
@@ -28,6 +28,28 @@ sub with_rack_unit_size ($self) {
     });
 }
 
+=head2 with_rack_name
+
+Modifies the resultset to add the C<rack_name> column (the full rack name).
+
+=cut
+
+sub with_rack_name ($self) {
+    $self->search(undef, { join => { rack => 'datacenter_room' } })
+        ->add_columns({ rack_name => \q{datacenter_room.vendor_name || ':' || rack.name} });
+}
+
+=head2 with_sku
+
+Modifies the resultset to add the C<sku> column.
+
+=cut
+
+sub with_sku ($self) {
+    $self->search(undef, { join => 'hardware_product' })
+        ->add_columns({ sku => 'hardware_product.sku' });
+}
+
 1;
 __END__
 

--- a/lib/Conch/Plugin/Database.pm
+++ b/lib/Conch/Plugin/Database.pm
@@ -41,7 +41,7 @@ that persists for the lifetime of the application.
     my $_rw_schema;
     $app->helper(schema => sub ($c) {
         return $_rw_schema if $_rw_schema;
-        my $app_name = $c->app->moniker.'-'.$c->version_tag.' ('.$$.')';
+        my $app_name = join(' ', $c->app->moniker, ($ARGV[0] // ()), $c->version_tag, '('.$$.')');
         $_rw_schema = Conch::DB->connect(
             $db_credentials->@{qw(dsn username password)},
             +{
@@ -69,7 +69,7 @@ L<Conch::DB> object that persists for the lifetime of the application.
     my $_ro_schema;
     $app->helper(ro_schema => sub ($c) {
         return $_ro_schema if $_ro_schema;
-        my $app_name = $c->app->moniker.'-'.$c->version_tag.' ('.$$.')';
+        my $app_name = join(' ', $c->app->moniker, ($ARGV[0] // ()), $c->version_tag, '('.$$.')');
         $_ro_schema = Conch::DB->connect(
             $db_credentials->@{qw(dsn ro_username ro_password)},
             +{

--- a/lib/Conch/Plugin/DeprecatedAction.pm
+++ b/lib/Conch/Plugin/DeprecatedAction.pm
@@ -1,0 +1,61 @@
+package Conch::Plugin::DeprecatedAction;
+
+use v5.26;
+use Mojo::Base 'Mojolicious::Plugin', -signatures;
+
+=pod
+
+=head1 NAME
+
+Conch::Plugin::DeprecationAction
+
+=head1 DESCRIPTION
+
+Mojo plugin to detect and report the usage of deprecated controller actions.
+
+=head1 HOOKS
+
+=head2 around_action
+
+Sets the C<X-Deprecated> header in the response.
+
+Also sends a message to rollbar when a deprecated action is invoked, if the
+C<report_deprecated_actions> feature is enabled.
+
+=cut
+
+sub register ($self, $app, $config) {
+    $app->hook(around_action => sub ($next, $c, $action, $last) {
+        my $result = $next->();
+
+        if (my $deprecated = $c->stash('deprecated')) {
+            $c->res->headers->add('X-Deprecated', 'this endpoint is deprecated and will be removed in api '.$deprecated);
+
+            # do this after the response has been sent
+            $c->on(finish => sub ($c) { $c->send_message_to_rollbar(
+                        'info',
+                        $deprecated,
+                        { context => ($c->stash('controller')//'').'#'.($c->stash('action')//'') },
+                    ) })
+                if $c->feature('rollbar') and $c->feature('report_deprecated_actions');
+        }
+
+        return $result;
+    });
+}
+
+1;
+__END__
+
+=pod
+
+=head1 LICENSING
+
+Copyright Joyent, Inc.
+
+This Source Code Form is subject to the terms of the Mozilla Public License,
+v.2.0. If a copy of the MPL was not distributed with this file, You can obtain
+one at L<http://mozilla.org/MPL/2.0/>.
+
+=cut
+# vim: set ts=4 sts=4 sw=4 et :

--- a/lib/Conch/Plugin/Rollbar.pm
+++ b/lib/Conch/Plugin/Rollbar.pm
@@ -138,7 +138,7 @@ thus created.
             {
                 fingerprint => $fingerprint,
                 uuid => $rollbar_id,
-                _get_extra_data($c)->%*,
+                _request_data($c)->%*,
             },
         );
 
@@ -178,7 +178,7 @@ A string or data structure of fingerprint data for grouping occurrences is optio
                 fingerprint => $fingerprint,
                 uuid => $rollbar_id,
                 level => $severity,
-                _get_extra_data($c)->%*,
+                _request_data($c)->%*,
             },
         );
 
@@ -186,7 +186,7 @@ A string or data structure of fingerprint data for grouping occurrences is optio
     });
 }
 
-sub _get_extra_data ($c) {
+sub _request_data($c) {
     my $user = $c->stash('user');
     my $headers = $c->req->headers->to_hash(1);
     delete $headers->@{qw(Authorization Cookie jwt_token)};

--- a/lib/Conch/Route.pm
+++ b/lib/Conch/Route.pm
@@ -83,7 +83,7 @@ sub all_routes (
     Conch::Route::Schema->routes($root->any('/schema'));
 
     # GET /workspace/:workspace/device-totals
-    $root->get('/workspace/:workspace/device-totals')->to('workspace_device#device_totals');
+    $root->get('/workspace/:workspace/device-totals')->to('workspace_device#device_totals', deprecated => 'v3.1');
 
     # all routes after this point require authentication
 
@@ -92,7 +92,7 @@ sub all_routes (
     $secured->get('/me', sub ($c) { $c->status(204) });
     $secured->post('/refresh_token')->to('login#refresh_token');
 
-    Conch::Route::Workspace->routes($secured->any('/workspace'));
+    Conch::Route::Workspace->routes($secured->any('/workspace')->to(deprecated => 'v3.1'));
     Conch::Route::Device->routes($secured->any('/device'), $app);
     Conch::Route::DeviceReport->routes($secured->any('/device_report'));
     Conch::Route::Relay->routes($secured->any('/relay'));

--- a/lib/Conch/Route.pm
+++ b/lib/Conch/Route.pm
@@ -75,10 +75,10 @@ sub all_routes (
     });
 
     # POST /login
-    $root->post('/login')->to('login#session_login');
+    $root->post('/login')->to('login#login');
 
     # POST /logout
-    $root->post('/logout')->to('login#session_logout');
+    $root->post('/logout')->to('login#logout');
 
     Conch::Route::Schema->routes($root->any('/schema'));
 

--- a/lib/Conch/Route/Build.pm
+++ b/lib/Conch/Route/Build.pm
@@ -72,8 +72,13 @@ sub routes {
                 ->delete('/')->to('build#remove_organization');
         }
 
+        my $build_devices = $with_build_ro->under('/device')->to('#find_devices');
+
         # GET /build/:build_id_or_name/device
-        $with_build_ro->get('/device')->to('#get_devices');
+        $build_devices->get('/')->to('#get_devices');
+
+        # GET /build/:build_id_or_name/device/pxe
+        $build_devices->get('/pxe')->to('#get_pxe_devices');
 
         # POST /build/:build_id_or_name/device
         $with_build_rw->post('/device')->to('#create_and_add_devices', require_role => 'rw');
@@ -249,6 +254,16 @@ Accepts the following optional query parameters:
 =item * Requires system admin authorization or the read-only role on the build
 
 =item * Response: F<response.yaml#/definitions/Devices>, F<response.yaml#/definitions/DeviceIds> or F<response.yaml#/definitions/DeviceSerials>
+
+=back
+
+=head3 C<GET /build/:build_id_or_name/device/pxe>
+
+=over 4
+
+=item * Requires system admin authorization or the read-only role on the build
+
+=item * Response: F<response.yaml#/definitions/DevicePXEs>
 
 =back
 

--- a/lib/Conch/Route/Build.pm
+++ b/lib/Conch/Route/Build.pm
@@ -112,8 +112,17 @@ All routes require authentication.
 
 =head3 C<GET /build>
 
-Takes one optional query parameter C<< device_health >> (defaults to false) to include
-correlated counts of devices having each health value.
+Supports the following optional query parameters:
+
+=over 4
+
+=item * C<with_device_health> - includes correlated counts of devices having each health value
+
+=item * C<with_device_phases> - includes correlated counts of devices having each phase value
+
+=item * C<with_rack_phases> - includes correlated counts of racks having each phase value
+
+=back
 
 =over 4
 
@@ -135,8 +144,17 @@ correlated counts of devices having each health value.
 
 =head3 C<GET /build/:build_id_or_name>
 
-Takes one optional query parameter C<< device_health >> (defaults to false) to include counts
-of devices having each health value.
+Supports the following optional query parameters:
+
+=over 4
+
+=item * C<with_device_health> - includes correlated counts of devices having each health value
+
+=item * C<with_device_phases> - includes correlated counts of devices having each phase value
+
+=item * C<with_rack_phases> - includes correlated counts of racks having each phase value
+
+=back
 
 =over 4
 

--- a/lib/Conch/Route/Build.pm
+++ b/lib/Conch/Route/Build.pm
@@ -258,10 +258,10 @@ Accepts the following optional query parameters:
 
 =over 4
 
-=item * C<< health=<value> >> show only devices with the health matching the provided value
+=item * C<health=:value> show only devices with the health matching the provided value
 (can be used more than once)
 
-=item * C<active_minutes=X> show only devices which have reported within the last X minutes
+=item * C<active_minutes=:X> show only devices which have reported within the last X minutes
 
 =item * C<ids_only=1> only return device IDs, not full device details
 

--- a/lib/Conch/Route/Build.pm
+++ b/lib/Conch/Route/Build.pm
@@ -23,7 +23,7 @@ sub routes {
     $build->to({ controller => 'build' });
 
     # GET /build
-    $build->get('/')->to('#list');
+    $build->get('/')->to('#get_all');
 
     # POST /build
     $build->require_system_admin->post('/')->to('#create');
@@ -47,7 +47,7 @@ sub routes {
         $with_build_admin->post('/')->to('#update');
 
         # GET /build/:build_id_or_name/user
-        $with_build_admin->get('/user')->to('#list_users');
+        $with_build_admin->get('/user')->to('#get_users');
 
         # POST /build/:build_id_or_name/user?send_mail=<1|0>
         $with_build_admin->post('/user')->to('#add_user');
@@ -61,7 +61,7 @@ sub routes {
             my $build_organization = $with_build_admin->any('/organization');
 
             # GET /build/:build_id_or_name/organization
-            $build_organization->get('/')->to('#list_organizations');
+            $build_organization->get('/')->to('#get_organizations');
 
             # POST /build/:build_id_or_name/organization?send_mail=<1|0>
             $build_organization->post('/')->to('#add_organization');

--- a/lib/Conch/Route/DatacenterRoom.pm
+++ b/lib/Conch/Route/DatacenterRoom.pm
@@ -55,6 +55,9 @@ sub routes {
     # POST   /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name/assignment
     # DELETE /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name/assignment
     # POST   /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name/phase?rack_only=<0|1>
+    # GET    /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name/layout/:layout_id_or_rack_unit_start
+    # POST   /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name/layout/:layout_id_or_rack_unit_start
+    # DELETE /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name/layout/:layout_id_or_rack_unit_start
     Conch::Route::Rack->one_rack_routes(
         $room->under('/:datacenter_room_id_or_alias')
             ->to('#find_datacenter_room', require_role => 'none')
@@ -239,6 +242,18 @@ only the rack's phase, or all the rack's devices' phases as well.
 =item * Response: Redirect to the updated rack
 
 =back
+
+=head3 C<GET /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name/layout/:layout_id_or_rack_unit_start>
+
+See L<Conch::Route::RackLayout/C<GET /layout/:layout_id>>.
+
+=head3 C<POST /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name/layout/:layout_id_or_rack_unit_start>
+
+See L<Conch::Route::RackLayout/C<POST /layout/:layout_id>>.
+
+=head3 C<DELETE /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name/layout/:layout_id_or_rack_unit_start>
+
+See L<Conch::Route::RackLayout/C<DELETE /layout/:layout_id>>.
 
 =head1 LICENSING
 

--- a/lib/Conch/Route/Device.pm
+++ b/lib/Conch/Route/Device.pm
@@ -148,13 +148,13 @@ Supports the following query parameters:
 
 =over 4
 
-=item * C</device?hostname=:hostname>
+=item * C<hostname=:hostname>
 
-=item * C</device?mac=:macaddr>
+=item * C<mac=:macaddr>
 
-=item * C</device?ipaddr=:ipaddr>
+=item * C<ipaddr=:ipaddr>
 
-=item * C</device?:setting_key=:setting_value>
+=item * C<:setting_key=:setting_value>
 
 =back
 

--- a/lib/Conch/Route/Device.pm
+++ b/lib/Conch/Route/Device.pm
@@ -94,7 +94,7 @@ sub routes {
         # POST /device/:device_id_or_serial_number/validation_plan/:validation_plan_id
         $with_device_ro->post('/validation_plan/<validation_plan_id:uuid>')->to('device_validation#run_validation_plan');
         # GET /device/:device_id_or_serial_number/validation_state?status=<pass|fail|error>&status=...
-        $with_device->get('/validation_state')->to('device_validation#list_validation_states');
+        $with_device->get('/validation_state')->to('device_validation#get_validation_states');
 
         {
             my $with_device_interface = $with_device_phase_earlier_than_prod

--- a/lib/Conch/Route/HardwareProduct.pm
+++ b/lib/Conch/Route/HardwareProduct.pm
@@ -23,7 +23,7 @@ sub routes {
     $hardware_product->to({ controller => 'hardware_product' });
 
     # GET /hardware_product
-    $hardware_product->get('/')->to('#list');
+    $hardware_product->get('/')->to('#get_all');
 
     # POST /hardware_product
     $hardware_product->require_system_admin->post('/')->to('#create');

--- a/lib/Conch/Route/HardwareProduct.pm
+++ b/lib/Conch/Route/HardwareProduct.pm
@@ -29,29 +29,18 @@ sub routes {
     $hardware_product->require_system_admin->post('/')->to('#create');
 
     {
-        # /hardware_product/:hardware_product_id
-        my $with_hardware_product_id = $hardware_product->under('/<hardware_product_id:uuid>')
+        # /hardware_product/:hardware_product_id_or_other
+        my $with_hardware_product_id_or_other = $hardware_product->under('/:hardware_product_id_or_other')
             ->to('#find_hardware_product');
 
-        # * /hardware_product/name=:hardware_product_name
-        # * /hardware_product/alias=:hardware_product_alias
-        # * /hardware_product/sku=:hardware_product_sku
-        my $with_hardware_product_key_and_value =
-            $hardware_product
-                ->under('/<:hardware_product_key>=<:hardware_product_value>'
-                    => [ hardware_product_key => [qw(name alias sku)] ])
-                ->to('#find_hardware_product');
+        # GET /hardware_product/<:identifier>
+        $with_hardware_product_id_or_other->get('/')->to('#get');
 
-        foreach ($with_hardware_product_id, $with_hardware_product_key_and_value) {
-            # GET /hardware_product/<:identifier>
-            $_->get('/')->to('#get');
+        # POST /hardware_product/<:identifier>
+        $with_hardware_product_id_or_other->require_system_admin->post('/')->to('#update');
 
-            # POST /hardware_product/<:identifier>
-            $_->require_system_admin->post('/')->to('#update');
-
-            # DELETE /hardware_product/<:identifier>
-            $_->require_system_admin->delete('/')->to('#delete');
-        }
+        # DELETE /hardware_product/<:identifier>
+        $with_hardware_product_id_or_other->require_system_admin->delete('/')->to('#delete');
     }
 }
 
@@ -82,13 +71,9 @@ All routes require authentication.
 
 =back
 
-=head3 C<GET /hardware_product/:hardware_product_id>
+=head3 C<GET /hardware_product/:hardware_product_id_or_other>
 
-=head3 C<GET /hardware_product/name=:hardware_product_name>
-
-=head3 C<GET /hardware_product/alias=:hardware_product_alias>
-
-=head3 C<GET /hardware_product/sku=:hardware_product_sku>
+Identifiers accepted: C<id>, C<sku>, C<name> and C<alias>.
 
 =over 4
 
@@ -96,13 +81,9 @@ All routes require authentication.
 
 =back
 
-=head3 C<POST /hardware_product/:hardware_product_id>
+=head3 C<POST /hardware_product/:hardware_product_id_or_other>
 
-=head3 C<POST /hardware_product/name=:hardware_product_name>
-
-=head3 C<POST /hardware_product/alias=:hardware_product_alias>
-
-=head3 C<POST /hardware_product/sku=:hardware_product_sku>
+Identifiers accepted: C<id>, C<sku>, C<name> and C<alias>.
 
 =over 4
 
@@ -114,13 +95,9 @@ All routes require authentication.
 
 =back
 
-=head3 C<DELETE /hardware_product/:hardware_product_id>
+=head3 C<DELETE /hardware_product/:hardware_product_id_or_other>
 
-=head3 C<DELETE /hardware_product/name=:hardware_product_name>
-
-=head3 C<DELETE /hardware_product/alias=:hardware_product_alias>
-
-=head3 C<DELETE /hardware_product/sku=:hardware_product_sku>
+Identifiers accepted: C<id>, C<sku>, C<name> and C<alias>.
 
 =over 4
 

--- a/lib/Conch/Route/Organization.pm
+++ b/lib/Conch/Route/Organization.pm
@@ -23,7 +23,7 @@ sub routes {
     $organization->to({ controller => 'organization' });
 
     # GET /organization
-    $organization->get('/')->to('#list');
+    $organization->get('/')->to('#get_all');
 
     # POST /organization
     $organization->require_system_admin->post('/')->to('#create');

--- a/lib/Conch/Route/Rack.pm
+++ b/lib/Conch/Route/Rack.pm
@@ -27,6 +27,9 @@ sub routes {
     # POST /rack
     $rack_with_system_admin->post('/')->to('#create');
 
+    # for these endpoints, rack name must be a long name (room_vendor_name:rack_name) --
+    # short name is only supported when room qualifier is included (see /room/* endpoints)
+
     # GET    /rack/:rack_id_or_name
     # POST   /rack/:rack_id_or_name
     # DELETE /rack/:rack_id_or_name
@@ -36,6 +39,9 @@ sub routes {
     # POST   /rack/:rack_id_or_name/assignment
     # DELETE /rack/:rack_id_or_name/assignment
     # POST   /rack/:rack_id_or_name/phase?rack_only=<0|1>
+    # GET    /rack/:rack_id_or_name/layout/:layout_id_or_rack_unit_start
+    # POST   /rack/:rack_id_or_name/layout/:layout_id_or_rack_unit_start
+    # DELETE /rack/:rack_id_or_name/layout/:layout_id_or_rack_unit_start
     $class->one_rack_routes($rack);
 }
 
@@ -69,6 +75,11 @@ sub one_rack_routes ($class, $r) {
 
     # POST .../rack/:rack_id_or_name/phase?rack_only=<0|1>
     $one_rack->post('/phase')->to('#set_phase');
+
+    # GET .../rack/:rack_id_or_name/layout/:layout_id_or_rack_unit_start
+    # POST .../rack/:rack_id_or_name/layout/:layout_id_or_rack_unit_start
+    # DELETE .../rack/:rack_id_or_name/layout/:layout_id_or_rack_unit_start
+    Conch::Route::RackLayout->one_layout_routes($one_rack->any('/layout'));
 }
 
 1;
@@ -198,6 +209,18 @@ only the rack's phase, or all the rack's devices' phases as well.
 =item * Response: Redirect to the updated rack
 
 =back
+
+=head3 C<GET /rack/:rack_id_or_name/layout/:layout_id_or_rack_unit_start>
+
+See L<Conch::Route::RackLayout/C<GET /layout/:layout_id>>.
+
+=head3 C<POST /rack/:rack_id_or_name/layout/:layout_id_or_rack_unit_start>
+
+See L<Conch::Route::RackLayout/C<POST /layout/:layout_id>>.
+
+=head3 C<DELETE /rack/:rack_id_or_name/layout/:layout_id_or_rack_unit_start>
+
+See L<Conch::Route::RackLayout/C<DELETE /layout/:layout_id>>.
 
 =head1 LICENSING
 

--- a/lib/Conch/Route/RackLayout.pm
+++ b/lib/Conch/Route/RackLayout.pm
@@ -1,6 +1,6 @@
 package Conch::Route::RackLayout;
 
-use Mojo::Base -strict;
+use Mojo::Base -strict, -signatures;
 
 =pod
 
@@ -27,13 +27,26 @@ sub routes {
     # POST /layout
     $layout->post('/')->to('#create');
 
-    my $with_layout = $layout->under('/<layout_id:uuid>')->to('#find_rack_layout');
-
     # GET /layout/:layout_id
-    $with_layout->get('/')->to('#get');
     # POST /layout/:layout_id
-    $with_layout->post('/')->to('#update');
     # DELETE /layout/:layout_id
+    $class->one_layout_routes($layout);
+}
+
+=head2 one_layout_routes
+
+Sets up the routes for working with just one layout, mounted under a provided route prefix.
+
+=cut
+
+sub one_layout_routes ($class, $r) {
+    my $with_layout = $r->under('/:layout_id_or_rack_unit_start')->to('#find_rack_layout', controller => 'rack_layout');
+
+    # GET .../layout/:layout_id_or_rack_unit_start
+    $with_layout->get('/')->to('#get');
+    # POST .../layout/:layout_id_or_rack_unit_start
+    $with_layout->post('/')->to('#update');
+    # DELETE .../layout/:layout_id_or_rack_unit_start
     $with_layout->delete('/')->to('#delete');
 }
 

--- a/lib/Conch/Route/Relay.pm
+++ b/lib/Conch/Route/Relay.pm
@@ -26,7 +26,7 @@ sub routes {
     $relay->post('/:relay_serial_number/register')->to('#register');
 
     # GET /relay
-    $relay->require_system_admin->get('/')->to('#list');
+    $relay->require_system_admin->get('/')->to('#get_all');
 
     my $with_relay = $relay->under('/:relay_id_or_serial_number')->to('#find_relay');
 

--- a/lib/Conch/Route/User.pm
+++ b/lib/Conch/Route/User.pm
@@ -38,7 +38,7 @@ sub routes {
         # POST /user/me/password?clear_tokens=<login_only|none|all>
         # (after changing password, (possibly) pass through to logging out too)
         $user->under('/me/password')->to('#change_own_password')
-            ->post('/')->to('login#session_logout');
+            ->post('/')->to('login#logout');
 
         {
             my $user_me_settings = $user_me->any('/settings');
@@ -98,7 +98,7 @@ sub routes {
         $user_with_target->delete('/password')->to('#reset_user_password');
 
         # GET /user
-        $user->require_system_admin->get('/')->to('#list');
+        $user->require_system_admin->get('/')->to('#get_all');
         # POST /user?send_mail=<1|0>
         $user->require_system_admin->post('/')->to('#create');
 

--- a/lib/Conch/Route/Validation.pm
+++ b/lib/Conch/Route/Validation.pm
@@ -25,7 +25,7 @@ sub routes {
     $v->to({ controller => 'validation' });
 
     # GET /validation
-    $v->get('/')->to('#list');
+    $v->get('/')->to('#get_all');
 
     {
         my $with_validation = $v->under('/:validation_id_or_name')->to('#find_validation');
@@ -40,7 +40,7 @@ sub routes {
     $vp->to({ controller => 'validation_plan' });
 
     # GET /validation_plan
-    $vp->get('/')->to('#list');
+    $vp->get('/')->to('#get_all');
 
     {
         my $with_plan = $vp->under('/:validation_plan_id_or_name')->to('#find_validation_plan');
@@ -49,7 +49,7 @@ sub routes {
         $with_plan->get('/')->to('#get');
 
         # GET /validation_plan/:validation_plan_id_or_name/validation
-        $with_plan->get('/validation')->to('#list_validations');
+        $with_plan->get('/validation')->to('#get_validations');
     }
 
     {

--- a/lib/Conch/Route/Workspace.pm
+++ b/lib/Conch/Route/Workspace.pm
@@ -141,9 +141,9 @@ Accepts the following optional query parameters:
 
 =item * C<< validated=<1|0> >> show only devices where the C<validated> attribute is set/not-set
 
-=item * C<< health=<value> >> show only devices with the health matching the provided value
+=item * C<health=:value> show only devices with the health matching the provided value
 
-=item * C<active_minutes=X> show only devices which have reported within the last X minutes (this is different from all active devices)
+=item * C<active_minutes=:X> show only devices which have reported within the last X minutes (this is different from all active devices)
 
 =item * C<ids_only=1> only return device IDs, not full device details
 

--- a/lib/Conch/Route/Workspace.pm
+++ b/lib/Conch/Route/Workspace.pm
@@ -24,7 +24,7 @@ sub routes {
     my $workspace = shift;    # secured, under /workspace
 
     # GET /workspace
-    $workspace->get('/')->to('workspace#list');
+    $workspace->get('/')->to('workspace#get_all');
 
     {
         # chainable actions that extract and look up workspace_id from the path
@@ -43,13 +43,13 @@ sub routes {
         $with_workspace->post('/child')->to('workspace#create_sub_workspace');
 
         # GET /workspace/:workspace_id_or_name/device?<various query params>
-        $with_workspace->get('/device')->to('workspace_device#list');
+        $with_workspace->get('/device')->to('workspace_device#get_all');
 
         # GET /workspace/:workspace_id_or_name/device/pxe
         $with_workspace->get('/device/pxe')->to('workspace_device#get_pxe_devices');
 
         # GET /workspace/:workspace_id_or_name/rack
-        $with_workspace->get('/rack')->to('workspace_rack#list');
+        $with_workspace->get('/rack')->to('workspace_rack#get_all');
         # POST /workspace/:workspace_id_or_name/rack
         $with_workspace_admin->post('/rack')->to('workspace_rack#add');
 
@@ -63,12 +63,12 @@ sub routes {
         }
 
         # GET /workspace/:workspace_id_or_name/relay
-        $with_workspace->get('/relay')->to('workspace_relay#list');
+        $with_workspace->get('/relay')->to('workspace_relay#get_all');
         # GET /workspace/:workspace_id_or_name/relay/<relay_id:uuid>/device
         $with_workspace->get('/relay/<relay_id:uuid>/device')->to('workspace_relay#get_relay_devices');
 
         # GET /workspace/:workspace_id_or_name/user
-        $with_workspace_admin->get('/user')->to('workspace_user#list');
+        $with_workspace_admin->get('/user')->to('workspace_user#get_all');
 
         # POST /workspace/:workspace_id_or_name/user?send_mail=<1|0>
         $with_workspace_admin->post('/user')->to('workspace_user#add_user');

--- a/misc/pod2githubpages
+++ b/misc/pod2githubpages
@@ -2,6 +2,7 @@
 use v5.26;
 use strict;
 use warnings;
+use feature 'unicode_strings';
 
 # This is like pod2github or pod2markdown, but takes a list of filename(s)
 # as arguments and outputs markdown documents in the right location(s)
@@ -30,6 +31,15 @@ around 'Pod::Markdown::format_perldoc_url' => sub {
     if ($url =~ /^\Q${\ $self->perldoc_url_prefix }\E/ and -x "bin/$'") {
         $url = '../scripts/'.$';
     }
+
+    if ($url =~ /#/) {
+        my ($base, $fragment) = split(/#/, $url);
+        my $new_fragment = lc($_[1])    # lower-case
+            =~ s/[^\w -]//gr            # strip verything but word chars, space and -
+            =~ tr/ /-/r;                # spaces become -
+        $url = $base.'#'.$new_fragment;
+    }
+
     return $url;
 };
 

--- a/t/database.t
+++ b/t/database.t
@@ -81,7 +81,7 @@ subtest 'read-only database handle' => sub {
             my ($name) = $dbh->selectrow_array('select application_name from pg_stat_activity where pid = pg_backend_pid()');
             return $name;
         }),
-        qr/^conch-${\ $t->API_VERSION_RE } \($$\)$/,
+        qr/^conch ${\ $t->API_VERSION_RE } \($$\)$/,
         'can properly identify the query process by app and pid in pg_stat_activity',
     );
 
@@ -110,7 +110,7 @@ subtest 'read-only database handle' => sub {
             my ($name) = $dbh->selectrow_array('select application_name from pg_stat_activity where pid = pg_backend_pid()');
             return $name;
         }),
-        qr/^conch-${\ $t->API_VERSION_RE } \($$\)$/,
+        qr/^conch ${\ $t->API_VERSION_RE } \($$\)$/,
         'can properly identify the query process by app and pid in pg_stat_activity',
     );
 

--- a/t/integration/crud/build.t
+++ b/t/integration/crud/build.t
@@ -763,7 +763,7 @@ $t->get_ok('/build/our second build/device?active_minutes=5')
     ->json_schema_is('Devices')
     ->json_is($devices);
 
-$t->get_ok('/build?with_device_health')
+$t->get_ok('/build?with_device_health&with_device_phases&with_rack_phases')
     ->status_is(200)
     ->json_schema_is('Builds')
     ->json_is([
@@ -775,6 +775,20 @@ $t->get_ok('/build?with_device_health')
                 unknown => 0,
                 pass => 0,
             },
+            device_phases => {
+                integration => 0,
+                installation => 0,
+                production => 0,
+                diagnostics => 0,
+                decommissioned => 0,
+            },
+            rack_phases => {
+                integration => 0,
+                installation => 0,
+                production => 0,
+                diagnostics => 0,
+                decommissioned => 0,
+            },
         },
         {
             $build2->%*,
@@ -784,10 +798,24 @@ $t->get_ok('/build?with_device_health')
                 unknown => 1,
                 pass => 0,
             },
+            device_phases => {
+                integration => 1,
+                installation => 0,
+                production => 0,
+                diagnostics => 0,
+                decommissioned => 0,
+            },
+            rack_phases => {
+                integration => 0,
+                installation => 0,
+                production => 0,
+                diagnostics => 0,
+                decommissioned => 0,
+            },
         },
     ]);
 
-$t->get_ok('/build/our second build?with_device_health')
+$t->get_ok('/build/our second build?with_device_health&with_device_phases&with_rack_phases')
     ->status_is(200)
     ->json_schema_is('Build')
     ->json_is({
@@ -797,6 +825,20 @@ $t->get_ok('/build/our second build?with_device_health')
             fail => 0,
             unknown => 1,
             pass => 0,
+        },
+        device_phases => {
+            integration => 1,
+            installation => 0,
+            production => 0,
+            diagnostics => 0,
+            decommissioned => 0,
+        },
+        rack_phases => {
+            integration => 0,
+            installation => 0,
+            production => 0,
+            diagnostics => 0,
+            decommissioned => 0,
         },
     });
 
@@ -994,6 +1036,58 @@ $t->get_ok('/build/our second build/rack')
         superhashof({ id => $rack2->id }),
     ]);
 
+$t->get_ok('/build?with_device_health&with_device_phases&with_rack_phases')
+    ->status_is(200)
+    ->json_schema_is('Builds')
+    ->json_is([
+        {
+            $build->%*,
+            device_health => {
+                error => 0,
+                fail => 0,
+                unknown => 1,
+                pass => 0,
+            },
+            device_phases => {
+                integration => 1,
+                installation => 0,
+                production => 0,
+                diagnostics => 0,
+                decommissioned => 0,
+            },
+            rack_phases => {
+                integration => 1,
+                installation => 0,
+                production => 0,
+                diagnostics => 0,
+                decommissioned => 0,
+            },
+        },
+        {
+            $build2->%*,
+            device_health => {
+                error => 0,
+                fail => 0,
+                unknown => 1,
+                pass => 0,
+            },
+            device_phases => {
+                integration => 1,
+                installation => 0,
+                production => 0,
+                diagnostics => 0,
+                decommissioned => 0,
+            },
+            rack_phases => {
+                integration => 1,
+                installation => 0,
+                production => 0,
+                diagnostics => 0,
+                decommissioned => 0,
+            },
+        },
+    ]);
+
 $t->post_ok('/build/my first build', json => { completed => undef })
     ->status_is(303)
     ->location_is('/build/'.$build->{id})
@@ -1013,6 +1107,8 @@ $t->post_ok('/build/my first build', json => { completed => $now->minus_days(1) 
     ->status_is(303)
     ->location_is('/build/'.$build->{id})
     ->log_info_is("build $build->{id} (my first build) completed; 0 users had role converted from rw to ro");
+
+$build->{completed} = $now->minus_days(1)->to_string;
 
 $device1->update({ phase => 'production' });
 
@@ -1041,6 +1137,58 @@ $t->get_ok('/build/my first build/device?phase_earlier_than=')
             (map +('build_'.$_ => $build->{$_}), qw(id name)),
             (map +($_ => undef), qw(rack_id rack_name rack_unit_start)),
         }),
+    ]);
+
+$t->get_ok('/build?with_device_health&with_device_phases&with_rack_phases')
+    ->status_is(200)
+    ->json_schema_is('Builds')
+    ->json_is([
+        {
+            $build->%*,
+            device_health => {
+                error => 0,
+                fail => 0,
+                unknown => 0,
+                pass => 1,
+            },
+            device_phases => {
+                integration => 1,
+                installation => 0,
+                production => 0,
+                diagnostics => 0,
+                decommissioned => 0,
+            },
+            rack_phases => {
+                integration => 1,
+                installation => 0,
+                production => 0,
+                diagnostics => 0,
+                decommissioned => 0,
+            },
+        },
+        {
+            $build2->%*,
+            device_health => {
+                error => 0,
+                fail => 0,
+                unknown => 1,
+                pass => 0,
+            },
+            device_phases => {
+                integration => 1,
+                installation => 0,
+                production => 0,
+                diagnostics => 0,
+                decommissioned => 0,
+            },
+            rack_phases => {
+                integration => 1,
+                installation => 0,
+                production => 0,
+                diagnostics => 0,
+                decommissioned => 0,
+            },
+        },
     ]);
 
 $device1->update({ phase => 'integration' });

--- a/t/integration/crud/build.t
+++ b/t/integration/crud/build.t
@@ -711,11 +711,12 @@ $t->get_ok('/build/our second build/device')
         superhashof({
             serial_number => 'FOO',
             hardware_product_id => $hardware_product->id,
+            sku => $hardware_product->sku,
             health => 'unknown',
             asset_tag => undef,
             links => [],
-            build_id => $build2->{id},
-            rack_id => undef,
+            (map +('build_'.$_ => $build2->{$_}), qw(id name)),
+            (map +($_ => undef), qw(rack_id rack_name rack_unit_start)),
         }),
     ]);
 my $devices = $t->tx->res->json;
@@ -843,7 +844,7 @@ $t->get_ok('/build/our second build/device')
             $devices->[0]->%*,
             asset_tag => 'fooey',
             links => [ 'https://foo.bar.com' ],
-            build_id => $build2->{id},
+            (map +('build_'.$_ => $build2->{$_}), qw(id name)),
             updated => re(qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/),
         },
     ]);
@@ -898,8 +899,10 @@ $t->get_ok('/build/my first build/device')
     ->json_schema_is('Devices')
     ->json_cmp_deeply([ superhashof({
         (map +($_ => $device1->$_), qw(id serial_number)),
-        build_id => undef,  # in the build via the rack, not directly (FIXME)
+        (map +('build_'.$_ => undef), qw(id name)), # in the build via the rack, not directly (FIXME)
         rack_id => $rack1->id,
+        rack_name => $rack1->datacenter_room->vendor_name.':'.$rack1->name,
+        rack_unit_start => $device1->device_location->rack_unit_start,
     }) ]);
 
 
@@ -929,8 +932,10 @@ $t->get_ok('/build/our second build/device')
         # now device2 is in build2 via rack2
         superhashof({
             (map +($_ => $device2->$_), qw(id serial_number)),
-            build_id => undef,
+            (map +('build_'.$_ => undef), qw(id name)), # in the build via the rack, not directly (FIXME)
             rack_id => $rack2->id,
+            rack_name => $rack2->datacenter_room->vendor_name.':'.$rack2->name,
+            rack_unit_start => $device2->device_location->rack_unit_start,
         }),
     ]);
 
@@ -958,13 +963,15 @@ $t->get_ok('/build/my first build/device')
     ->json_cmp_deeply([
         superhashof({
             (map +($_ => $device1->$_), qw(id serial_number)),
-            build_id => undef,  # in the build via the rack, not directly (FIXME)
+            (map +('build_'.$_ => undef), qw(id name)), # in the build via the rack, not directly (FIXME)
             rack_id => $rack1->id,
+            rack_name => $rack1->datacenter_room->vendor_name.':'.$rack1->name,
+            rack_unit_start => $device1->device_location->rack_unit_start,
         }),
         superhashof({
             (map +($_ => $device2->$_), qw(id serial_number)),
-            build_id => $build->{id},
-            rack_id => undef,
+            (map +('build_'.$_ => $build->{$_}), qw(id name)),
+            (map +($_ => undef), qw(rack_id rack_name rack_unit_start)),
         }),
     ]);
 
@@ -1016,8 +1023,8 @@ $t->get_ok('/build/my first build/device')
         # device1 phase >= production, so its location is no longer canonical
         superhashof({
             (map +($_ => $device2->$_), qw(id serial_number)),
-            build_id => $build->{id},
-            rack_id => undef,
+            (map +('build_'.$_ => $build->{$_}), qw(id name)),
+            (map +($_ => undef), qw(rack_id rack_name rack_unit_start)),
         }),
     ]);
 
@@ -1026,14 +1033,13 @@ $t->get_ok('/build/my first build/device?phase_earlier_than=')
     ->json_schema_is('Devices')
     ->json_cmp_deeply([
         superhashof({
-            (map +($_ => $device1->$_), qw(id serial_number)),
-            build_id => undef,  # in the build via the rack, not directly (FIXME)
+            (map +('build_'.$_ => undef), qw(id name)), # in the build via the rack, not directly (FIXME)
             # rack_id omitted because phase=production
         }),
         superhashof({
             (map +($_ => $device2->$_), qw(id serial_number)),
-            build_id => $build->{id},
-            rack_id => undef,
+            (map +('build_'.$_ => $build->{$_}), qw(id name)),
+            (map +($_ => undef), qw(rack_id rack_name rack_unit_start)),
         }),
     ]);
 
@@ -1147,13 +1153,13 @@ $t->get_ok('/build/our second build/device')
         $new_device,
         superhashof({
             (map +($_ => $device1->$_), qw(id serial_number)),
-            build_id => $build2->{id},
+            (map +('build_'.$_ => $build2->{$_}), qw(id name)),
             # device.phase >= production, so its location is no longer canonical
         }),
         superhashof({
             (map +($_ => $device2->$_), qw(id serial_number)),
-            build_id => $build2->{id},
-            rack_id => undef,
+            (map +('build_'.$_ => $build2->{$_}), qw(id name)),
+            (map +($_ => undef), qw(rack_id rack_name rack_unit_start)),
         }),
     ]);
 

--- a/t/integration/crud/devices.t
+++ b/t/integration/crud/devices.t
@@ -314,12 +314,12 @@ subtest 'unlocated device with a registered relay' => sub {
         ->json_schema_is('DetailedDevice');
 
     foreach my $query (@post_queries) {
-        $t2->post_ok($query->@*);
-        if ($query->[0] =~ /settings|validated/) {
+        $t2->post_ok($query->@*)
+            ->location_is('/device/'.$test_device_id);
+        if ($query->[0] =~ /settings|validated|phase/) {
             $t2->status_is(204);
         } else {
-            $t2->status_is(303)
-                ->location_is('/device/'.$test_device_id);
+            $t2->status_is(303);
         }
     }
 

--- a/t/integration/crud/devices.t
+++ b/t/integration/crud/devices.t
@@ -155,7 +155,7 @@ subtest 'unlocated device with a registered relay' => sub {
             system_uuid => ignore,
             phase => 'integration',
             links => [],
-            build_id => $build->id,
+            (map +('build_'.$_ => $build->$_), qw(id name)),
             (map +($_ => undef), qw(asset_tag uptime_since validated)),
             (map +($_ => re(qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/)), qw(created updated last_seen)),
             hardware_product_id => $hardware_product->id,
@@ -363,7 +363,7 @@ subtest 'located device' => sub {
             health => 'unknown',
             phase => 'integration',
             links => [],
-            build_id => undef,
+            (map +('build_'.$_ => undef), qw(id name)),
             (map +($_ => undef), qw(asset_tag hostname last_seen system_uuid uptime_since validated)),
             (map +($_ => re(qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/)), qw(created updated)),
             hardware_product_id => $hardware_product->id,
@@ -548,7 +548,7 @@ subtest 'located device' => sub {
         ->log_debug_is('User has rw access to device '.$located_device_id.' via role entry');
 
     $located_device->update({ phase => 'production' });
-    $device_data->{build_id} = $build->id;
+    $device_data->@{qw(build_id build_name)} = map $build->$_, qw(id name);
     $device_data->{phase} = 'production';
     delete $device_data->@{qw(location nics disks)};
 
@@ -821,7 +821,7 @@ subtest 'mutate device attributes' => sub {
     $t->post_ok('/device/TEST/build', json => { build_id => $build2->id })
         ->status_is(303)
         ->location_is('/device/'.$test_device_id);
-    $detailed_device->{build_id} = $build2->id;
+    $detailed_device->@{qw(build_id build_name)} = map $build2->$_, qw(id name);
 
     $ubr->delete;
 

--- a/t/integration/crud/rack-layouts.t
+++ b/t/integration/crud/rack-layouts.t
@@ -28,11 +28,13 @@ my $hw_product_storage = $t->load_fixture('hardware_product_storage');  # rack_u
 # start 11, width 4
 
 my $fake_id = create_uuid_str();
+my @racks = $t->app->db_racks->search({ name => [qw(rack.0a rack.1a)] })->prefetch('datacenter_room')->order_by('name')->all;
+my $rack_id = $racks[0]->id;
 
 $t->get_ok('/layout')
     ->status_is(200)
     ->json_schema_is('RackLayouts')
-    ->json_cmp_deeply(bag(
+    ->json_cmp_deeply([
         map +{
             $_->%*,
             id => re(Conch::UUID::UUID_FORMAT),
@@ -40,11 +42,32 @@ $t->get_ok('/layout')
             updated => re(qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/),
         },
         (map +(
-            { rack_id => $_, rack_unit_start => 1, rack_unit_size => 2, hardware_product_id => $hw_product_compute->id },
-            { rack_id => $_, rack_unit_start => 3, rack_unit_size => 4, hardware_product_id => $hw_product_storage->id },
-            { rack_id => $_, rack_unit_start => 11, rack_unit_size => 4, hardware_product_id => $hw_product_storage->id },
-        ), my $rack_id = $t->load_fixture('rack_0a')->id, $t->load_fixture('rack_1a')->id)
-    ));
+            {
+                rack_id => $_->id,
+                rack_name => $_->datacenter_room->vendor_name.':'.$_->name,
+                rack_unit_start => 1,
+                rack_unit_size => 2,
+                hardware_product_id => $hw_product_compute->id,
+                sku => $hw_product_compute->sku,
+            },
+            {
+                rack_id => $_->id,
+                rack_name => $_->datacenter_room->vendor_name.':'.$_->name,
+                rack_unit_start => 3,
+                rack_unit_size => 4,
+                hardware_product_id => $hw_product_storage->id,
+                sku => $hw_product_storage->sku,
+            },
+            {
+                rack_id => $_->id,
+                rack_name => $_->datacenter_room->vendor_name.':'.$_->name,
+                rack_unit_start => 11,
+                rack_unit_size => 4,
+                hardware_product_id => $hw_product_storage->id,
+                sku => $hw_product_storage->sku,
+            },
+        ), @racks)
+    ]);
 
 my $initial_layouts = $t->tx->res->json;
 my $layout_width_4 = $initial_layouts->[2];    # start 11, width 4.
@@ -68,12 +91,13 @@ $t->get_ok("/rack/$rack_id/layout")
             $_->%*,
             id => re(Conch::UUID::UUID_FORMAT),
             rack_id => $rack_id,
+            rack_name => 'ROOM:0.A:rack.0a',
             created => re(qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/),
             updated => re(qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/),
         },
-        { rack_unit_start => 1, rack_unit_size => 2, hardware_product_id => $hw_product_compute->id },
-        { rack_unit_start => 3, rack_unit_size => 4, hardware_product_id => $hw_product_storage->id },
-        { rack_unit_start => 11, rack_unit_size => 4, hardware_product_id => $hw_product_storage->id },
+        { rack_unit_start => 1, rack_unit_size => 2, hardware_product_id => $hw_product_compute->id, sku => $hw_product_compute->sku },
+        { rack_unit_start => 3, rack_unit_size => 4, hardware_product_id => $hw_product_storage->id, sku => $hw_product_storage->sku },
+        { rack_unit_start => 11, rack_unit_size => 4, hardware_product_id => $hw_product_storage->id, sku => $hw_product_storage->sku },
     ]);
 
 my $layout_1_2 = $t->load_fixture('rack_0a_layout_1_2');
@@ -183,13 +207,14 @@ $t->get_ok($_)
             $_->%*,
             id => re(Conch::UUID::UUID_FORMAT),
             rack_id => $rack_id,
+            rack_name => 'ROOM:0.A:rack.0a',
             created => re(qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/),
             updated => re(qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/),
         },
-        { rack_unit_start => 1, rack_unit_size => 2, hardware_product_id => $hw_product_compute->id },
-        { rack_unit_start => 3, rack_unit_size => 4, hardware_product_id => $hw_product_storage->id },
-        { rack_unit_start => 11, rack_unit_size => 4, hardware_product_id => $hw_product_storage->id },
-        { rack_unit_start => 42, rack_unit_size => 1, hardware_product_id => $hw_product_switch->id },
+        { rack_unit_start => 1, rack_unit_size => 2, hardware_product_id => $hw_product_compute->id, sku => $hw_product_compute->sku },
+        { rack_unit_start => 3, rack_unit_size => 4, hardware_product_id => $hw_product_storage->id, sku => $hw_product_storage->sku },
+        { rack_unit_start => 11, rack_unit_size => 4, hardware_product_id => $hw_product_storage->id, sku => $hw_product_storage->sku },
+        { rack_unit_start => 42, rack_unit_size => 1, hardware_product_id => $hw_product_switch->id, sku => $hw_product_switch->sku },
     ])
     foreach
         '/rack/'.$rack_id.'/layout',
@@ -389,9 +414,30 @@ $t->get_ok('/rack/'.$rack_id.'/assignment')
     ->status_is(200)
     ->json_schema_is('RackAssignments')
     ->json_cmp_deeply([
-        { rack_unit_start => 1, rack_unit_size => 2, hardware_product_name => $hw_product_compute->name, device_id => undef, device_asset_tag => undef },
-        { rack_unit_start => 20, rack_unit_size => 4, hardware_product_name => $hw_product_storage->name, device_id => $device->id, device_asset_tag => undef },
-        { rack_unit_start => 26, rack_unit_size => 2, hardware_product_name => $hw_product_compute->name, device_id => undef, device_asset_tag => undef },
+        {
+            rack_unit_start => 1,
+            rack_unit_size => 2,
+            hardware_product_name => $hw_product_compute->name,
+            sku => $hw_product_compute->sku,
+            device_id => undef,
+            device_asset_tag => undef,
+        },
+        {
+            rack_unit_start => 20,
+            rack_unit_size => 4,
+            hardware_product_name => $hw_product_storage->name,
+            sku => $hw_product_storage->sku,
+            device_id => $device->id,
+            device_asset_tag => undef,
+        },
+        {
+            rack_unit_start => 26,
+            rack_unit_size => 2,
+            hardware_product_name => $hw_product_compute->name,
+            sku => $hw_product_compute->sku,
+            device_id => undef,
+            device_asset_tag => undef,
+        },
     ]);
 
 $t->post_ok('/rack/'.$rack_id.'/layout',
@@ -414,7 +460,14 @@ $t->get_ok('/rack/'.$rack_id.'/assignment')
     ->status_is(200)
     ->json_schema_is('RackAssignments')
     ->json_cmp_deeply([
-        { rack_unit_start => 3, rack_unit_size => 2, hardware_product_name => $hw_product_compute->name, device_id => undef, device_asset_tag => undef },
+        {
+            rack_unit_start => 3,
+            rack_unit_size => 2,
+            hardware_product_name => $hw_product_compute->name,
+            sku => $hw_product_compute->sku,
+            device_id => undef,
+            device_asset_tag => undef,
+        },
     ]);
 
 $t->post_ok('/rack/'.$rack_id.'/layout', json => [])

--- a/t/integration/crud/rack-layouts.t
+++ b/t/integration/crud/rack-layouts.t
@@ -72,10 +72,19 @@ $t->get_ok('/layout')
 my $initial_layouts = $t->tx->res->json;
 my $layout_width_4 = $initial_layouts->[2];    # start 11, width 4.
 
-$t->get_ok("/layout/$initial_layouts->[0]{id}")
+$t->get_ok($_)
     ->status_is(200)
     ->json_schema_is('RackLayout')
-    ->json_is($initial_layouts->[0]);
+    ->json_is($initial_layouts->[0])
+    ->log_debug_is('Found rack layout '.(split('/'))[-1].((split('/'))[1] eq 'rack' ? ' in rack id '.(split('/'))[2] : ''))
+    foreach
+        '/layout/'.$initial_layouts->[0]{id},
+        '/rack/'.$racks[0]->id.'/layout/'.$initial_layouts->[0]{id},
+        '/rack/'.$racks[0]->id.'/layout/1';
+
+$t->get_ok('/layout/1')
+    ->status_is(400)
+    ->json_is({ error => 'cannot look up layout by rack_unit_start without qualifying by rack' });
 
 $t->post_ok('/layout', json => { wat => 'wat' })
     ->status_is(400)

--- a/t/integration/crud/racks.t
+++ b/t/integration/crud/racks.t
@@ -38,8 +38,12 @@ $t->get_ok($_)
     ->json_cmp_deeply(superhashof({
         id => $rack->id,
         name => 'rack.0a',
+        full_rack_name => 'ROOM:0.A:rack.0a',
         datacenter_room_id => $room->id,
+        datacenter_room_alias => 'room 0a',
         rack_role_id => re(Conch::UUID::UUID_FORMAT),
+        rack_role_name => 'rack_role 42U',
+        (map +('build_'.$_ => $rack->build->$_), qw(id name)),
     }))
     foreach
         '/rack/'.$rack->id,
@@ -126,14 +130,17 @@ $t->get_ok($t->tx->res->headers->location)
     ->json_cmp_deeply({
         id => re(Conch::UUID::UUID_FORMAT),
         name => 'r4ck',
+        full_rack_name => 'ROOM:0.A:r4ck',
         datacenter_room_id => $room->id,
+        datacenter_room_alias => 'room 0a',
         rack_role_id => $rack->rack_role_id,
+        rack_role_name => 'rack_role 42U',
         serial_number => 'abc',
         asset_tag => undef,
         phase => 'integration',
         created => re(qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/),
         updated => re(qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/),
-        build_id => $build->id,
+        (map +('build_'.$_ => $build->$_), qw(id name)),
     });
 my $new_rack = $t->tx->res->json;
 
@@ -218,7 +225,10 @@ $t->get_ok($t->tx->res->headers->location)
         name => 'rack',
         serial_number => 'abc',
         asset_tag => 'deadbeef',
+        datacenter_room_id => $room->id,
+        datacenter_room_alias => 'room 0a',
         rack_role_id => $small_rack_role->id,
+        rack_role_name => $small_rack_role->name,
     }));
 
 $t->get_ok($_)
@@ -285,6 +295,7 @@ $t->get_ok('/rack/'.$rack->id.'/assignment')
             device_id => undef,
             device_asset_tag => undef,
             hardware_product_name => $hardware_product_compute->name,
+            sku => $hardware_product_compute->sku,
         },
         {
             rack_unit_start => 3,
@@ -292,6 +303,7 @@ $t->get_ok('/rack/'.$rack->id.'/assignment')
             device_id => undef,
             device_asset_tag => undef,
             hardware_product_name => $hardware_product_storage->name,
+            sku => $hardware_product_storage->sku,
         },
         {
             rack_unit_start => 11,
@@ -299,6 +311,7 @@ $t->get_ok('/rack/'.$rack->id.'/assignment')
             device_id => undef,
             device_asset_tag => undef,
             hardware_product_name => $hardware_product_storage->name,
+            sku => $hardware_product_storage->sku,
         },
     ]);
 my $assignments = $t->tx->res->json;

--- a/t/integration/crud/racks.t
+++ b/t/integration/crud/racks.t
@@ -607,5 +607,28 @@ $t->get_ok($_)
         '/room/'.$room->alias.'/rack/'.$room->vendor_name.':'.$rack->name.'/assignment',
         '/room/'.$room->alias.'/rack/'.$rack->name.'/assignment';
 
+$t->get_ok('/rack/'.$rack->id.'/layout')
+    ->status_is(200)
+    ->location_is('/rack/'.$rack->id.'/layout')
+    ->json_schema_is('RackLayouts');
+my $layouts = $t->tx->res->json;
+
+$t->get_ok($_)
+    ->status_is(200)
+    ->location_is('/layout/'.$layouts->[0]{id})
+    ->json_schema_is('RackLayout')
+    ->json_is($layouts->[0])
+    ->log_debug_is('Found rack layout '.(split('/'))[-1].' in rack id '.$rack->id)
+    foreach map +(
+        '/rack/'.$rack->id.'/layout/'.$layouts->[0]{$_},
+        '/rack/'.$room->vendor_name.':'.$rack->name.'/layout/'.$layouts->[0]{$_},
+        '/room/'.$room->id.'/rack/'.$rack->id.'/layout/'.$layouts->[0]{$_},
+        '/room/'.$room->id.'/rack/'.$room->vendor_name.':'.$rack->name.'/layout/'.$layouts->[0]{id},
+        '/room/'.$room->id.'/rack/'.$rack->name.'/layout/'.$layouts->[0]{$_},
+        '/room/'.$room->alias.'/rack/'.$rack->id.'/layout/'.$layouts->[0]{$_},
+        '/room/'.$room->alias.'/rack/'.$room->vendor_name.':'.$rack->name.'/layout/'.$layouts->[0]{$_},
+        '/room/'.$room->alias.'/rack/'.$rack->name.'/layout/'.$layouts->[0]{$_},
+    ), qw(id rack_unit_start);
+
 done_testing;
 # vim: set ts=4 sts=4 sw=4 et :

--- a/t/integration/crud/racks.t
+++ b/t/integration/crud/racks.t
@@ -199,7 +199,7 @@ $t->post_ok("/rack/$new_rack->{id}", json => {
 $new_rack->@{qw(name serial_number asset_tag)} = qw(rack abc deadbeef);
 
 $t->post_ok($_, json => { rack_role_id => $small_rack_role->id })
-    ->status_is(303)
+    ->status_is($_ eq '/rack/'.$new_rack->{id} ? 303 : 204)
     ->location_is('/rack/'.$new_rack->{id})
     foreach
         '/rack/'.$new_rack->{id},

--- a/t/integration/crud/rooms.t
+++ b/t/integration/crud/rooms.t
@@ -84,7 +84,7 @@ $t2->get_ok($_)
         '/room/'.$room->{alias}.'/rack/rack.0a';
 
 $t->app->db_racks->search({ id => $rack->{id} })->update({ build_id => $build->id });
-$rack->{build_id} = $build->id;
+$rack->@{qw(build_id build_name)} = map $build->$_, qw(id name);
 
 $t2->get_ok('/room')
     ->status_is(403);

--- a/t/integration/crud/workspace-devices.t
+++ b/t/integration/crud/workspace-devices.t
@@ -218,6 +218,8 @@ subtest 'Devices with PXE data' => sub {
     delete $pxe_data->[0]{location};
     $pxe_data->[0]{phase} = 'production';
 
+    # in this case, we omit the entire result... because we cannot possibly include the device
+    # and not its location, because it is only present in the workspace via rack.
     $t->get_ok('/workspace/'.$global_ws_id.'/device/pxe')
         ->status_is(200)
         ->json_schema_is('WorkspaceDevicePXEs')

--- a/t/integration/crud/workspace-rack.t
+++ b/t/integration/crud/workspace-rack.t
@@ -133,6 +133,7 @@ subtest 'Assign device to a location' => sub {
                 device_id => $test->id,
                 device_asset_tag => undef,
                 hardware_product_name => $hardware_product_compute->name,
+                sku => $hardware_product_compute->sku,
             },
             {
                 rack_unit_start => 3,
@@ -140,6 +141,7 @@ subtest 'Assign device to a location' => sub {
                 device_id => $new_device->id,
                 device_asset_tag => undef,
                 hardware_product_name => $hardware_product_storage->name,
+                sku => $hardware_product_storage->sku,
             },
             {
                 rack_unit_start => 11,
@@ -147,6 +149,7 @@ subtest 'Assign device to a location' => sub {
                 device_id => undef,
                 device_asset_tag => undef,
                 hardware_product_name => $hardware_product_storage->name,
+                sku => $hardware_product_storage->sku,
             },
         ]);
 

--- a/t/integration/crud/workspace.t
+++ b/t/integration/crud/workspace.t
@@ -29,6 +29,7 @@ subtest 'Workspaces' => sub {
 
     $t->get_ok('/workspace')
         ->status_is(200)
+        ->header_is('X-Deprecated', 'this endpoint is deprecated and will be removed in api v3.1')
         ->json_schema_is('WorkspacesAndRoles')
         ->json_is([{
             id          => $global_ws_id,

--- a/t/integration/unsecured-endpoints.t
+++ b/t/integration/unsecured-endpoints.t
@@ -101,6 +101,7 @@ subtest 'device totals' => sub {
 
     $t->get_ok("/workspace/$global_ws_id/device-totals")
         ->status_is(200)
+        ->header_is('X-Deprecated', 'this endpoint is deprecated and will be removed in api v3.1')
         ->json_schema_is('DeviceTotals')
         ->json_is({
             all => [
@@ -121,6 +122,7 @@ subtest 'device totals' => sub {
 
     $t->get_ok("/workspace/$global_ws_id/device-totals.circ")
         ->status_is(200)
+        ->header_is('X-Deprecated', 'this endpoint is deprecated and will be removed in api v3.1')
         ->json_schema_is('DeviceTotalsCirconus')
         ->json_is({
             'Switch Vendor' => {


### PR DESCRIPTION
Internal fixes:
- db connection labels include script name
- doc fixes

Enhancements to existing endpoints:
- return 204 for most POSTs if nothing changed, plus a Location header in more instances
- order GET /build/\*/rack, GET /room/\*/rack results by rack name
- sort device disks by slot number in GET /device/:id_or_serial
- use GET /hardware_product/<sku or name or alias> in place of sku=.. etc
- include names in addition to ids in some GET responses (shortening some client code by removing the need to do a name->id lookup)
- do not list all users in GET /organization, only admins (avoid leaking privileged information)
- add ?with_device_phases and ?with_rack_phases to GET /build, GET /build/:id_or_name endpoints (allows more avoidance of database-intensive queries on overview pages)
- add X-Deprecated response header for endpoints to be removed soon (and send rollbar messages when such endpoints are used)

New endpoints:
- GET /build/:id_or_name/device/pxe
- GET, POST, DELETE /rack/:rack_id_or_long_name/layout/:layout_id_or_rack_unit_start
- GET, POST, DELETE /room/:room_id_or_alias/rack/:rack_id_or_name/layout/:layout_id_or_rack_unit_start
