### PR TITLE
fix switch_peers validation

### DIFF
--- a/lib/Conch/Validation.pm
+++ b/lib/Conch/Validation.pm
@@ -535,7 +535,6 @@ sub register_result ($self, %attrs) {
 
     my $validation_result = {
         message  => $attrs{message}  || $message,
-        name     => $attrs{name}     || $self->name,
         category => $attrs{category} || $self->category,
         component    => $attrs{component},
         status       => $success ? _STATUS_PASS : _STATUS_FAIL,

--- a/lib/Conch/Validation/SwitchPeers.pm
+++ b/lib/Conch/Validation/SwitchPeers.pm
@@ -97,7 +97,6 @@ sub validate {
         $self->register_result(
             expected => 2,
             got      => $num_ports,
-            name     => 'num_ports',
             component => $switch_name,
         );
     }

--- a/lib/Conch/Validation/SwitchPeers.pm
+++ b/lib/Conch/Validation/SwitchPeers.pm
@@ -73,7 +73,7 @@ sub validate {
             expected     => [@peer_ports],
             got          => $peer_port,
             cmp          => 'oneOf',
-            component    => $nic->{nic},
+            component    => $nic->{mac},
             name         => 'peer_ports'
         );
 
@@ -85,7 +85,7 @@ sub validate {
     $self->register_result(
         expected => 2,
         got      => $num_switches,
-        name     => 'num_switches'
+        component => 'num_switches',
     );
 
     # Validate the number of ports per switch


### PR DESCRIPTION
ensure that switch_peers validation results are all unique
    
This resolves https://rollbar.com/joyent_buildops/conch/items/3871/ (and many more) where
validation_result.component is null, therefore resulting in many duplicate validation_result rows
being created, which results in a database constraint violation.

