### PR TITLE
v3.1: remove deprecated "rack_id" parameter when modifying a layout

### DIFF
--- a/docs/json-schema/request.json
+++ b/docs/json-schema/request.json
@@ -960,22 +960,11 @@
       "type" : "object"
     },
     "RackLayoutUpdate" : {
-      "$comment" : "NOTE: rack_id is deprecated: cannot change rack_id in an existing layout",
       "additionalProperties" : false,
       "minProperties" : 1,
       "properties" : {
         "hardware_product_id" : {
           "$ref" : "common.json#/definitions/uuid"
-        },
-        "rack_id" : {
-          "allOf" : [
-            {
-              "deprecated" : true
-            },
-            {
-              "$ref" : "common.json#/definitions/uuid"
-            }
-          ]
         },
         "rack_unit_start" : {
           "$ref" : "common.json#/definitions/positive_integer"

--- a/json-schema/request.yaml
+++ b/json-schema/request.yaml
@@ -211,15 +211,10 @@ definitions:
         rack_unit_start:
           $ref: common.yaml#/definitions/positive_integer
   RackLayoutUpdate:
-    $comment: 'NOTE: rack_id is deprecated: cannot change rack_id in an existing layout'
     type: object
     additionalProperties: false
     minProperties: 1
     properties:
-      rack_id:
-        allOf:
-          - deprecated: true
-          - $ref: common.yaml#/definitions/uuid
       hardware_product_id:
         $ref: common.yaml#/definitions/uuid
       rack_unit_start:

--- a/lib/Conch/Controller/RackLayout.pm
+++ b/lib/Conch/Controller/RackLayout.pm
@@ -167,12 +167,6 @@ sub update ($c) {
 
     my $layout = $c->stash('rack_layout_rs')->single;
 
-    # if changing rack...
-    if ($input->{rack_id} and $input->{rack_id} ne $layout->rack_id) {
-        $c->log->debug('Cannot move a layout to a new rack. Delete this layout and create a new one at the new location');
-        return $c->status(400, { error => 'changing rack_id is not permitted' });
-    }
-
     # only permit updating occupied layouts if the hardware_product_id is the only change,
     # iff it is changing to the device_hardware_product_id.
     if (my $device = $layout->related_resultset('device_location')

--- a/t/integration/crud/rack-layouts.t
+++ b/t/integration/crud/rack-layouts.t
@@ -237,12 +237,6 @@ $t->get_ok($_)
 
 my $layout_3_6 = $t->load_fixture('rack_0a_layout_3_6');
 
-# can't move a layout to a new rack
-$t->post_ok('/layout/'.$layout_3_6->id,
-        json => { rack_id => $t->load_fixture('rack_1a')->id })
-    ->status_is(400)
-    ->json_is({ error => 'changing rack_id is not permitted' });
-
 # can't put something into an assigned position
 $t->post_ok('/layout/'.$layout_3_6->id, json => { rack_unit_start => 11 })
     ->status_is(409)


### PR DESCRIPTION
affects endpoints:
POST /layout/:layout_id
POST /rack/:rack_id_or_name/layout/:layout_id_or_rack_unit_start
POST /room/:datacenter_room_id_or_alias/rack/:rack_id_or_name/layout/:layout_id_or_rack_unit_start