### PR TITLE
move POST /device endpoint

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -33,7 +33,7 @@ requires 'Net::DNS';    # not used directly, but Email::Valid sometimes demands 
 requires 'experimental', '0.020';
 
 # mojolicious and networking
-requires 'Mojolicious', '8.31';
+requires 'Mojolicious', '8.36';
 requires 'Mojo::Pg';
 requires 'Mojo::JWT';
 requires 'Mojolicious::Plugin::Util::RandomString', '0.07'; # memory leak: https://rt.cpan.org/Ticket/Display.html?id=125981

--- a/cpanfile
+++ b/cpanfile
@@ -16,7 +16,7 @@ requires 'Try::Tiny';
 requires 'Time::HiRes';
 requires 'Time::Moment', '>= 0.43'; # for PR#28, fixes use of stdbool.h (thanks Dale)
 requires 'Time::Local', '1.27';     # https://pandorafms.com/blog/2020-perl/
-requires 'JSON::Validator', '3.24'; # https://github.com/mojolicious/json-validator/pull/182, /190, /201, /206
+requires 'JSON::Validator', '3.25'; # https://github.com/mojolicious/json-validator/pull/182, /190, /201, /206, /207
 requires 'Data::Validate::IP';      # for json schema validation of 'ipv4', 'ipv6' types
 requires 'HTTP::Tiny';
 requires 'Safe::Isa';

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -2206,10 +2206,10 @@ DISTRIBUTIONS
       JSON::PP 2.27300
       Scalar::Util 0
       perl 5.006
-  JSON-Validator-3.24
-    pathname: J/JH/JHTHORSEN/JSON-Validator-3.24.tar.gz
+  JSON-Validator-3.25
+    pathname: J/JH/JHTHORSEN/JSON-Validator-3.25.tar.gz
     provides:
-      JSON::Validator 3.24
+      JSON::Validator 3.25
       JSON::Validator::Error undef
       JSON::Validator::Formats undef
       JSON::Validator::Joi undef

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -2683,8 +2683,8 @@ DISTRIBUTIONS
       Mojolicious 8.03
       SQL::Abstract 1.86
       perl 5.010001
-  Mojolicious-8.33
-    pathname: S/SR/SRI/Mojolicious-8.33.tar.gz
+  Mojolicious-8.36
+    pathname: S/SR/SRI/Mojolicious-8.36.tar.gz
     provides:
       Mojo undef
       Mojo::Asset undef
@@ -2753,7 +2753,7 @@ DISTRIBUTIONS
       Mojo::UserAgent::Transactor undef
       Mojo::Util undef
       Mojo::WebSocket undef
-      Mojolicious 8.33
+      Mojolicious 8.36
       Mojolicious::Command undef
       Mojolicious::Command::Author::cpanify undef
       Mojolicious::Command::Author::generate undef

--- a/docs/json-schema/query_params.json
+++ b/docs/json-schema/query_params.json
@@ -124,6 +124,15 @@
       },
       "type" : "object"
     },
+    "ProcessDeviceReport" : {
+      "additionalProperties" : false,
+      "properties" : {
+        "no_save_db" : {
+          "$ref" : "/definitions/boolean_integer_default_false"
+        }
+      },
+      "type" : "object"
+    },
     "ResetUserPassword" : {
       "additionalProperties" : false,
       "properties" : {

--- a/docs/modules/Conch::Plugin::Rollbar.md
+++ b/docs/modules/Conch::Plugin::Rollbar.md
@@ -22,6 +22,12 @@ Sets up the hooks.
 
 Sends exceptions to Rollbar.
 
+## LISTENERS
+
+### Send fatal log message
+
+Sends fatal log messages to Rollbar.
+
 ## EVENTS
 
 ### dispatch\_message\_payload

--- a/docs/modules/Conch::Route::Device.md
+++ b/docs/modules/Conch::Route::Device.md
@@ -23,11 +23,6 @@ a [role](../modules/Conch%3A%3ADB%3A%3AResult%3A%3AUserWorkspaceRole#role) in th
 Full (admin-level) access is also granted to a device if a report was sent for that device
 using a relay that registered with that user's credentials.
 
-### `POST /device/:device_serial_number`
-
-- Request: [request.json#/definitions/DeviceReport](../json-schema/request.json#/definitions/DeviceReport)
-- Response: [response.json#/definitions/ValidationStateWithResults](../json-schema/response.json#/definitions/ValidationStateWithResults)
-
 ### `GET /device?:key=:value`
 
 Supports the following query parameters:

--- a/docs/modules/Conch::Route::DeviceReport.md
+++ b/docs/modules/Conch::Route::DeviceReport.md
@@ -16,6 +16,19 @@ All routes require authentication.
 
 ### `POST /device_report`
 
+Submits a device report for processing. The device must already exist.
+Device data will be updated in the database.
+
+- The authenticated user must have previously registered the relay being used for the
+report submission (as indicated via `#/relay/serial` in the report).
+- Request: [request.json#/definitions/DeviceReport](../json-schema/request.json#/definitions/DeviceReport)
+- Response: [response.json#/definitions/ValidationStateWithResults](../json-schema/response.json#/definitions/ValidationStateWithResults)
+
+### `POST /device_report?no_update_db=1`
+
+Submits a device report for processing. Device data will **not** be updated in the database;
+only validations will be run.
+
 - Request: [request.json#/definitions/DeviceReport](../json-schema/request.json#/definitions/DeviceReport)
 - Response: [response.json#/definitions/ReportValidationResults](../json-schema/response.json#/definitions/ReportValidationResults)
 

--- a/docs/modules/Test::Conch.md
+++ b/docs/modules/Test::Conch.md
@@ -64,6 +64,7 @@ Wrapper around ["status\_is" in Test::Mojo](https://metacpan.org/pod/Test%3A%3AM
 * 200 and most 4xx responses should have content.
 * 201 and most 3xx responses should have a Location header.
 * 204 and most 3xx responses should not have body content.
+* 302 should not be used at all
 ```
 
 Also, unexpected responses will dump the response payload.

--- a/json-schema/query_params.yaml
+++ b/json-schema/query_params.yaml
@@ -182,5 +182,11 @@ definitions:
       required:
         - ids_only
         - serials_only
+  ProcessDeviceReport:
+    type: object
+    additionalProperties: false
+    properties:
+      no_save_db:
+        $ref: /definitions/boolean_integer_default_false
 
 # vim: set sts=2 sw=2 et :

--- a/lib/Conch.pm
+++ b/lib/Conch.pm
@@ -106,6 +106,11 @@ sub startup {
         $res_headers->header('Request-Id', $request_id);
         $res_headers->header('X-Request-Id', $request_id);
         $res_headers->add('X-Conch-API', $c->version_tag);
+
+        $c->send_message_to_rollbar('error',
+                'usage of endpoint that has been moved permanently',
+                { old_uri => $c->req->url, new_uri => $c->res->headers->location })
+            if $c->res->code == 308 and $c->feature('rollbar');
     });
 
 =head2 status

--- a/lib/Conch.pm
+++ b/lib/Conch.pm
@@ -37,9 +37,10 @@ sub startup {
 
     $self->sessions->cookie_name('conch');
     $self->sessions->samesite('Strict');            # do not send with cross-site requests
-    $self->sessions->secure(1) if $ENV{MOJO_MODE} eq 'production';  # https only
+    $self->sessions->secure(1) if ($ENV{MOJO_MODE} // '') eq 'production';  # https only
 
     $self->plugin('Config');
+    $self->mode(delete $self->config->{mode}) if exists $self->config->{mode};
     $self->secrets(delete $self->config->{secrets});
 
     $self->plugin('Conch::Plugin::Features', $self->config);

--- a/lib/Conch.pm
+++ b/lib/Conch.pm
@@ -47,7 +47,7 @@ sub startup {
     $self->plugin('Conch::Plugin::GitVersion', $self->config);
     $self->plugin('Conch::Plugin::Database', $self->config);
 
-    # specify which MIME types we can handle
+    # specify MIME type mappings for responses
     $self->types->type(json => 'application/json');
     $self->types->type(csv => 'text/csv');
 

--- a/lib/Conch/Controller/DatacenterRoom.pm
+++ b/lib/Conch/Controller/DatacenterRoom.pm
@@ -144,7 +144,7 @@ Permanently delete a datacenter room.
 
 sub delete ($c) {
     if ($c->stash('datacenter_room_rs')->related_resultset('racks')->exists) {
-        $c->log->debug('Cannot delete datacenter_room: in use by one or more racks');
+        $c->log->debug('Cannot delete datacenter room: in use by one or more racks');
         return $c->status(409, { error => 'cannot delete a datacenter_room when a rack is referencing it' });
     }
 

--- a/lib/Conch/Controller/HardwareProduct.pm
+++ b/lib/Conch/Controller/HardwareProduct.pm
@@ -45,11 +45,11 @@ sub find_hardware_product ($c) {
 
     # identifier can be id, sku, name, alias
     if (is_uuid($identifier)) {
-        $c->log->debug('Looking up a hardware_product by id '.$identifier);
+        $c->log->debug('Looking up a hardware product by id '.$identifier);
         $hardware_product_rs = $hardware_product_rs->search({ 'hardware_product.id' => $identifier });
     }
     else {
-        $c->log->debug('Looking up a hardware_product by sku,name,alias '.$identifier);
+        $c->log->debug('Looking up a hardware product by sku,name,alias '.$identifier);
         $hardware_product_rs = $hardware_product_rs->search({
             -or => [ map +{ 'hardware_product.'.$_ => $identifier }, qw(sku name alias) ],
         });

--- a/lib/Conch/Controller/HardwareVendor.pm
+++ b/lib/Conch/Controller/HardwareVendor.pm
@@ -23,11 +23,11 @@ C<hardware_vendor>.
 sub find_hardware_vendor ($c) {
     my $hardware_vendor_rs = $c->db_hardware_vendors;
     if (is_uuid($c->stash('hardware_vendor_id_or_name'))) {
-        $c->log->debug('Looking up a hardware_vendor by id ('.$c->stash('hardware_vendor_id_or_name').')');
+        $c->log->debug('Looking up a hardware vendor by id ('.$c->stash('hardware_vendor_id_or_name').')');
         $hardware_vendor_rs = $hardware_vendor_rs->search({ id => $c->stash('hardware_vendor_id_or_name') });
     }
     else {
-        $c->log->debug('Looking up a hardware_vendor by name ('.$c->stash('hardware_vendor_id_or_name').')');
+        $c->log->debug('Looking up a hardware vendor by name ('.$c->stash('hardware_vendor_id_or_name').')');
         $hardware_vendor_rs = $hardware_vendor_rs->search({ name => $c->stash('hardware_vendor_id_or_name') });
     }
 

--- a/lib/Conch/Controller/Rack.pm
+++ b/lib/Conch/Controller/Rack.pm
@@ -311,7 +311,7 @@ Delete a rack.
 
 sub delete ($c) {
     if ($c->stash('rack_rs')->related_resultset('rack_layouts')->exists) {
-        $c->log->debug('Cannot delete rack: in use by one or more rack_layouts');
+        $c->log->debug('Cannot delete rack: in use by one or more rack layouts');
         return $c->status(409, { error => 'cannot delete a rack when a rack_layout is referencing it' });
     }
 

--- a/lib/Conch/Controller/RackRole.pm
+++ b/lib/Conch/Controller/RackRole.pm
@@ -33,7 +33,7 @@ sub find_rack_role ($c) {
     my $rack_role = $rs->single;
 
     if (not $rack_role) {
-        $c->log->debug('Could not find rack_role '.$c->stash('rack_role_id_or_name'));
+        $c->log->debug('Could not find rack role '.$c->stash('rack_role_id_or_name'));
         return $c->status(404);
     }
 
@@ -118,7 +118,7 @@ sub update ($c) {
             my @assigned_rack_units = sort { $a <=> $b } keys %assigned_rack_units;
 
             if (my @out_of_range = grep $_ > $input->{rack_size}, @assigned_rack_units) {
-                $c->log->debug('found layout used by rack_role id '.$rack_role->id
+                $c->log->debug('found layout used by rack role id '.$rack_role->id
                     .' that has assigned rack_units greater requested new rack_size of '
                     .$input->{rack_size}.': ', join(', ', @out_of_range));
                 return $c->status(409, { error => 'cannot resize rack_role: found an assigned rack layout that extends beyond the new rack_size' });

--- a/lib/Conch/Plugin/Logging.pm
+++ b/lib/Conch/Plugin/Logging.pm
@@ -36,7 +36,7 @@ sub register ($self, $app, $config) {
     my ($log_to_stderr, $verbose) = delete $plugin_config->@{qw(log_to_stderr verbose)};
 
     my %log_args = (
-        level => 'debug',
+        level => $ENV{MOJO_LOG_LEVEL} // 'debug',
         bunyan => 1,
         $verbose ? ( with_trace => 1 ) : (),
         $plugin_config->%*,

--- a/lib/Conch/Route/DatacenterRoom.pm
+++ b/lib/Conch/Route/DatacenterRoom.pm
@@ -44,7 +44,8 @@ sub routes {
     $with_datacenter_room_system_admin->delete('/')->to('#delete');
 
     # GET /room/:datacenter_room_id_or_alias/rack
-    $with_datacenter_room_ro->get('/rack')->to('#racks');
+    $with_datacenter_room_ro->get('/racks', sub { shift->status(308, 'get_room_racks') });
+    $with_datacenter_room_ro->get('/rack', 'get_room_racks')->to('#racks');
 
     # GET    /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name
     # POST   /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name

--- a/lib/Conch/Route/Device.pm
+++ b/lib/Conch/Route/Device.pm
@@ -21,9 +21,7 @@ sub routes {
     my $device = shift; # secured, under /device
     my $app = shift;
 
-    # TODO: this should be POST /device_report
-    # POST /device/:device_serial_number
-    $device->post('/:device_serial_number')->to('device_report#process');
+    $device->post('/:device_serial_number', sub { shift->status(308, '/device_report') });
 
     # GET /device?:key=:value
     $device->get('/')->to('device#lookup_by_other_attribute');
@@ -133,16 +131,6 @@ a L<role|Conch::DB::Result::UserWorkspaceRole/role> in that workspace).
 
 Full (admin-level) access is also granted to a device if a report was sent for that device
 using a relay that registered with that user's credentials.
-
-=head2 C<POST /device/:device_serial_number>
-
-=over 4
-
-=item * Request: F<request.yaml#/definitions/DeviceReport>
-
-=item * Response: F<response.yaml#/definitions/ValidationStateWithResults>
-
-=back
 
 =head2 C<GET /device?:key=:value>
 

--- a/lib/Conch/Route/DeviceReport.pm
+++ b/lib/Conch/Route/DeviceReport.pm
@@ -20,8 +20,11 @@ sub routes {
     my $class = shift;
     my $device_report = shift; # secured, under /device_report
 
-    # POST /device_report
-    $device_report->post('/')->to('device_report#validate_report');
+    $device_report
+        # POST /device_report
+        ->under(['POST'], '/')->to('device_report#process')
+        # POST /device_report?no_save_db=1
+        ->post('/')->to('device_report#validate_report');
 
     # chainable action that looks up device_report_id, saves a device_report_rs,
     # and checks device access authorization
@@ -45,6 +48,25 @@ __END__
 All routes require authentication.
 
 =head2 C<POST /device_report>
+
+Submits a device report for processing. The device must already exist.
+Device data will be updated in the database.
+
+=over 4
+
+=item * The authenticated user must have previously registered the relay being used for the
+report submission (as indicated via C<#/relay/serial> in the report).
+
+=item * Request: F<request.yaml#/definitions/DeviceReport>
+
+=item * Response: F<response.yaml#/definitions/ValidationStateWithResults>
+
+=back
+
+=head2 C<POST /device_report?no_update_db=1>
+
+Submits a device report for processing. Device data will B<not> be updated in the database;
+only validations will be run.
 
 =over 4
 

--- a/lib/Conch/Route/HardwareProduct.pm
+++ b/lib/Conch/Route/HardwareProduct.pm
@@ -1,6 +1,7 @@
 package Conch::Route::HardwareProduct;
 
 use Mojo::Base -strict;
+use experimental 'signatures';
 
 =pod
 
@@ -29,6 +30,10 @@ sub routes {
     $hardware_product->require_system_admin->post('/')->to('#create');
 
     {
+        $hardware_product->any('/<:hardware_product_key>=<:hardware_product_value>'
+                => [ hardware_product_key => [qw(name alias sku)] ],
+            sub ($c) { $c->status(308, $c->req->url =~ s/(?:name|alias|sku)=//r) });
+
         my $with_hardware_product_id_or_other = $hardware_product->under('/:hardware_product_id_or_other')
             ->to('#find_hardware_product');
 

--- a/lib/Conch/Route/Rack.pm
+++ b/lib/Conch/Route/Rack.pm
@@ -62,9 +62,12 @@ sub one_rack_routes ($class, $r) {
     $one_rack->require_system_admin->delete('/')->to('#delete');
 
     # GET .../rack/:rack_id_or_name/layout
-    $one_rack->get('/layout')->to('#get_layouts');
+    $one_rack->get('/layouts', sub { shift->status(308, 'get_layouts') });
+    $one_rack->get('/layout', 'get_layouts')->to('#get_layouts');
+
     # POST .../rack/:rack_id_or_name/layout
-    $one_rack->post('/layout')->to('#overwrite_layouts');
+    $one_rack->post('/layouts', sub { shift->status(308, 'overwrite_layouts') });
+    $one_rack->post('/layout', 'overwrite_layouts')->to('#overwrite_layouts');
 
     # GET .../rack/:rack_id_or_name/assignment
     $one_rack->get('/assignment')->to('#get_assignment');

--- a/lib/Conch/Route/User.pm
+++ b/lib/Conch/Route/User.pm
@@ -26,8 +26,7 @@ sub routes {
     # interfaces for user updating their own account...
     {
         # all /user/me routes operate with the target user set to ourselves
-        my $user_me = $user->under('/me')
-            ->to(cb => sub ($c) { $c->stash('target_user', $c->stash('user')); return 1 });
+        my $user_me = $user->under('/me', sub ($c) { $c->stash('target_user', $c->stash('user')); return 1 });
 
         # GET /user/me
         $user_me->get('/')->to('#get');

--- a/lib/Test/Conch.pm
+++ b/lib/Test/Conch.pm
@@ -227,6 +227,7 @@ Wrapper around L<Test::Mojo/status_is>, adding some additional checks.
  * 200 and most 4xx responses should have content.
  * 201 and most 3xx responses should have a Location header.
  * 204 and most 3xx responses should not have body content.
+ * 302 should not be used at all
 
 Also, unexpected responses will dump the response payload.
 
@@ -262,6 +263,8 @@ sub status_is ($self, $status, $desc = undef) {
     $self->test('fail', $code.' responses should not have content')
         if any { $code == $_ } 204,301,302,303,304,305,307,308 and $self->tx->res->text;
 
+    $self->test('fail', 'HTTP 302 is superseded by 303 and 307')
+        if $code == 302;
 
     Test::More::diag('got response: ', Data::Dumper->new([ $self->tx->res->json ])
             ->Sortkeys(1)->Indent(1)->Terse(1)->Maxdepth(5)->Dump)

--- a/lib/Test/Conch.pm
+++ b/lib/Test/Conch.pm
@@ -99,10 +99,9 @@ sub new {
         : $args->{config}{features}{no_db} ? undef
         : $class->init_db // Test::More::BAIL_OUT('failed to create test database');
 
-    $ENV{MOJO_MODE} ||= 'test';
-
     my $self = Test::Mojo->new(
         Conch => {
+            mode => $ENV{MOJO_MODE} // 'test',
             features => {
                 no_db => ($pg ? 0 : 1),
                 ($args->{config}//{})->{features} ? delete($args->{config}{features})->%* : (),

--- a/lib/Test/Conch.pm
+++ b/lib/Test/Conch.pm
@@ -1,6 +1,7 @@
 package Test::Conch;
 
 use v5.26;
+BEGIN { $ENV{MOJO_LOG_LEVEL} ||= 'debug' }  # before Test::Mojo changes it
 use Mojo::Base 'Test::Mojo', -signatures;
 
 use Test::More ();

--- a/t/conch-log.t
+++ b/t/conch-log.t
@@ -143,16 +143,16 @@ my $api_version_re = qr/^${ Test::Conch->API_VERSION_RE }$/;
 sub add_test_routes ($t) {
     my $r = Mojolicious::Routes->new;
 
-    $r->get('/_hello')->to(cb => sub ($c) {
+    $r->get('/_hello', sub ($c) {
         $c->log->warn('this is a warn message');
         $c->log->debug('this is a debug message');
         $c->status(204);
     });
-    $r->post('/_error')->to(cb => sub ($c) {
+    $r->post('/_error', sub ($c) {
         $c->log->error('error line from controller');
         $c->status(400, { error => 'something bad happened' });
     });
-    $r->post('/_die')->to(cb => sub ($c) { die 'ach, I am slain' });
+    $r->post('/_die', sub ($c) { die 'ach, I am slain' });
     $t->add_routes($r);
 
     return (warn => __LINE__-11, debug => __LINE__-10, error => __LINE__-6, die => __LINE__-3);

--- a/t/conch-rollbar.t
+++ b/t/conch-rollbar.t
@@ -37,12 +37,12 @@ my $t = Test::Conch->new(
 
 my $r = Mojolicious::Routes->new;
 my $line_number;
-$r->post('/_die/cb')->to(cb => sub ($c) {
+$r->post('/_die/cb', sub ($c) {
     $line_number = __LINE__; die 'ach, I am slain';
 });
 $r->post('/_die/action')->to('user#die');
 $r->post('/_die/dbix_class')->to('user#dbix_class');
-$r->post('/_send_message')->to(cb => sub ($c) {
+$r->post('/_send_message', sub ($c) {
     $c->send_message_to_rollbar(
         'info',
         'here is a message',
@@ -84,7 +84,7 @@ package RollbarSimulator {
     use Conch::UUID 'create_uuid_str';
     use Mojo::Base 'Mojolicious', -signatures;
     sub startup ($self) {
-        $self->routes->post('/api/1/item')->to(cb => sub ($c) {
+        $self->routes->post('/api/1/item', sub ($c) {
             my $payload = $c->req->json;
             Test::More::like($payload->{data}{uuid}, Conch::UUID::UUID_FORMAT, 'got rollbar uuid in payload');
             $c->app->plugins->emit(rollbar_sent => $payload);

--- a/t/conch-status.t
+++ b/t/conch-status.t
@@ -30,7 +30,7 @@ use Test::Conch;
     );
 
     $t->get_ok('/301')->status_is(301)->location_is('/301-success');
-    $t->get_ok('/302')->status_is(302)->location_is('/302-success');
+    # 302 skipped - generates a test failure in status_is()
     $t->get_ok('/303')->status_is(303)->location_is('/303-success');
     $t->get_ok('/305')->status_is(305)->location_is('/305-success');
     $t->get_ok('/307')->status_is(307)->location_is('/307-success');

--- a/t/integration/crud/devices.t
+++ b/t/integration/crud/devices.t
@@ -50,14 +50,14 @@ my $test_device_id;
 
 subtest 'unlocated device, no registered relay' => sub {
     my $report_data = from_json(path('t/integration/resource/passing-device-report.json')->slurp_utf8);
-    $t->post_ok('/device/TEST', json => $report_data)
+    $t->post_ok('/device_report', json => $report_data)
         ->status_is(409)
         ->json_schema_is('Error')
         ->json_is({ error => 'relay serial deadbeef is not registered' });
 
     delete $report_data->{relay};
 
-    $t->post_ok('/device/TEST', json => $report_data)
+    $t->post_ok('/device_report', json => $report_data)
         ->status_is(200)
         ->json_schema_is('ValidationStateWithResults');
 
@@ -128,7 +128,7 @@ subtest 'unlocated device with a registered relay' => sub {
         ->status_is(201);
 
     my $report = path('t/integration/resource/passing-device-report.json')->slurp_utf8;
-    $t->post_ok('/device/TEST', { 'Content-Type' => 'application/json' }, $report)
+    $t->post_ok('/device_report', { 'Content-Type' => 'application/json' }, $report)
         ->status_is(200)
         ->json_schema_is('ValidationStateWithResults');
 

--- a/t/integration/crud/hardware-product.t
+++ b/t/integration/crud/hardware-product.t
@@ -31,7 +31,7 @@ my $validation_plan_id = $products->[0]{validation_plan_id};
 
 $t->get_ok('/hardware_product/'.create_uuid_str())
     ->status_is(404)
-    ->log_debug_like(qr/^Looking up a hardware_product by id ${\Conch::UUID::UUID_FORMAT}$/);
+    ->log_debug_like(qr/^Looking up a hardware product by id ${\Conch::UUID::UUID_FORMAT}$/);
 
 $t->get_ok("/hardware_product/$hw_id")
     ->status_is(200)
@@ -178,7 +178,7 @@ $t->get_ok($t->tx->res->headers->location)
 
 $t->get_ok('/hardware_product/foo')
     ->status_is(404)
-    ->log_debug_is('Looking up a hardware_product by sku,name,alias foo');
+    ->log_debug_is('Looking up a hardware product by sku,name,alias foo');
 
 $t->get_ok($_)
     ->status_is(200)

--- a/t/integration/crud/hardware-product.t
+++ b/t/integration/crud/hardware-product.t
@@ -180,6 +180,10 @@ $t->get_ok('/hardware_product/foo')
     ->status_is(404)
     ->log_debug_is('Looking up a hardware product by sku,name,alias foo');
 
+$t->get_ok('/hardware_product/name=sungo2')
+    ->status_is(308)
+    ->location_is('/hardware_product/sungo2');
+
 $t->get_ok($_)
     ->status_is(200)
     ->location_is('/hardware_product/'.$new_product->{id})

--- a/t/integration/crud/rack-roles.t
+++ b/t/integration/crud/rack-roles.t
@@ -110,7 +110,7 @@ $t->delete_ok("/rack_role/$idr")
 
 $t->get_ok("/rack_role/$idr")
     ->status_is(404)
-    ->log_debug_is('Could not find rack_role '.$idr);
+    ->log_debug_is('Could not find rack role '.$idr);
 
 $t->get_ok('/rack_role')
     ->status_is(200)

--- a/t/integration/crud/racks.t
+++ b/t/integration/crud/racks.t
@@ -610,6 +610,10 @@ $t->get_ok($_)
         '/room/'.$room->alias.'/rack/'.$room->vendor_name.':'.$rack->name.'/assignment',
         '/room/'.$room->alias.'/rack/'.$rack->name.'/assignment';
 
+$t->get_ok('/rack/'.$rack->id.'/layouts')
+    ->status_is(308)
+    ->location_is('/rack/'.$rack->id.'/layout');
+
 $t->get_ok('/rack/'.$rack->id.'/layout')
     ->status_is(200)
     ->location_is('/rack/'.$rack->id.'/layout')

--- a/t/integration/crud/rooms.t
+++ b/t/integration/crud/rooms.t
@@ -37,6 +37,10 @@ $t->get_ok($_)
         '/room/'.$room->{id},
         '/room/'.$room->{alias};
 
+$t->get_ok('/room/'.$room->{id}.'/racks')
+    ->status_is(308)
+    ->location_is('/room/'.$room->{id}.'/rack');
+
 $t->get_ok('/room/'.$room->{id}.'/rack')
     ->status_is(200)
     ->json_schema_is('Racks')

--- a/t/integration/crud/workspace-devices.t
+++ b/t/integration/crud/workspace-devices.t
@@ -49,7 +49,7 @@ $t->post_ok('/relay/deadbeef/register',
     ->status_is(201);
 
 my $report = path('t/integration/resource/passing-device-report.json')->slurp_utf8;
-$t->post_ok('/device/TEST', { 'Content-Type' => 'application/json' }, $report)
+$t->post_ok('/device_report', { 'Content-Type' => 'application/json' }, $report)
     ->status_is(200)
     ->json_schema_is('ValidationStateWithResults')
     ->json_is('/device_id', $devices[0]->id);

--- a/t/integration/device-validations.t
+++ b/t/integration/device-validations.t
@@ -41,13 +41,13 @@ $build->create_related('user_build_roles', { user_id => $ro_user->id, role => 'a
 $t->post_ok('/build/'.$build->id.'/device', json => [ { serial_number => 'TEST', sku => $good_report_data->{sku} } ])
     ->status_is(204);
 
-$t->post_ok('/device/TEST', { 'Content-Type' => 'application/json' }, $error_report)
+$t->post_ok('/device_report', { 'Content-Type' => 'application/json' }, $error_report)
     ->status_is(200)
     ->json_schema_is('ValidationStateWithResults')
     ->json_is('/status', 'error');
 my $error_validation_state_id = $t->tx->res->json->{id};
 
-$t->post_ok('/device/TEST', { 'Content-Type' => 'application/json' }, $good_report)
+$t->post_ok('/device_report', { 'Content-Type' => 'application/json' }, $good_report)
     ->status_is(200)
     ->json_schema_is('ValidationStateWithResults')
     ->json_is('/status', 'pass');

--- a/t/integration/unsecured-endpoints.t
+++ b/t/integration/unsecured-endpoints.t
@@ -39,7 +39,7 @@ $t->get_ok('/workspace')->status_is(401);
 $t->get_ok('/workspace/'.create_uuid_str())->status_is(401);
 
 $t->get_ok('/device/TEST')->status_is(401);
-$t->post_ok('/device/TEST', json => { a => 'b' })->status_is(401);
+$t->post_ok('/device_report', json => { a => 'b' })->status_is(401);
 
 $t->post_ok('/relay/TEST/register', json => { a => 'b' })->status_is(401);
 


### PR DESCRIPTION
- send a message to Rollbar upon use of an endpoint that returns HTTP 308
- return HTTP 308 for endpoints that were recently removed
- forward fatal log messages to Rollbar
- move POST /device/:serial to POST /device_report
   existing POST /device_report has been moved to POST /device_report?no_save_db=1

