### PR TITLE
fix: hardware_product.specification must be a json string

### DIFF
--- a/lib/Conch/Controller/HardwareProduct.pm
+++ b/lib/Conch/Controller/HardwareProduct.pm
@@ -113,6 +113,18 @@ sub create ($c) {
             if not $c->$rs_name->active->search({ id => $input->{$key} })->exists;
     }
 
+    # the specification field is json-encoded (for now); it must be decoded and validated separately
+    if (defined $input->{specification}) {
+        my $new_specification = eval { from_json($input->{specification}) };
+        return $c->status(400, {
+            error => 'request did not match required format',
+            details => [ { path => '/allOf/0/$ref/properties/specification', message => 'Does not match json format.' } ],
+            schema => $c->url_for('/schema/request/HardwareProductCreate'),
+        }) if not defined $new_specification;
+
+        return if not $c->validate_request('HardwareProductSpecification', $new_specification);
+    }
+
     my $hardware_product = $c->txn_wrapper(sub ($c) {
         $c->db_hardware_products->create($input);
     });
@@ -152,6 +164,18 @@ sub update ($c) {
         (my $rs_name = $key) =~ s/_id$/s/; $rs_name = 'db_'.$rs_name;
         return $c->status(409, { error => $key.' does not exist' })
             if not $c->$rs_name->active->search({ id => $input->{$key} })->exists;
+    }
+
+    # the specification field is json-encoded (for now); it must be decoded and validated separately
+    if (defined $input->{specification}) {
+        my $new_specification = eval { from_json($input->{specification}) };
+        return $c->status(400, {
+            error => 'request did not match required format',
+            details => [ { path => '/allOf/0/$ref/properties/specification', message => 'Does not match json format.' } ],
+            schema => $c->url_for('/schema/request/HardwareProductCreate'),
+        }) if not defined $new_specification;
+
+        return if not $c->validate_request('HardwareProductSpecification', $new_specification);
     }
 
     $c->txn_wrapper(sub ($c) {

--- a/t/integration/crud/hardware-product.t
+++ b/t/integration/crud/hardware-product.t
@@ -61,7 +61,6 @@ $t->post_ok('/hardware_product', json => {
         validation_plan_id => $validation_plan_id,
         purpose => 'myself',
         bios_firmware => '1.2.3',
-        cpu_num => 2,
         cpu_type => 'fooey',
     })
     ->status_is(303)
@@ -87,7 +86,7 @@ $t->get_ok($t->tx->res->headers->location)
         purpose => 'myself',
         bios_firmware => '1.2.3',
         hba_firmware => undef,
-        cpu_num => 2,
+        cpu_num => 0,
         cpu_type => 'fooey',
         dimms_num => 0,
         ram_total => 0,
@@ -205,7 +204,6 @@ $t->post_ok('/hardware_product', json => {
         validation_plan_id => $validation_plan_id,
         purpose => 'myself',
         bios_firmware => '1.2.3',
-        cpu_num => 2,
         cpu_type => 'fooey',
     })
     ->status_is(303)

--- a/t/integration/crud/hardware-product.t
+++ b/t/integration/crud/hardware-product.t
@@ -52,17 +52,33 @@ $t->post_ok('/hardware_product', json => { name => 'sungo', alias => 'sungo' })
         qw(hardware_vendor_id sku rack_unit_size validation_plan_id purpose bios_firmware cpu_type),
     ));
 
-$t->post_ok('/hardware_product', json => {
-        name => 'sungo',
-        hardware_vendor_id => $vendor_id,
-        alias => 'sungo',
-        rack_unit_size => 2,
-        sku => 'my sku',
-        validation_plan_id => $validation_plan_id,
-        purpose => 'myself',
-        bios_firmware => '1.2.3',
-        cpu_type => 'fooey',
-    })
+my %hw_fields = (
+    name => 'sungo',
+    hardware_vendor_id => $vendor_id,
+    alias => 'sungo',
+    rack_unit_size => 2,
+    sku => 'my sku',
+    validation_plan_id => $validation_plan_id,
+    purpose => 'myself',
+    bios_firmware => '1.2.3',
+    cpu_type => 'fooey',
+);
+
+$t->post_ok('/hardware_product', json => { %hw_fields, specification => 'not json!' } )
+    ->status_is(400)
+    ->json_schema_is('RequestValidationError')
+    ->json_cmp_deeply('/details', [ { path => '/allOf/0/$ref/properties/specification', message => 'Does not match json format.' } ]);
+
+$t->post_ok('/hardware_product', json => { %hw_fields, specification => '{"disk_size":"not an object"}' } )
+    ->status_is(400)
+    ->json_schema_is('RequestValidationError')
+    ->json_cmp_deeply({
+        error => 'request did not match required format',
+        details => [ { path => '/disk_size', message => 'Expected object - got string.' } ],
+        schema => '/schema/request/hardware_product_specification',
+    });
+
+$t->post_ok('/hardware_product', json => \%hw_fields)
     ->status_is(303)
     ->location_like(qr!^/hardware_product/${\Conch::UUID::UUID_FORMAT}$!);
 
@@ -163,6 +179,20 @@ $t->post_ok('/hardware_product', json => {
     ->status_is(409)
     ->json_schema_is('Error')
     ->json_is({ error => 'validation_plan_id does not exist' });
+
+$t->post_ok("/hardware_product/$new_hw_id", json => { specification => 'not json!' })
+    ->status_is(400)
+    ->json_schema_is('RequestValidationError')
+    ->json_cmp_deeply('/details', [ { path => '/allOf/0/$ref/properties/specification', message => 'Does not match json format.' } ]);
+
+$t->post_ok("/hardware_product/$new_hw_id", json => { specification => '{"disk_size":"not an object"}' })
+    ->status_is(400)
+    ->json_schema_is('RequestValidationError')
+    ->json_cmp_deeply({
+        error => 'request did not match required format',
+        details => [ { path => '/disk_size', message => 'Expected object - got string.' } ],
+        schema => '/schema/request/hardware_product_specification',
+    });
 
 $t->post_ok("/hardware_product/$new_hw_id", json => { name => 'sungo2' })
     ->status_is(303)


### PR DESCRIPTION
validate hardware_product.specification on creation and update
    
The specification property must be null, or a properly json-encoded string.
Note that this will be changing in v3.1: specification will be passed as a
fully inflated document rather than as an encoded string.
    
resolves rollbar notifications:
https://rollbar.com/joyent_buildops/conch/items/3502
https://rollbar.com/joyent_buildops/conch/items/3503
