### PR TITLE
v3.0.0 b8: nicer device report collisions

### DIFF
--- a/lib/Conch/Controller/DeviceReport.pm
+++ b/lib/Conch/Controller/DeviceReport.pm
@@ -83,6 +83,12 @@ sub process ($c) {
         $device->discard_changes;
         $device->health('error');
         $device->update({ updated => \'now()' }) if $device->is_changed;
+
+        if (my $system_uuid_device = $c->db_devices->find({ system_uuid => $unserialized_report->{system_uuid} })) {
+            $system_uuid_device->health('error');
+            $system_uuid_device->update({ updated => \'now()' }) if $system_uuid_device->is_changed;
+        }
+
         return $c->status(400, { error => 'could not process report for device '
             .$unserialized_report->{serial_number}
             .($c->stash('exception') ? ': '.(split(/\n/, $c->stash('exception'), 2))[0] : '') });

--- a/lib/Conch/Controller/DeviceReport.pm
+++ b/lib/Conch/Controller/DeviceReport.pm
@@ -89,9 +89,9 @@ sub process ($c) {
             $system_uuid_device->update({ updated => \'now()' }) if $system_uuid_device->is_changed;
         }
 
+        my $exception = delete $c->stash->{exception};
         return $c->status(400, { error => 'could not process report for device '
-            .$unserialized_report->{serial_number}
-            .($c->stash('exception') ? ': '.(split(/\n/, $c->stash('exception'), 2))[0] : '') });
+            .$unserialized_report->{serial_number}.($exception ? ': '.(split(/\n/, $exception, 2))[0] : '') });
     };
 
     $c->log->debug('Storing device report for device '.$unserialized_report->{serial_number});
@@ -437,8 +437,9 @@ sub validate_report ($c) {
         die 'rollback: device used for report validation should not be persisted';
     });
 
+    my $exception = delete $c->stash->{exception};
     return $c->status(400, { error => 'no validations ran'
-            .($c->stash('exception') ? ': '.(split(/\n/, $c->stash('exception'), 2))[0] : '') })
+            .($exception ? ': '.(split(/\n/, $exception, 2))[0] : '') })
         if not @validation_results;
 
     $c->status(200, {

--- a/t/integration/device-reports.t
+++ b/t/integration/device-reports.t
@@ -425,6 +425,9 @@ subtest 'system_uuid collisions' => sub {
 
     $existing_device->discard_changes;
     is($existing_device->health, 'error', 'bad reports flip device health to error');
+
+    my $test_device = $t->app->db_devices->find({ serial_number => 'TEST' });
+    is($test_device->health, 'error', 'TEST device had health set to error as well');
 };
 
 subtest 'submit report for decommissioned device' => sub {


### PR DESCRIPTION
bring in changes made to v2.38 (#996, #997):

* properly handle a report using a different device's system_uuid (this change was already present in v3.0)
* also set both conflicting devices to the error state for better detection
* on device collision, remove exception from stash so rollbar does not send it