### PR TITLE
v3.0 b12 fixes

### DIFF
--- a/docs/json-schema/device_report.json
+++ b/docs/json-schema/device_report.json
@@ -1,7 +1,7 @@
 {
   "$schema" : "http://json-schema.org/draft-07/schema#",
   "definitions" : {
-    "DeviceReport_v3.0.0" : {
+    "DeviceReport_v3_0_0" : {
       "description" : "the contents of a posted device report from relays and reporters",
       "properties" : {
         "bios_version" : {

--- a/docs/json-schema/request.json
+++ b/docs/json-schema/request.json
@@ -393,7 +393,7 @@
       "type" : "object"
     },
     "DeviceReport" : {
-      "$ref" : "device_report.json#/definitions/DeviceReport_v3.0.0"
+      "$ref" : "device_report.json#/definitions/DeviceReport_v3_0_0"
     },
     "DeviceSetting" : {
       "allOf" : [

--- a/docs/json-schema/response.json
+++ b/docs/json-schema/response.json
@@ -542,7 +542,7 @@
               "type" : "null"
             },
             {
-              "$ref" : "device_report.json#/definitions/DeviceReport_v3.0.0"
+              "$ref" : "device_report.json#/definitions/DeviceReport_v3_0_0"
             },
             {
               "type" : "object"

--- a/docs/modules/Conch::Controller::HardwareProduct.md
+++ b/docs/modules/Conch::Controller::HardwareProduct.md
@@ -38,17 +38,17 @@ Updates an existing hardware\_product.
 
 ### set\_specification
 
-Uses the URI fragment as a json pointer to determine the path within the `specification` property
-to operate on. New data is written, and existing data is overwritten without regard to type (so long
-as it conforms to the schema).
+Uses the URI query parameter `path` as a json pointer to determine the path within the
+`specification` property to operate on. New data is written, and existing data is overwritten
+without regard to type (so long as it conforms to the schema).
 
 After the update operation, the `specification` property must validate against
 [common.json#/definitions/HardwareProductSpecification](../json-schema/common.json#/definitions/HardwareProductSpecification).
 
 ### delete\_specification
 
-Uses the URI fragment as a json pointer to determine the path within the `specification` property
-to operate on. All of the data at the indicated path is deleted.
+Uses the URI query parameter `path` as a json pointer to determine the path within the
+`specification` property to operate on. All of the data at the indicated path is deleted.
 
 After the delete operation, the `specification` property must validate against
 [common.json#/definitions/HardwareProductSpecification](../json-schema/common.json#/definitions/HardwareProductSpecification).

--- a/docs/modules/Conch::Route::HardwareProduct.md
+++ b/docs/modules/Conch::Route::HardwareProduct.md
@@ -57,10 +57,10 @@ Identifiers accepted: `id`, `sku`, `name` and `alias`.
 
 ### `PUT /hardware_product/:hardware_product_id_or_other/specification?path=:path_to_data`
 
-Sets a specific part of the json blob data in the `specification` field, treating the URI fragment
-as the JSON pointer to the data to be added or modified. Existing data at the path is overwritten
-without regard to type, so long as the JSON Schema is respected. For example, this existing
-`specification` field and this request:
+Sets a specific part of the json blob data in the `specification` field, treating the URI query
+parameter `path` as the JSON pointer to the data to be added or modified. Existing data at the path
+is overwritten without regard to type, so long as the JSON Schema is respected. For example, this
+existing `specification` field and this request:
 
 ```
 {
@@ -88,9 +88,9 @@ Results in this data in `specification`, changing the data type at node `/foo/ba
 
 ### `DELETE /hardware_product/:hardware_product_id_or_other/specification?path=:path_to_data`
 
-Deletes a specific part of the json blob data in the `specification` field, treating the URI
-fragment as the JSON pointer to the data to be removed. All other properties in the json blob
-are left untouched.
+Deletes a specific part of the json blob data in the `specification` field, treating the URI query
+parameter `path` as the JSON pointer to the data to be removed. All other properties in the json
+blob are left untouched.
 
 After the delete operation, the `specification` property must validate against
 [common.json#/definitions/HardwareProductSpecification](../json-schema/common.json#/definitions/HardwareProductSpecification).

--- a/json-schema/device_report.yaml
+++ b/json-schema/device_report.yaml
@@ -8,7 +8,7 @@ definitions:
       - type: integer
       - type: string
         pattern: '^[0-9]+$'
-  DeviceReport_v3.0.0:
+  DeviceReport_v3_0_0:
     description: the contents of a posted device report from relays and reporters
     type: object
     required:

--- a/json-schema/request.yaml
+++ b/json-schema/request.yaml
@@ -63,7 +63,7 @@ definitions:
       vendor_name:
         $ref: common.yaml#/definitions/mojo_relaxed_placeholder
   DeviceReport:
-    $ref: device_report.yaml#/definitions/DeviceReport_v3.0.0
+    $ref: device_report.yaml#/definitions/DeviceReport_v3_0_0
   RackCreate:
     type: object
     additionalProperties: false

--- a/json-schema/response.yaml
+++ b/json-schema/response.yaml
@@ -296,7 +296,7 @@ definitions:
         description: the contents of the device report. Given its age we cannot provide a schema.
         anyOf:
           - type: 'null'
-          - $ref: device_report.yaml#/definitions/DeviceReport_v3.0.0
+          - $ref: device_report.yaml#/definitions/DeviceReport_v3_0_0
           - type: object
     if:
       properties:

--- a/lib/Conch/Controller/HardwareProduct.pm
+++ b/lib/Conch/Controller/HardwareProduct.pm
@@ -203,9 +203,9 @@ sub delete ($c) {
 
 =head2 set_specification
 
-Uses the URI fragment as a json pointer to determine the path within the C<specification> property
-to operate on. New data is written, and existing data is overwritten without regard to type (so long
-as it conforms to the schema).
+Uses the URI query parameter C<path> as a json pointer to determine the path within the
+C<specification> property to operate on. New data is written, and existing data is overwritten
+without regard to type (so long as it conforms to the schema).
 
 After the update operation, the C<specification> property must validate against
 F<common.yaml#/definitions/HardwareProductSpecification>.
@@ -249,8 +249,8 @@ sub set_specification ($c) {
 
 =head2 delete_specification
 
-Uses the URI fragment as a json pointer to determine the path within the C<specification> property
-to operate on. All of the data at the indicated path is deleted.
+Uses the URI query parameter C<path> as a json pointer to determine the path within the
+C<specification> property to operate on. All of the data at the indicated path is deleted.
 
 After the delete operation, the C<specification> property must validate against
 F<common.yaml#/definitions/HardwareProductSpecification>.

--- a/lib/Conch/Route/HardwareProduct.pm
+++ b/lib/Conch/Route/HardwareProduct.pm
@@ -138,10 +138,10 @@ Identifiers accepted: C<id>, C<sku>, C<name> and C<alias>.
 
 =head2 C<PUT /hardware_product/:hardware_product_id_or_other/specification?path=:path_to_data>
 
-Sets a specific part of the json blob data in the C<specification> field, treating the URI fragment
-as the JSON pointer to the data to be added or modified. Existing data at the path is overwritten
-without regard to type, so long as the JSON Schema is respected. For example, this existing
-C<specification> field and this request:
+Sets a specific part of the json blob data in the C<specification> field, treating the URI query
+parameter C<path> as the JSON pointer to the data to be added or modified. Existing data at the path
+is overwritten without regard to type, so long as the JSON Schema is respected. For example, this
+existing C<specification> field and this request:
 
   {
     "foo": { "bar": 123 },
@@ -172,9 +172,9 @@ F<common.yaml#/definitions/HardwareProductSpecification>.
 
 =head2 C<DELETE /hardware_product/:hardware_product_id_or_other/specification?path=:path_to_data>
 
-Deletes a specific part of the json blob data in the C<specification> field, treating the URI
-fragment as the JSON pointer to the data to be removed. All other properties in the json blob
-are left untouched.
+Deletes a specific part of the json blob data in the C<specification> field, treating the URI query
+parameter C<path> as the JSON pointer to the data to be removed. All other properties in the json
+blob are left untouched.
 
 After the delete operation, the C<specification> property must validate against
 F<common.yaml#/definitions/HardwareProductSpecification>.

--- a/sql/migrations/0129-validation_result-result_order.sql
+++ b/sql/migrations/0129-validation_result-result_order.sql
@@ -42,6 +42,8 @@ SELECT run_migration(129, $$
     alter table validation_state alter column hardware_product_id set not null;
     create index validation_state_hardware_product_id_idx on validation_state (hardware_product_id);
 
+    \copy validation_result to '/mnt/tmp/validation_result_bak_pre_v3.sql';
+    \copy validation_state_member to '/mnt/tmp/validation_state_member_bak_pre_v3.sql';
     truncate validation_state_member, validation_result;
 
 

--- a/t/json-validation.t
+++ b/t/json-validation.t
@@ -137,7 +137,7 @@ subtest 'device report validation' => sub {
 
     cmp_deeply(
         [ $validator->validate('00000000-0000-0000-0000-000000000000',
-                $validator->get('/definitions/DeviceReport_v3.0.0/properties/system_uuid')) ],
+                $validator->get('/definitions/DeviceReport_v3_0_0/properties/system_uuid')) ],
         [ methods(
             path => '/',
             message => re(qr/should not match/i),
@@ -147,7 +147,7 @@ subtest 'device report validation' => sub {
 
     cmp_deeply(
         [ $validator->validate({ '' => {} },
-                $validator->get('/definitions/DeviceReport_v3.0.0/properties/disks')) ],
+                $validator->get('/definitions/DeviceReport_v3_0_0/properties/disks')) ],
         [ methods(
             path => '/',
             message => re(qr{/propertyName/ String does not match '?\^\\S\+\$'?}i),


### PR DESCRIPTION
- fix documentation of recently-added hardware_product endpoints
- rename a json schema to conform to an upcoming naming restriction
- make copies of the validation_result and validation_state_member tables just before truncating them during the v3 deployment process