### PR TITLE
no longer return the full validation state+result on device report submission

### DIFF
--- a/docs/modules/Conch::Controller::DeviceReport.md
+++ b/docs/modules/Conch::Controller::DeviceReport.md
@@ -15,7 +15,7 @@ Controller for processing and managing device reports.
 Processes the device report, turning it into the various device\_\* tables as well
 as running validations
 
-Response uses the ValidationStateWithResults json schema.
+Response contains no data but returns the resource to fetch the result in the Location header.
 
 ### \_record\_device\_configuration
 

--- a/docs/modules/Conch::DB::Result::ValidationState.md
+++ b/docs/modules/Conch::DB::Result::ValidationState.md
@@ -120,14 +120,6 @@ Composing rels: ["validation\_state\_members"](#validation_state_members) -> val
 
 Include all the associated validation results, when available.
 
-### prefetch\_validation\_results
-
-Add validation\_state\_members, validation\_result rows to the resultset cache. This allows those
-rows to be included in serialized data (see ["TO\_JSON"](#to_json)).
-
-The implementation is gross because has-multi accessors always go to the db, so there is no
-non-private way of extracting related rows from the result.
-
 ## LICENSING
 
 Copyright Joyent, Inc.

--- a/docs/modules/Conch::Route::DeviceReport.md
+++ b/docs/modules/Conch::Route::DeviceReport.md
@@ -23,7 +23,7 @@ Device data will be updated in the database.
 report submission (as indicated via `#/relay/serial` in the report).
 - Controller/Action: ["process" in Conch::Controller::DeviceReport](../modules/Conch%3A%3AController%3A%3ADeviceReport#process)
 - Request: [request.json#/definitions/DeviceReport](../json-schema/request.json#/definitions/DeviceReport)
-- Response: [response.json#/definitions/ValidationStateWithResults](../json-schema/response.json#/definitions/ValidationStateWithResults)
+- Response: `201 Created`, plus Location header
 
 ### `POST /device_report?no_update_db=1`
 

--- a/lib/Conch/Controller/DeviceReport.pm
+++ b/lib/Conch/Controller/DeviceReport.pm
@@ -19,7 +19,7 @@ Controller for processing and managing device reports.
 Processes the device report, turning it into the various device_* tables as well
 as running validations
 
-Response uses the ValidationStateWithResults json schema.
+Response contains no data but returns the resource to fetch the result in the Location header.
 
 =cut
 
@@ -183,11 +183,8 @@ sub process ($c) {
         }
     }
 
-    # prime the resultset cache for the serializer
-    $validation_state->prefetch_validation_results;
-
-    $c->res->headers->location($c->url_for('/device/'.$device->id));
-    $c->status(200, $validation_state);
+    $c->res->headers->location($c->url_for('/validation_state/'.$validation_state->id));
+    $c->status(201);
 }
 
 =head2 _record_device_configuration

--- a/lib/Conch/DB/Result/ValidationState.pm
+++ b/lib/Conch/DB/Result/ValidationState.pm
@@ -251,23 +251,6 @@ sub TO_JSON ($self) {
     return $data;
 }
 
-=head2 prefetch_validation_results
-
-Add validation_state_members, validation_result rows to the resultset cache. This allows those
-rows to be included in serialized data (see L</TO_JSON>).
-
-The implementation is gross because has-multi accessors always go to the db, so there is no
-non-private way of extracting related rows from the result.
-
-=cut
-
-sub prefetch_validation_results ($self) {
-    my $members = $self->{_relationship_data}{validation_state_members};
-    $_->related_resultset('validation_result')->set_cache([ $_->validation_result ])
-        foreach $members->@*;
-    $self->related_resultset('validation_state_members')->set_cache($members);
-}
-
 1;
 __END__
 

--- a/lib/Conch/Route/DeviceReport.pm
+++ b/lib/Conch/Route/DeviceReport.pm
@@ -61,7 +61,7 @@ report submission (as indicated via C<#/relay/serial> in the report).
 
 =item * Request: F<request.yaml#/definitions/DeviceReport>
 
-=item * Response: F<response.yaml#/definitions/ValidationStateWithResults>
+=item * Response: C<201 Created>, plus Location header
 
 =back
 

--- a/t/integration/crud/devices.t
+++ b/t/integration/crud/devices.t
@@ -59,6 +59,10 @@ subtest 'unlocated device, no registered relay' => sub {
     delete $report_data->{relay};
 
     $t->post_ok('/device_report', json => $report_data)
+        ->status_is(201)
+        ->location_like(qr!^/validation_state/${\Conch::UUID::UUID_FORMAT}$!);
+
+    $t->get_ok($t->tx->res->headers->location)
         ->status_is(200)
         ->json_schema_is('ValidationStateWithResults');
 
@@ -130,6 +134,10 @@ subtest 'unlocated device with a registered relay' => sub {
 
     my $report = path('t/integration/resource/passing-device-report.json')->slurp_utf8;
     $t->post_ok('/device_report', { 'Content-Type' => 'application/json' }, $report)
+        ->status_is(201)
+        ->location_like(qr!^/validation_state/${\Conch::UUID::UUID_FORMAT}$!);
+
+    $t->get_ok($t->tx->res->headers->location)
         ->status_is(200)
         ->json_schema_is('ValidationStateWithResults');
 

--- a/t/integration/crud/workspace-devices.t
+++ b/t/integration/crud/workspace-devices.t
@@ -50,6 +50,10 @@ $t->post_ok('/relay/deadbeef/register',
 
 my $report = path('t/integration/resource/passing-device-report.json')->slurp_utf8;
 $t->post_ok('/device_report', { 'Content-Type' => 'application/json' }, $report)
+    ->status_is(201)
+    ->location_like(qr!^/validation_state/${\Conch::UUID::UUID_FORMAT}$!);
+
+$t->get_ok($t->tx->res->headers->location)
     ->status_is(200)
     ->json_schema_is('ValidationStateWithResults')
     ->json_cmp_deeply(superhashof({

--- a/t/integration/device-reports.t
+++ b/t/integration/device-reports.t
@@ -151,8 +151,11 @@ subtest 'save reports for device' => sub {
     });
 
     $t->post_ok('/device_report', { 'Content-Type' => 'application/json' }, $good_report)
+        ->status_is(201)
+        ->location_like(qr!^/validation_state/${\Conch::UUID::UUID_FORMAT}$!);
+
+    $t->get_ok($t->tx->res->headers->location)
         ->status_is(200)
-        ->location_is('/device/'.$t->tx->res->json->{device_id})
         ->json_schema_is('ValidationStateWithResults')
         ->json_cmp_deeply(superhashof({
             device_id => re(Conch::UUID::UUID_FORMAT),
@@ -213,8 +216,11 @@ subtest 'save reports for device' => sub {
         ($altered_report->{interfaces}{eth1}{mac}, $altered_report->{interfaces}{eth5}{mac});
 
     $t->post_ok('/device_report', json => $altered_report)
+        ->status_is(201)
+        ->location_like(qr!^/validation_state/${\Conch::UUID::UUID_FORMAT}$!);
+
+    $t->get_ok($t->tx->res->headers->location)
         ->status_is(200)
-        ->location_is('/device/'.$device_id)
         ->json_schema_is('ValidationStateWithResults')
         ->json_cmp_deeply(superhashof({
             device_id => $device_id,
@@ -231,8 +237,11 @@ subtest 'save reports for device' => sub {
 
     # submit another passing report (this makes 3)
     $t->post_ok('/device_report', { 'Content-Type' => 'application/json' }, $good_report)
+        ->status_is(201)
+        ->location_like(qr!^/validation_state/${\Conch::UUID::UUID_FORMAT}$!);
+
+    $t->get_ok($t->tx->res->headers->location)
         ->status_is(200)
-        ->location_is('/device/'.$device_id)
         ->json_schema_is('ValidationStateWithResults')
         ->json_cmp_deeply(superhashof({
             device_id => $device_id,
@@ -289,8 +298,11 @@ subtest 'save reports for device' => sub {
 
     # submit another passing report...
     $t->post_ok('/device_report', { 'Content-Type' => 'application/json' }, $good_report)
+        ->status_is(201)
+        ->location_like(qr!^/validation_state/${\Conch::UUID::UUID_FORMAT}$!);
+
+    $t->get_ok($t->tx->res->headers->location)
         ->status_is(200)
-        ->location_is('/device/'.$device_id)
         ->json_schema_is('ValidationStateWithResults')
         ->json_cmp_deeply(superhashof({
             device_id => $device_id,
@@ -312,8 +324,11 @@ subtest 'save reports for device' => sub {
 
     my $error_report = path('t/integration/resource/error-device-report.json')->slurp_utf8;
     $t->post_ok('/device_report', { 'Content-Type' => 'application/json' }, $error_report)
+        ->status_is(201)
+        ->location_like(qr!^/validation_state/${\Conch::UUID::UUID_FORMAT}$!);
+
+    $t->get_ok($t->tx->res->headers->location)
         ->status_is(200)
-        ->location_is('/device/'.$device_id)
         ->json_schema_is('ValidationStateWithResults')
         ->json_is('/status', 'error');
 
@@ -342,8 +357,11 @@ subtest 'save reports for device' => sub {
 
     # return device to a good state
     $t->post_ok('/device_report', { 'Content-Type' => 'application/json' }, $good_report)
+        ->status_is(201)
+        ->location_like(qr!^/validation_state/${\Conch::UUID::UUID_FORMAT}$!);
+
+    $t->get_ok($t->tx->res->headers->location)
         ->status_is(200)
-        ->location_is('/device/'.$device_id)
         ->json_schema_is('ValidationStateWithResults')
         ->json_is('/status', 'pass');
 
@@ -384,8 +402,11 @@ subtest 'save reports for device' => sub {
 
         # then submit the report again and observe it moving back.
         $t->post_ok('/device_report', { 'Content-Type' => 'application/json' }, json => $report_data)
+        ->status_is(201)
+        ->location_like(qr!^/validation_state/${\Conch::UUID::UUID_FORMAT}$!);
+
+    $t->get_ok($t->tx->res->headers->location)
             ->status_is(200)
-            ->location_is('/device/'.$device_id)
             ->json_schema_is('ValidationStateWithResults')
             ->json_is('/status', 'pass');
 
@@ -400,8 +421,11 @@ subtest 'save reports for device' => sub {
         $report_data->{links} = [ 'https://foo.com/1' ];
 
         $t->post_ok('/device_report', { 'Content-Type' => 'application/json' }, json => $report_data)
+        ->status_is(201)
+        ->location_like(qr!^/validation_state/${\Conch::UUID::UUID_FORMAT}$!);
+
+    $t->get_ok($t->tx->res->headers->location)
             ->status_is(200)
-            ->location_is('/device/'.$device_id)
             ->json_schema_is('ValidationStateWithResults')
             ->json_is('/status', 'pass');
 
@@ -413,8 +437,11 @@ subtest 'save reports for device' => sub {
 
         push $report_data->{links}->@*, 'https://foo.com/0';
         $t->post_ok('/device_report', { 'Content-Type' => 'application/json' }, json => $report_data)
+        ->status_is(201)
+        ->location_like(qr!^/validation_state/${\Conch::UUID::UUID_FORMAT}$!);
+
+    $t->get_ok($t->tx->res->headers->location)
             ->status_is(200)
-            ->location_is('/device/'.$device_id)
             ->json_schema_is('ValidationStateWithResults')
             ->json_is('/status', 'pass');
 
@@ -484,8 +511,11 @@ subtest 'submit report for production device' => sub {
     $altered_report->{system_uuid} = create_uuid_str();
 
     $t->post_ok('/device_report', json => $altered_report)
+        ->status_is(201)
+        ->location_like(qr!^/validation_state/${\Conch::UUID::UUID_FORMAT}$!);
+
+    $t->get_ok($t->tx->res->headers->location)
         ->status_is(200)
-        ->location_is('/device/'.$t->tx->res->json->{device_id})
         ->json_schema_is('ValidationStateWithResults')
         ->json_cmp_deeply(superhashof({
             device_id => re(Conch::UUID::UUID_FORMAT),
@@ -501,8 +531,11 @@ subtest 'submit report for production device' => sub {
         ($altered_report->{interfaces}{eth1}{mac}, $altered_report->{interfaces}{eth5}{mac});
 
     $t->post_ok('/device_report', json => $altered_report)
+        ->status_is(201)
+        ->location_like(qr!^/validation_state/${\Conch::UUID::UUID_FORMAT}$!);
+
+    $t->get_ok($t->tx->res->headers->location)
         ->status_is(200)
-        ->location_is('/device/'.$device->id)
         ->json_schema_is('ValidationStateWithResults')
         ->json_cmp_deeply(superhashof({
             device_id => $device->id,
@@ -532,8 +565,11 @@ subtest 'hardware_product is different' => sub {
     $altered_report->{product_name} = 'something else';
 
     $t->post_ok('/device_report', json => $altered_report)
+        ->status_is(201)
+        ->location_like(qr!^/validation_state/${\Conch::UUID::UUID_FORMAT}$!);
+
+    $t->get_ok($t->tx->res->headers->location)
         ->status_is(200)
-        ->location_is('/device/'.$device->id)
         ->json_schema_is('ValidationStateWithResults')
         ->json_cmp_deeply(superhashof({
             device_id => $device->id,

--- a/t/integration/device-validations.t
+++ b/t/integration/device-validations.t
@@ -42,12 +42,20 @@ $t->post_ok('/build/'.$build->id.'/device', json => [ { serial_number => 'TEST',
     ->status_is(204);
 
 $t->post_ok('/device_report', { 'Content-Type' => 'application/json' }, $error_report)
+    ->status_is(201)
+    ->location_like(qr!^/validation_state/${\Conch::UUID::UUID_FORMAT}$!);
+
+$t->get_ok($t->tx->res->headers->location)
     ->status_is(200)
     ->json_schema_is('ValidationStateWithResults')
     ->json_is('/status', 'error');
 my $error_validation_state_id = $t->tx->res->json->{id};
 
 $t->post_ok('/device_report', { 'Content-Type' => 'application/json' }, $good_report)
+    ->status_is(201)
+    ->location_like(qr!^/validation_state/${\Conch::UUID::UUID_FORMAT}$!);
+
+$t->get_ok($t->tx->res->headers->location)
     ->status_is(200)
     ->json_schema_is('ValidationStateWithResults')
     ->json_is('/status', 'pass');


### PR DESCRIPTION
Instead, we return the URL that can be used to fetch it in the Location header
of the response. This is much cheaper for the database, given 99% of the time it
is an automated system submitting reports and the response is not used.

(this effectively reverses #685. sorry sungo.)