### PR TITLE
v3 b7: better logging

### DIFF
--- a/docs/modules/Conch::Plugin::Logging.md
+++ b/docs/modules/Conch::Plugin::Logging.md
@@ -11,6 +11,20 @@
 Initializes the logger object, and sets up hooks in various places to log request data and
 process exceptions.
 
+## HELPERS
+
+These methods are made available on the `$c` object (the invocant of all controller methods,
+and therefore other helpers).
+
+### log
+
+Returns the main [Conch::Log](../modules/Conch%3A%3ALog) object for the application, used for most logging.
+
+### get\_logger
+
+Returns a secondary [Conch::Log](../modules/Conch%3A%3ALog) object, to log specialized messages to a separate location.
+Uses the provided `type` in the filename (e.g. `type => foo` will log to `foo.log`).
+
 ## LICENSING
 
 Copyright Joyent, Inc.

--- a/docs/modules/Conch::ValidationSystem.md
+++ b/docs/modules/Conch::ValidationSystem.md
@@ -13,6 +13,8 @@ have available in Conch::Validation::\*.
 
 Validations not referenced by an active plan are ignored.
 
+Returns a tuple, indicating the number of valid and invalid plans checked.
+
 ### check\_validation\_plan
 
 Verifies that a validation plan and its validations are all correct (correct

--- a/lib/Conch.pm
+++ b/lib/Conch.pm
@@ -204,9 +204,15 @@ in user-facing content.
 
     push $self->commands->namespaces->@*, 'Conch::Command';
 
-    Conch::ValidationSystem->new(log => $self->log, schema => $self->ro_schema)
-            ->check_validation_plans
-        if not $ARGV[0] and not $self->feature('no_db');
+    if (not $ARGV[0] and not $self->feature('no_db')) {
+        my ($good_plans, $bad_plans) = Conch::ValidationSystem->new(
+            log => $self->get_logger('validation'),
+            schema => $self->ro_schema,
+        )->check_validation_plans;
+
+        $self->log->info($good_plans.' validation plans verified');
+        $self->log->warn($bad_plans.' invalid validation plans identified') if $bad_plans;
+    }
 
     Conch::Route->all_routes($self->routes, $self);
 

--- a/lib/Conch.pm
+++ b/lib/Conch.pm
@@ -206,7 +206,7 @@ in user-facing content.
 
     Conch::ValidationSystem->new(log => $self->log, schema => $self->ro_schema)
             ->check_validation_plans
-        if not $self->feature('no_db');
+        if not $ARGV[0] and not $self->feature('no_db');
 
     Conch::Route->all_routes($self->routes, $self);
 

--- a/lib/Conch/Controller/DeviceReport.pm
+++ b/lib/Conch/Controller/DeviceReport.pm
@@ -119,7 +119,7 @@ sub process ($c) {
 
     my $validation_state = Conch::ValidationSystem->new(
         schema => $c->schema,
-        log => $c->log,
+        log => $c->get_logger('validation'),
     )->run_validation_plan(
         validation_plan => $validation_plan,
         # TODO: to eliminate needless db queries, we should prefetch all the relationships
@@ -421,7 +421,7 @@ sub validate_report ($c) {
 
         ($status, @validation_results) = Conch::ValidationSystem->new(
             schema => $c->ro_schema,
-            log => $c->log,
+            log => $c->get_logger('validation'),
         )->run_validation_plan(
             validation_plan => $validation_plan,
             device => $device,

--- a/lib/Conch/Controller/DeviceValidation.pm
+++ b/lib/Conch/Controller/DeviceValidation.pm
@@ -69,7 +69,7 @@ sub validate ($c) {
 
     my @validation_results = Conch::ValidationSystem->new(
         schema => $c->ro_schema,
-        log => $c->log,
+        log => $c->get_logger('validation'),
     )->run_validation(
         validation => $validation,
         device => $c->db_ro_devices->find($c->stash('device_id')),
@@ -108,7 +108,7 @@ sub run_validation_plan ($c) {
 
     my ($status, @validation_results) = Conch::ValidationSystem->new(
         schema => $c->ro_schema,
-        log => $c->log,
+        log => $c->get_logger('validation'),
     )->run_validation_plan(
         validation_plan => $validation_plan,
         device => $c->db_ro_devices->find($c->stash('device_id')),

--- a/t/integration/crud/racks.t
+++ b/t/integration/crud/racks.t
@@ -446,13 +446,13 @@ $t->post_ok('/rack/'.$rack->id.'/assignment', json => [
         { device_id => $new_id, rack_unit_start => 11 },
     ])
     ->status_is(404)
-    ->log_is('Could not find device '.$new_id);
+    ->log_warn_is('Could not find device '.$new_id);
 
 $t->post_ok('/rack/'.$rack->id.'/assignment', json => [
         { device_id => $foo->id, device_serial_number => 'BAR', rack_unit_start => 11 },
     ])
     ->status_is(400)
-    ->log_is(re(qr/unique constraint.*serial_number/));
+    ->log_error_is(re(qr/unique constraint.*serial_number/));
 
 # current layout:
 # slot 1, tag=ohhai - FOO = new device

--- a/t/validation-system/check_validations.t
+++ b/t/validation-system/check_validations.t
@@ -38,11 +38,11 @@ subtest 'inactive validation in an active plan' => sub {
     my @modules = $validation_system->check_validation_plan($validation_plan);
     is(scalar @modules, 0, 'no valid validations in this plan');
 
-    $t->log_is(
+    $t->log_warn_is(
         re(qr/validation id $uuid_re "inactive validation" version 1 is inactive but is referenced by an active plan \("plan with inactive validation"\)/),
         'logged for inactive validation',
     );
-    $t->log_is(
+    $t->log_info_is(
         re(qr/Validation plan id $uuid_re "plan with inactive validation" is valid/),
         'logged validation plan non-failure',
     );
@@ -68,11 +68,11 @@ subtest 'non-existent module' => sub {
     my @modules = $validation_system->check_validation_plan($validation_plan);
     is(scalar @modules, 0, 'no valid validations in this plan');
 
-    $t->log_is(
+    $t->log_error_is(
         re(qr{\Qcould not load Conch::Validation::DoesNotExist, used in validation plan "plan with missing module": Can't locate Conch/Validation/DoesNotExist.pm in \E}),
         'logged for missing validation module',
     );
-    $t->log_is(
+    $t->log_warn_is(
         re(qr/Validation plan id $uuid_re "plan with missing module" is not valid/),
         'logged validation plan failure',
     );
@@ -98,11 +98,11 @@ subtest 'module with syntax error' => sub {
     my @modules = $validation_system->check_validation_plan($validation_plan);
     is(scalar @modules, 0, 'no valid validations in this plan');
 
-    $t->log_is(
+    $t->log_error_is(
         re(qr/could not load Conch::Validation::Broken, used in validation plan "plan with broken module": Missing right curly or square bracket/),
         'logged for broken validation module',
     );
-    $t->log_is(
+    $t->log_warn_is(
         re(qr/Validation plan id $uuid_re "plan with broken module" is not valid/),
         'logged validation plan failure',
     );
@@ -128,11 +128,11 @@ subtest 'module does not inherit from Conch::Validation' => sub {
     my @modules = $validation_system->check_validation_plan($validation_plan);
     is(scalar @modules, 0, 'no valid validations in this plan');
 
-    $t->log_is(
+    $t->log_error_is(
         re(qr/Conch::Validation::WrongParentage must be a sub-class of Conch::Validation/),
         'logged for validation module with wrong parentage',
     );
-    $t->log_is(
+    $t->log_warn_is(
         re(qr/Validation plan id $uuid_re "plan with module with wrong parentage" is not valid/),
         'logged validation plan failure',
     );
@@ -159,11 +159,11 @@ foreach my $field (qw(version name description)) {
         my @modules = $validation_system->check_validation_plan($validation_plan);
         is(scalar @modules, 0, 'no valid validations in this plan');
 
-        $t->log_is(
+        $t->log_warn_is(
             re(qr/"$field" field for validation id $uuid_re does not match value in Conch::Validation::Wrong${\ ucfirst($field) } \("[^"]+" vs "[^"]+"\)/),
             "logged for validation module with wrong $field",
         );
-        $t->log_is(
+        $t->log_warn_is(
             re(qr/Validation plan id $uuid_re "plan with module with wrong $field" is not valid/),
             'logged validation plan failure',
         );
@@ -190,11 +190,11 @@ subtest 'missing category' => sub {
     my @modules = $validation_system->check_validation_plan($validation_plan);
     is(scalar @modules, 0, 'no valid validations in this plan');
 
-    $t->log_is(
+    $t->log_error_is(
         re(qr/Conch::Validation::MissingCategory does not set a category/),
         'logged for validation module with missing category',
     );
-    $t->log_is(
+    $t->log_warn_is(
         re(qr/Validation plan id $uuid_re "plan with module with missing category" is not valid/),
         'logged validation plan failure',
     );
@@ -229,7 +229,7 @@ subtest 'a real validator' => sub {
     my @modules = $validation_system->check_validation_plan($validation_plan);
     is(scalar @modules, 1, 'one valid validations in this plan');
 
-    $t->log_is(
+    $t->log_info_is(
         re(qr/Validation plan id $uuid_re "a plan with a real validation" is valid/),
         'logged validation plan success',
     );

--- a/t/validation-system/check_validations.t
+++ b/t/validation-system/check_validations.t
@@ -256,8 +256,10 @@ subtest 'all plans, and all real validation modules' => sub {
     $validation_plan->add_to_validations($_) foreach @validations;
 
     $t->reset_log;
-    my $module_count = $validation_system->check_validation_plans;
-    is($module_count, $num_validations_added + 1, 'all validations are in these plans, and valid');
+    my ($good_plans, $bad_plans) = $validation_system->check_validation_plans;
+
+    is($good_plans, 2, 'found two good plans');
+    is($bad_plans, 0, 'found no bad plans');
 
     $t->logs_are(
         [

--- a/t/validation-system/exceptions.t
+++ b/t/validation-system/exceptions.t
@@ -43,7 +43,7 @@ subtest '->run, local exception' => sub {
         'correctly parsed an exception from an external library containing a stack trace',
     );
 
-    $t->log_is(
+    $t->log_error_is(
         re(qr/Validation 'local_exception' threw an exception on device id '${\$device->id}': I did something dumb/),
         'logged the unexpected exception',
     );
@@ -77,7 +77,7 @@ my $exception_test = sub ($use_stack_traces = 0) {
         'correctly parsed an exception from an external library, identifying the validator line that called the library',
     );
 
-    $t->log_is(
+    $t->log_error_is(
         re(qr/unexpected end of string while parsing JSON string/),
         'logged the unexpected exception',
     );
@@ -111,7 +111,7 @@ subtest '->run, blessed external exception containing a stack trace' => sub {
         'correctly parsed an exception from an external library containing a stack trace',
     );
 
-    $t->log_is(
+    $t->log_error_is(
         re(qr/Validation 'mutate_device' threw an exception on device id '${\$device->id}': .*permission denied for relation device/),
         'logged the unexpected exception',
     );

--- a/t/validation-system/load_validations.t
+++ b/t/validation-system/load_validations.t
@@ -129,7 +129,7 @@ subtest 'a validation module was deleted entirely' => sub {
     like($old_validation->deactivated, qr/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3,9}Z$/,
         'the validation has been deactivated');
 
-    $t->log_is(
+    $t->log_info_is(
         re(qr/deactivating validation for no-longer-present modules: Conch::Validation::OldAndCrufty/),
         'logged the deactivation',
     );


### PR DESCRIPTION
Pull out some common log lines into separate files:
- the info level line that logs the request and response for every hit (when 'verbose' mode is enabled) is now in dispatch.log
- everything to do with validations (which can get noisy) is in validation.log
